### PR TITLE
chore(web): run frontend tests without watch mode

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
     "format": "prettier --plugin-search-dir . --write .",
-    "test:unit": "vitest"
+    "test:unit": "svelte-kit sync && vitest run"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",


### PR DESCRIPTION
## Summary
- run `svelte-kit sync` before tests
- switch vitest to non-watch run mode

## Testing
- `npm test`
- `pre-commit run --files web/package.json`


------
https://chatgpt.com/codex/tasks/task_e_689d59fdf2ac83258776b5537407095f