### PR TITLE
refactor: separate election logic from vector DB manager

### DIFF
--- a/pipeline/app/corpus/__init__.py
+++ b/pipeline/app/corpus/__init__.py
@@ -4,9 +4,10 @@ Corpus Service for SmarterVote Pipeline
 This module provides a unified interface for vector database operations.
 """
 
+from .election_vector_database_manager import ElectionVectorDatabaseManager
 from .vector_database_manager import VectorDatabaseManager
 
 # Main service class for backwards compatibility
 CorpusService = VectorDatabaseManager
 
-__all__ = ["CorpusService", "VectorDatabaseManager"]
+__all__ = ["CorpusService", "VectorDatabaseManager", "ElectionVectorDatabaseManager"]

--- a/pipeline/app/corpus/election_vector_database_manager.py
+++ b/pipeline/app/corpus/election_vector_database_manager.py
@@ -1,0 +1,74 @@
+"""Election specific extensions to the VectorDatabaseManager.
+
+This module provides helpers that apply election metadata (race IDs and
+canonical issues) on top of the generic :class:`~.vector_database_manager.VectorDatabaseManager`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from ..schema import CanonicalIssue, ExtractedContent, VectorDocument
+from .vector_database_manager import VectorDatabaseManager
+
+logger = logging.getLogger(__name__)
+
+
+class ElectionVectorDatabaseManager(VectorDatabaseManager):
+    """Vector database manager with election specific helpers."""
+
+    async def build_corpus(self, race_id: str, content: List[ExtractedContent]) -> bool:
+        """Index extracted content in the vector database for a given race."""
+        logger.info(f"Indexing {len(content)} content items for race {race_id}")
+
+        if not self.client:
+            await self.initialize()
+
+        indexed_count = 0
+        for item in content:
+            try:
+                chunks = self._chunk_content(item)
+                for chunk in chunks:
+                    success = await self._index_chunk(chunk, extra_metadata={"race_id": race_id})
+                    if success:
+                        indexed_count += 1
+            except Exception as exc:  # pragma: no cover - logging
+                logger.error(f"Failed to index content from {item.source.url}: {exc}")
+
+        logger.info(f"Successfully indexed {indexed_count} chunks for race {race_id}")
+        return indexed_count > 0
+
+    async def search_similar(
+        self,
+        query: str,
+        race_id: Optional[str] = None,
+        issue: Optional[CanonicalIssue] = None,
+        limit: int = 10,
+    ) -> List[VectorDocument]:
+        """Search for similar content scoped to a race/issue."""
+        where: Dict[str, Any] = {}
+        if race_id:
+            where["race_id"] = race_id
+        if issue:
+            where["issue"] = issue.value
+
+        return await super().search_similar(query, where=where or None, limit=limit)
+
+    async def search_content(self, race_id: str, issue: Optional[CanonicalIssue] = None) -> List[ExtractedContent]:
+        """Search and retrieve content for summarization."""
+        where: Dict[str, Any] = {"race_id": race_id}
+        if issue:
+            where["issue"] = issue.value
+        return await super().search_content(where)
+
+    async def get_race_content(self, race_id: str, issue: Optional[CanonicalIssue] = None) -> List[VectorDocument]:
+        """Retrieve documents for a specific race."""
+        where: Dict[str, Any] = {"race_id": race_id}
+        if issue:
+            where["issue"] = issue.value
+        return await super().get_documents(where)
+
+    async def get_content_stats(self, race_id: str) -> Dict[str, Any]:
+        """Get statistics about indexed content for a race."""
+        return await super().get_content_stats({"race_id": race_id})

--- a/pipeline/app/corpus/test_service.py
+++ b/pipeline/app/corpus/test_service.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ..corpus.vector_database_manager import VectorDatabaseManager
+from ..corpus.election_vector_database_manager import ElectionVectorDatabaseManager
 from ..schema import CanonicalIssue, ExtractedContent, Source, SourceType, VectorDocument
 
 
@@ -64,8 +64,8 @@ def sample_content():
 
 @pytest.fixture
 def db_manager(temp_db_dir):
-    """Create a vector database manager with temporary storage."""
-    manager = VectorDatabaseManager()
+    """Create an election-aware vector database manager with temporary storage."""
+    manager = ElectionVectorDatabaseManager()
     manager.config["persist_directory"] = temp_db_dir
     yield manager
     # Clean up ChromaDB connections
@@ -76,8 +76,8 @@ def db_manager(temp_db_dir):
             pass
 
 
-class TestVectorDatabaseManager:
-    """Test cases for VectorDatabaseManager class."""
+class TestElectionVectorDatabaseManager:
+    """Test cases for ElectionVectorDatabaseManager class."""
 
     @pytest.mark.asyncio
     async def test_initialization(self, db_manager):
@@ -104,7 +104,7 @@ class TestVectorDatabaseManager:
     async def test_initialization_creates_directory(self, temp_db_dir):
         """Test that initialization creates the persist directory."""
         db_path = Path(temp_db_dir) / "test_subdir"
-        manager = VectorDatabaseManager()
+        manager = ElectionVectorDatabaseManager()
         manager.config["persist_directory"] = str(db_path)
 
         assert not db_path.exists()
@@ -366,7 +366,7 @@ class TestVectorDatabaseManager:
         with patch.dict(
             "os.environ", {"CHROMA_CHUNK_SIZE": "300", "CHROMA_CHUNK_OVERLAP": "30", "CHROMA_SIMILARITY_THRESHOLD": "0.8"}
         ):
-            manager = VectorDatabaseManager()
+            manager = ElectionVectorDatabaseManager()
 
             assert manager.config["chunk_size"] == 300
             assert manager.config["chunk_overlap"] == 30
@@ -378,14 +378,14 @@ class TestVectorDatabaseManager:
         race_id = "persistence-test-2024"
 
         # First session: create and populate database
-        manager1 = VectorDatabaseManager()
+        manager1 = ElectionVectorDatabaseManager()
         manager1.config["persist_directory"] = temp_db_dir
         await manager1.initialize()
         await manager1.build_corpus(race_id, [sample_content])
         first_count = manager1.collection.count()
 
         # Second session: reconnect to same database
-        manager2 = VectorDatabaseManager()
+        manager2 = ElectionVectorDatabaseManager()
         manager2.config["persist_directory"] = temp_db_dir
         await manager2.initialize()
         second_count = manager2.collection.count()

--- a/test_vector_db.py
+++ b/test_vector_db.py
@@ -11,7 +11,9 @@ from pathlib import Path
 # Add the project root to sys.path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from pipeline.app.corpus.vector_database_manager import VectorDatabaseManager
+from pipeline.app.corpus.election_vector_database_manager import (
+    ElectionVectorDatabaseManager,
+)
 from pipeline.app.schema import ExtractedContent, Source, SourceType
 
 
@@ -23,7 +25,7 @@ async def test_basic_functionality():
     # Create temporary directory for test
     with tempfile.TemporaryDirectory() as temp_dir:
         # Initialize manager with temp directory
-        manager = VectorDatabaseManager()
+        manager = ElectionVectorDatabaseManager()
         manager.config["persist_directory"] = temp_dir
         print(f"📁 Using temporary database at: {temp_dir}")
 


### PR DESCRIPTION
## Summary
- split election-specific methods into `ElectionVectorDatabaseManager`
- keep Chroma operations in `VectorDatabaseManager` with in-memory fallback for tests
- update corpus tests to use the new manager

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c7bb83d083258890ce0d2131460c