### PR TITLE
Add races API service and tests

### DIFF
--- a/services/races-api/Dockerfile
+++ b/services/races-api/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+COPY ../../pipeline /app/pipeline
+
+ENV PYTHONUNBUFFERED=1 \
+    DATA_DIR=/app/data/published/
+
+EXPOSE 8080
+
+CMD ["python", "main.py"]

--- a/services/races-api/main.py
+++ b/services/races-api/main.py
@@ -1,0 +1,56 @@
+"""
+FastAPI service for accessing published race data.
+
+This service exposes endpoints for listing available races and retrieving
+individual race data stored as JSON files.
+"""
+
+import os
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from pipeline.app.publish import PublishService
+from pipeline.app.schema import Race
+
+# Configure data directory from environment variable
+DATA_DIR = os.getenv("DATA_DIR", "data/published/")
+
+# Initialize publish service with custom data directory
+publish_service = PublishService()
+publish_service.output_dir = Path(DATA_DIR)
+publish_service.output_dir.mkdir(parents=True, exist_ok=True)
+
+# Initialize FastAPI app
+app = FastAPI(title="SmarterVote Races API")
+
+# Enable CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/races", response_model=List[str])
+def list_races() -> List[str]:
+    """List available race IDs."""
+    return publish_service.get_published_races()
+
+
+@app.get("/races/{race_id}", response_model=Race)
+def get_race(race_id: str) -> Race:
+    """Retrieve race data by ID."""
+    race_data = publish_service.get_race_data(race_id)
+    if not race_data:
+        raise HTTPException(status_code=404, detail="Race not found")
+    return Race(**race_data)
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/services/races-api/requirements.txt
+++ b/services/races-api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+pydantic==2.5.0

--- a/tests/services/races-api/test_main.py
+++ b/tests/services/races-api/test_main.py
@@ -1,0 +1,60 @@
+"""Tests for the races API service."""
+
+import json
+import os
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(tmp_path):
+    """Create a TestClient with temporary data directory."""
+    # Create sample race file
+    race_data = {
+        "id": "race1",
+        "title": "Test Race 1",
+        "office": "Office",
+        "jurisdiction": "Jurisdiction",
+        "election_date": "2024-11-05T00:00:00",
+        "candidates": [],
+        "description": "Test race",
+        "key_issues": [],
+        "status": "completed",
+        "sources": [],
+        "created_at": "2023-01-01T00:00:00",
+        "last_updated": "2023-01-02T00:00:00",
+        "confidence": "unknown"
+    }
+    (tmp_path / "race1.json").write_text(json.dumps(race_data))
+
+    os.environ["DATA_DIR"] = str(tmp_path)
+
+    # Dynamically import the app after setting DATA_DIR
+    main_path = Path(__file__).resolve().parents[3] / "services" / "races-api" / "main.py"
+    sys.path.append(str(main_path.parents[2]))
+    spec = importlib.util.spec_from_file_location("races_api", main_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+
+    return TestClient(module.app)
+
+
+def test_list_races(client):
+    response = client.get("/races")
+    assert response.status_code == 200
+    assert response.json() == ["race1"]
+
+
+def test_get_race(client):
+    response = client.get("/races/race1")
+    assert response.status_code == 200
+    assert response.json()["id"] == "race1"
+
+
+def test_get_race_not_found(client):
+    response = client.get("/races/unknown")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add FastAPI-based races API exposing published race data
- support DATA_DIR env config and endpoints for listing races and fetching race details
- provide unit tests for races API service

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9e1f345c832581430e0af168c98e