### PR TITLE
Add Step02IngestHandler to pipeline client registry

### DIFF
--- a/pipeline_client/backend/step_registry.py
+++ b/pipeline_client/backend/step_registry.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, Protocol, runtime_checkable
 
 # Shared provider registry
 from pipeline.app.providers import registry
+from pipeline.app.schema import RaceJSON
 
 # Use the LLM-first service
 from pipeline.app.step01_metadata.race_metadata_service import RaceMetadataService
+from pipeline.app.step02_ingest import IngestService
 
 
 def to_jsonable(obj):
@@ -26,8 +28,7 @@ def to_jsonable(obj):
 
 @runtime_checkable
 class StepHandler(Protocol):
-    async def handle(self, payload: Dict[str, Any], options: Dict[str, Any]) -> Any:
-        ...
+    async def handle(self, payload: Dict[str, Any], options: Dict[str, Any]) -> Any: ...
 
 
 class Step01MetadataHandler:
@@ -81,8 +82,72 @@ class Step01MetadataHandler:
             raise RuntimeError(error_msg)
 
 
+class Step02IngestHandler:
+    def __init__(self) -> None:
+        self.service_cls = IngestService
+
+    async def handle(self, payload: Dict[str, Any], options: Dict[str, Any]) -> Any:
+        logger = logging.getLogger("pipeline")
+
+        race_id = payload.get("race_id")
+        if not race_id:
+            error_msg = f"Step02IngestHandler: Missing 'race_id' in payload.\nPayload received: {payload}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        race_json_payload = payload.get("race_json")
+        race_json: RaceJSON | None = None
+        if race_json_payload:
+            try:
+                if isinstance(race_json_payload, RaceJSON):
+                    race_json = race_json_payload
+                elif hasattr(RaceJSON, "model_validate"):
+                    race_json = RaceJSON.model_validate(race_json_payload)
+                else:
+                    race_json = RaceJSON.parse_obj(race_json_payload)  # type: ignore[arg-type]
+            except Exception as e:
+                logger.warning(f"Step02IngestHandler: Invalid race_json provided: {e}")
+                race_json = None
+
+        logger.info(f"Initializing IngestService for race_id='{race_id}'")
+
+        try:
+            service = self.service_cls()
+            logger.debug("IngestService instantiated successfully")
+        except Exception as e:
+            error_msg = f"Step02IngestHandler: Failed to instantiate IngestService: {e}"
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        try:
+            logger.info(f"Running ingest for race_id='{race_id}'")
+            t0 = time.perf_counter()
+
+            result = await service.ingest(race_id, race_json=race_json)
+
+            duration_ms = int((time.perf_counter() - t0) * 1000)
+            logger.info(f"Ingest completed in {duration_ms}ms")
+
+            output = []
+            for item in result:
+                if hasattr(item, "model_dump"):
+                    output.append(item.model_dump(mode="json", by_alias=True, exclude_none=True))
+                elif hasattr(item, "json"):
+                    output.append(json.loads(item.json(by_alias=True, exclude_none=True)))
+                else:
+                    output.append(to_jsonable(item))
+
+            logger.debug(f"Ingest conversion completed, items: {len(output)}")
+            return output
+        except Exception as e:
+            error_msg = f"Step02IngestHandler: Error running ingest(race_id='{race_id}'): {e}"
+            logger.error(error_msg, exc_info=True)
+            raise RuntimeError(error_msg)
+
+
 REGISTRY: Dict[str, StepHandler] = {
     "step01_metadata": Step01MetadataHandler(),
+    "step02_ingest": Step02IngestHandler(),
 }
 
 


### PR DESCRIPTION
## Summary
- add Step02IngestHandler that runs `IngestService` and serializes its output
- register new handler under `step02_ingest`

## Testing
- `python -m pytest -v` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_689d327089808325a6848f280bd64dd3