### PR TITLE
refactor: streamline discovery and add AI relevance filter

### DIFF
--- a/pipeline/app/step01_metadata/race_metadata_service.py
+++ b/pipeline/app/step01_metadata/race_metadata_service.py
@@ -80,7 +80,7 @@ class RaceMetadataService:
         self.providers = providers
         self.fetcher = WebContentFetcher()
         self.extractor = ContentExtractor()
-        self.search = SearchUtils({"max_results_per_query": 8, "per_host_concurrency": 4})
+        self.search = SearchUtils({"top_results_per_query": 8, "per_host_concurrency": 4})
 
         self.office_info = {
             "senate": {

--- a/pipeline/app/utils/ai_relevance_filter.py
+++ b/pipeline/app/utils/ai_relevance_filter.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List
+
+try:
+    from ..schema import ExtractedContent
+except ImportError:
+    from shared.models import ExtractedContent  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class AIRelevanceFilter:
+    """Simple AI-based relevance filtering for extracted documents."""
+
+    def __init__(self, threshold: float = 0.5) -> None:
+        self.threshold = threshold
+        self.model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+    async def assess(self, text: str) -> Dict[str, Any]:
+        """Assess relevance of text using an AI model or keyword heuristic."""
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            score = 1.0 if any(k in text.lower() for k in ["election", "candidate", "policy"]) else 0.0
+            reasons = ["keyword_match"] if score > 0 else ["no_keywords"]
+            return {"is_relevant": score >= self.threshold, "score": score, "reasons": reasons}
+
+        try:
+            import openai
+
+            openai.api_key = api_key
+            resp = await openai.ChatCompletion.acreate(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Rate the relevance of the following text to election policies on a scale 0-1",
+                    },
+                    {"role": "user", "content": text[:4000]},
+                ],
+                max_tokens=5,
+            )
+            raw = resp.choices[0].message["content"].strip()
+            score = float(raw)
+            reasons: List[str] = ["model_assessment"]
+        except Exception as e:  # noqa: BLE001
+            logger.warning("AI relevance check failed: %s", e)
+            score = 0.0
+            reasons = ["model_error"]
+
+        return {"is_relevant": score >= self.threshold, "score": score, "reasons": reasons}
+
+    async def filter_content(self, docs: List[ExtractedContent]) -> List[ExtractedContent]:
+        """Filter documents by relevance using assess()."""
+        filtered: List[ExtractedContent] = []
+        for doc in docs:
+            assessment = await self.assess(doc.text)
+            doc.metadata["relevance"] = assessment
+            if assessment["is_relevant"]:
+                filtered.append(doc)
+        return filtered

--- a/pipeline/app/utils/test_ai_relevance_filter.py
+++ b/pipeline/app/utils/test_ai_relevance_filter.py
@@ -1,0 +1,31 @@
+"""Tests for AIRelevanceFilter."""
+
+from datetime import datetime
+
+import pytest
+
+from ..schema import ExtractedContent, Source, SourceType
+from .ai_relevance_filter import AIRelevanceFilter
+
+
+@pytest.mark.asyncio
+async def test_filter_content_filters_irrelevant():
+    filt = AIRelevanceFilter(threshold=0.5)
+    doc1 = ExtractedContent(
+        source=Source(url="https://a", type=SourceType.WEBSITE, last_accessed=datetime.utcnow()),
+        text="The candidate discussed election policy yesterday",
+        metadata={},
+        extraction_timestamp=datetime.utcnow(),
+        word_count=7,
+    )
+    doc2 = ExtractedContent(
+        source=Source(url="https://b", type=SourceType.WEBSITE, last_accessed=datetime.utcnow()),
+        text="Completely unrelated text",
+        metadata={},
+        extraction_timestamp=datetime.utcnow(),
+        word_count=3,
+    )
+    out = await filt.filter_content([doc1, doc2])
+    assert doc1 in out
+    assert doc2 not in out
+    assert "relevance" in doc1.metadata


### PR DESCRIPTION
## Summary
- simplify search utilities with configurable query/result caps and remove site restrictions
- deduplicate candidate queries and add general issue searches
- introduce AI relevance filtering post-extraction

## Testing
- `python -m pytest -v` *(fails: google cloud storage missing, metadata integration URL validation)*
- `python -m pytest pipeline/app/providers/test_service_providers.py::TestLLMSummarizationEngineProviders::test_cheap_mode_vs_premium_mode pipeline/app/step06_summarise/test_service.py::TestLLMSummarizationEngine::test_validate_configuration_single_provider pipeline/app/step06_summarise/test_service.py::TestLLMSummarizationEngine::test_validate_configuration_all_providers -v`

------
https://chatgpt.com/codex/tasks/task_e_689d13762eac8325be1a716e1129dc73