### PR TITLE
Add ingest service orchestrating discovery, fetch, and extraction

### DIFF
--- a/pipeline/app/step02_ingest/__init__.py
+++ b/pipeline/app/step02_ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Ingest Service for SmarterVote Pipeline."""
+
+from .ingest_service import IngestService
+
+__all__ = ["IngestService"]

--- a/pipeline/app/step02_ingest/ingest_service.py
+++ b/pipeline/app/step02_ingest/ingest_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from ..schema import ExtractedContent, RaceJSON, Source
+from ..step02_discover import SourceDiscoveryEngine
+from ..step03_fetch import WebContentFetcher
+from ..step04_extract import ContentExtractor
+
+logger = logging.getLogger(__name__)
+
+
+class IngestService:
+    """Orchestrates discovery, fetching, and extraction of race content."""
+
+    def __init__(self) -> None:
+        self.discovery = SourceDiscoveryEngine()
+        self.fetcher = WebContentFetcher()
+        self.extractor = ContentExtractor()
+
+    async def ingest(self, race_id: str, race_json: Optional[RaceJSON] = None) -> List[ExtractedContent]:
+        """Run full ingestion pipeline for a race.
+
+        Args:
+            race_id: Race identifier like ``"mo-senate-2024"``.
+            race_json: Optional ``RaceJSON`` to optimize discovery.
+
+        Returns:
+            List of ``ExtractedContent`` items with associated ``Source``.
+        """
+        sources = await self.discovery.discover_all_sources(race_id, race_json)
+        if not sources:
+            logger.warning("No sources discovered for %s", race_id)
+            return []
+
+        raw_content = await self.fetcher.fetch_content(sources)
+        extracted = await self.extractor.extract_content(raw_content)
+
+        # Ensure each extracted item has its Source and no raw content is leaked
+        cleaned: List[ExtractedContent] = [ec for ec in extracted if isinstance(ec.source, Source)]
+        return cleaned

--- a/pipeline/app/step02_ingest/test_service.py
+++ b/pipeline/app/step02_ingest/test_service.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ..schema import ExtractedContent, Source, SourceType
+from . import IngestService
+
+
+class TestIngestService:
+    """Tests for the IngestService."""
+
+    @pytest.fixture
+    def ingest_service(self) -> IngestService:
+        return IngestService()
+
+    @pytest.mark.asyncio
+    async def test_ingest_returns_extracted_content(self, ingest_service: IngestService):
+        source = Source(
+            url="https://example.com/test",
+            type=SourceType.WEBSITE,
+            title="Test Source",
+            last_accessed=datetime.utcnow(),
+        )
+        extracted = ExtractedContent(
+            source=source,
+            text="example text",
+            metadata={},
+            extraction_timestamp=datetime.utcnow(),
+            word_count=2,
+        )
+
+        ingest_service.discovery.discover_all_sources = AsyncMock(return_value=[source])
+        ingest_service.fetcher.fetch_content = AsyncMock(return_value=[{"source": source, "content": "<html></html>"}])
+        ingest_service.extractor.extract_content = AsyncMock(return_value=[extracted])
+
+        result = await ingest_service.ingest("test-race")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].source == source
+        assert not hasattr(result[0], "content")


### PR DESCRIPTION
## Summary
- add `IngestService` to run discovery, fetch, and extract pipeline steps
- expose service through step02_ingest package
- test ingest service behavior with mocked dependencies

## Testing
- `python -m pytest -v pipeline/app/step02_ingest/test_service.py`


------
https://chatgpt.com/codex/tasks/task_e_689d2f89a790832597e7d06ac40caae6