### PR TITLE
docs: note response_format for JSON output

### DIFF
--- a/pipeline/app/providers/base.py
+++ b/pipeline/app/providers/base.py
@@ -84,8 +84,10 @@ class AIProvider(ABC):
         Providers MAY honor the following kwargs (best-effort):
           - temperature: float
           - max_tokens: int
-          - json_mode: bool  (hint to enable native JSON mode if supports_json_mode=True)
+          - response_format: dict
           - extra: dict      (provider-specific passthrough)
+
+        Providers should enable native JSON output when `response_format` is supplied and the model supports it.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
## Summary
- document `response_format` as a supported kwargs for provider generation
- advise providers to enable native JSON output when `response_format` is used

## Testing
- `python -m pytest -v` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_689bf97b12a88325b2f31097b97842a6