### PR TITLE
feat: add continue API to pipeline client backend

### DIFF
--- a/pipeline_client/backend/models.py
+++ b/pipeline_client/backend/models.py
@@ -80,3 +80,11 @@ class BatchRunResponse(BaseModel):
     batch_id: str
     total_runs: int
     runs: List[RunInfo]
+
+
+class ContinueRunRequest(BaseModel):
+    """Request to continue a pipeline run."""
+
+    run_id: str
+    steps: Optional[List[str]] = None
+    state: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- add ContinueRunRequest model
- expose POST /api/continue endpoint for continuing runs

## Testing
- `pre-commit run --files pipeline_client/backend/main.py pipeline_client/backend/models.py`
- `python -m pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_689e6e46cf5c832583a44d8fcfe5871a