### PR TITLE
Add AI usefulness check using provider registry

### DIFF
--- a/pipeline/app/__main__.py
+++ b/pipeline/app/__main__.py
@@ -139,7 +139,10 @@ class CorpusFirstPipeline:
 
             # Step 3: EXTRACT - HTML/PDF → plain text → /norm/{race}/
             logger.info("📄 Step 3: EXTRACT - Converting to plain text")
-            extracted_content = await self.extract.extract_content(raw_content)
+            race_context = {"race_id": race_id}
+            if race_json and getattr(race_json, "candidates", None):
+                race_context["candidates"] = [c.name for c in race_json.candidates]
+            extracted_content = await self.extract.extract_content(raw_content, race_context=race_context)
             job.step_extract = True
             logger.info(f"✅ Extracted text from {len(extracted_content)} items")
 

--- a/pipeline/app/step02_ingest/ingest_service.py
+++ b/pipeline/app/step02_ingest/ingest_service.py
@@ -35,7 +35,10 @@ class IngestService:
             return []
 
         raw_content = await self.fetcher.fetch_content(sources)
-        extracted = await self.extractor.extract_content(raw_content)
+        race_context = {"race_id": race_id}
+        if race_json and getattr(race_json, "candidates", None):
+            race_context["candidates"] = [c.name for c in race_json.candidates]
+        extracted = await self.extractor.extract_content(raw_content, race_context=race_context)
 
         # Ensure each extracted item has its Source and no raw content is leaked
         cleaned: List[ExtractedContent] = [ec for ec in extracted if isinstance(ec.source, Source)]

--- a/pipeline/app/step04_extract/test_service.py
+++ b/pipeline/app/step04_extract/test_service.py
@@ -46,6 +46,7 @@ class TestExtractService:
         assert "Test Title" in extracted[0].text
         assert "sufficient length" in extracted[0].text
         assert extracted[0].word_count > 0
+        assert "usefulness_ai" in extracted[0].metadata
 
     def test_extract_from_html_removes_scripts(self, extract_service):
         """Test that HTML extraction removes script tags."""


### PR DESCRIPTION
## Summary
- use provider registry to run a cheap-tier LLM usefulness check
- pass race context into content extraction and record AI decision
- plumb race context through ingest and metadata services

## Testing
- `python -m pytest pipeline/app/step04_extract/test_service.py pipeline/app/step02_ingest/test_service.py pipeline/app/step01_metadata/test_race_metadata_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689d375b5c488325abedd487582c31b9