### PR TITLE
Refactor metadata service to emit RaceJSON

### DIFF
--- a/pipeline/app/__main__.py
+++ b/pipeline/app/__main__.py
@@ -111,14 +111,16 @@ class CorpusFirstPipeline:
         try:
             # Step 0: EXTRACT RACE METADATA - High-level race details for optimization
             logger.info(f"📋 Step 0: EXTRACT RACE METADATA - Analyzing race structure for {race_id}")
-            race_metadata = await self.metadata.extract_race_metadata(race_id)
+            race_json = await self.metadata.extract_race_metadata(race_id)
             job.step_metadata = True
-            logger.info(f"✅ Extracted metadata: {race_metadata.full_office_name} in {race_metadata.jurisdiction}")
-            logger.info(f"🎯 Priority issues: {', '.join(race_metadata.major_issues[:3])}")
+            meta = race_json.race_metadata
+            if meta:
+                logger.info(f"✅ Extracted metadata: {meta.full_office_name} in {meta.jurisdiction}")
+                logger.info(f"🎯 Priority issues: {', '.join(meta.major_issues[:3])}")
 
             # Step 1: DISCOVER - Seed URLs + Google dorks + Fresh issue search
             logger.info(f"📡 Step 1: DISCOVER - Finding sources and fresh issues for {race_id}")
-            sources = await self.discovery.discover_all_sources(race_id, race_metadata)
+            sources = await self.discovery.discover_all_sources(race_id, race_json)
             if not sources:
                 logger.warning(f"No sources found for race {race_id}")
                 return False

--- a/shared/models.py
+++ b/shared/models.py
@@ -170,7 +170,7 @@ class Candidate(BaseModel):
     name: str
     party: Optional[str] = None
     incumbent: bool = False
-    summary: str  # Triangulated summary from 3 LLMs
+    summary: str = ""  # Triangulated summary from 3 LLMs
     issues: Dict[CanonicalIssue, IssueStance] = Field(default_factory=dict)
     top_donors: List[TopDonor] = Field(default_factory=list)
     website: Optional[HttpUrl] = None
@@ -199,13 +199,6 @@ class RaceMetadata(BaseModel):
     is_special_election: bool = False
     is_runoff: bool = False
 
-    # Key candidates (extracted from race_id pattern or early discovery)
-    discovered_candidates: List[str] = Field(
-        default_factory=list, description="Candidate names discovered during metadata extraction (backward compatibility)"
-    )
-    structured_candidates: List[DiscoveredCandidate] = Field(
-        default_factory=list, description="Structured candidate information with party, incumbent status, and sources"
-    )
     incumbent_party: Optional[str] = None
     competitive_rating: Optional[str] = None  # safe, lean, toss-up, etc.
 


### PR DESCRIPTION
## Summary
- return RaceJSON with candidate list from RaceMetadataService
- drop candidate fields from RaceMetadata and seed major issues list empty
- wire discovery and pipeline orchestration to consume RaceJSON metadata

## Testing
- `python -m pytest -v` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_689bf560406483258f90890d74d30a89