### PR TITLE
feat: track multiple pipeline steps per run

### DIFF
--- a/pipeline_client/backend/main.py
+++ b/pipeline_client/backend/main.py
@@ -114,7 +114,7 @@ async def api_execute(request: Dict[str, Any]) -> Dict[str, Any]:
 
     # Create run request
     run_request = RunRequest(payload=payload, options=options)
-    run_info = run_manager.create_run(step, run_request)
+    run_info = run_manager.create_run([step], run_request)
 
     # Start execution in background
     asyncio.create_task(_execute_run_async(step, run_request, run_info.run_id))
@@ -137,7 +137,7 @@ async def api_continue(request: ContinueRunRequest) -> Dict[str, Any]:
 async def _execute_run_async(step: str, request: RunRequest, run_id: str):
     """Execute a single run asynchronously."""
     try:
-        await run_step_async(step, request)
+        await run_step_async(step, request, run_id)
     except Exception as e:
         # Error handling is done in run_step_async
         pass
@@ -154,7 +154,7 @@ async def batch_run(step: str, request: BatchRunRequest) -> BatchRunResponse:
 
     for race_id in request.race_ids:
         run_request = RunRequest(payload={"race_id": race_id}, options=request.options)
-        run_info = run_manager.create_run(step, run_request)
+        run_info = run_manager.create_run([step], run_request)
         runs.append(run_info)
 
     # Start batch execution in background
@@ -168,7 +168,7 @@ async def _execute_batch(step: str, runs: List[RunInfo], options):
     for run_info in runs:
         try:
             request = RunRequest(payload=run_info.payload, options=options)
-            await run_step_async(step, request)
+            await run_step_async(step, request, run_info.run_id)
         except Exception:
             # Error handling is done in run_step_async
             pass

--- a/pipeline_client/backend/models.py
+++ b/pipeline_client/backend/models.py
@@ -37,11 +37,22 @@ class RunResponse(BaseModel):
     meta: Dict[str, Any] = {}
 
 
+class RunStep(BaseModel):
+    """Information about a single step within a run."""
+
+    name: str
+    status: RunStatus = RunStatus.PENDING
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    duration_ms: Optional[int] = None
+    artifact_id: Optional[str] = None
+    error: Optional[str] = None
+
+
 class RunInfo(BaseModel):
     """Information about a pipeline run."""
 
     run_id: str
-    step: str
     status: RunStatus
     payload: Dict[str, Any]
     options: Dict[str, Any]
@@ -50,6 +61,7 @@ class RunInfo(BaseModel):
     duration_ms: Optional[int] = None
     artifact_id: Optional[str] = None
     error: Optional[str] = None
+    steps: List[RunStep] = []
     logs: Optional[List[Dict]] = []
 
 

--- a/tests/test_run_steps.py
+++ b/tests/test_run_steps.py
@@ -1,0 +1,70 @@
+import asyncio
+import importlib
+import sys
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pipeline_client.backend import run_manager as rm_module
+from pipeline_client.backend import settings as settings_module
+from pipeline_client.backend.models import RunRequest, RunStatus
+from pipeline_client.backend.run_manager import RunManager
+
+
+class DummyHandler:
+    async def handle(self, payload, options):  # pragma: no cover - simple stub
+        return payload
+
+
+def test_run_records_multiple_steps(monkeypatch, tmp_path):
+    """Running multiple steps under one run_id stores each step."""
+
+    # Stub step registry before importing modules that depend on it
+    dummy_registry = types.SimpleNamespace()
+    dummy_registry.REGISTRY = {}
+    dummy_registry.get_handler = lambda step: dummy_registry.REGISTRY[step]
+    monkeypatch.setitem(sys.modules, "pipeline_client.backend.step_registry", dummy_registry)
+
+    pipeline_runner = importlib.import_module("pipeline_client.backend.pipeline_runner")
+    main_module = importlib.import_module("pipeline_client.backend.main")
+
+    # Temporary run manager and artifacts directory
+    tmp_runs = tmp_path / "runs"
+    tmp_runs.mkdir()
+    new_rm = RunManager(storage_dir=str(tmp_runs))
+    rm_module.run_manager = new_rm
+    pipeline_runner.run_manager = new_rm
+    main_module.run_manager = new_rm
+
+    tmp_artifacts = tmp_path / "artifacts"
+    tmp_artifacts.mkdir()
+    monkeypatch.setattr(settings_module.settings, "artifacts_dir", tmp_artifacts)
+
+    # Register dummy steps
+    dummy_registry.REGISTRY["dummy1"] = DummyHandler()
+    dummy_registry.REGISTRY["dummy2"] = DummyHandler()
+
+    # First step starts a new run
+    resp1 = asyncio.run(pipeline_runner.run_step_async("dummy1", RunRequest(payload={})))
+    run_id = resp1.meta["run_id"]
+
+    # Second step continues the same run
+    asyncio.run(pipeline_runner.run_step_async("dummy2", RunRequest(payload={}), run_id=run_id))
+
+    run_info = new_rm.get_run(run_id)
+    assert run_info is not None
+    assert [s.name for s in run_info.steps] == ["dummy1", "dummy2"]
+    assert all(step.status == RunStatus.COMPLETED for step in run_info.steps)
+
+    client = TestClient(main_module.app)
+    resp = client.get(f"/run/{run_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["steps"]) == 2
+
+    resp = client.get("/runs")
+    assert resp.status_code == 200
+    runs = resp.json()["runs"]
+    found = next(r for r in runs if r["run_id"] == run_id)
+    assert len(found["steps"]) == 2


### PR DESCRIPTION
## Summary
- support multi-step runs by storing `RunStep` entries on `RunInfo`
- allow pipeline runner and orchestrator to append steps to existing runs
- surface full step history via run APIs and added regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e8893faf083258e1ea945ab4230f8