### PR TITLE
Refactor search utils to minimal raw results

### DIFF
--- a/pipeline/app/utils/test_search_utils.py
+++ b/pipeline/app/utils/test_search_utils.py
@@ -7,7 +7,7 @@ from .search_utils import SearchUtils
 
 
 @pytest.mark.asyncio
-async def test_deduplicate_sources_normalizes_tracking_params():
+async def test_deduplicate_sources_ignores_query_params():
     utils = SearchUtils({})
     url1 = "https://example.com/path?utm_source=news&id=5&fbclid=123"
     url2 = "https://example.com/path?id=5"
@@ -17,3 +17,4 @@ async def test_deduplicate_sources_normalizes_tracking_params():
     ]
     deduped = utils.deduplicate_sources(sources)
     assert len(deduped) == 1
+    assert str(deduped[0].url) == url1


### PR DESCRIPTION
## Summary
- simplify `search_google_custom` to return raw results without URL normalization or trust scoring
- dedupe sources using scheme+netloc+path only
- adjust tests for query-parameter-insensitive dedupe

## Testing
- `python -m pytest -v` *(fails: ModuleNotFoundError: No module named 'langdetect')*

------
https://chatgpt.com/codex/tasks/task_e_689c032266248325866f4b5569b9b605