### PR TITLE
feat(web): add pipeline run interfaces

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -109,3 +109,35 @@ export interface RaceSummary {
   updated_utc: string;
   candidates: CandidateSummary[];
 }
+
+// Pipeline run types
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface RunStep {
+  name: string;
+  status: RunStatus;
+  started_at?: string;
+  completed_at?: string;
+  duration_ms?: number;
+  artifact_id?: string;
+  error?: string;
+}
+
+export interface RunInfo {
+  run_id: string;
+  status: RunStatus;
+  payload: Record<string, any>;
+  options: Record<string, any>;
+  started_at: string;
+  completed_at?: string;
+  duration_ms?: number;
+  artifact_id?: string;
+  error?: string;
+  steps: RunStep[];
+  logs?: Record<string, any>[];
+}


### PR DESCRIPTION
## Summary
- define `RunStatus`, `RunStep`, and `RunInfo` interfaces in `types.ts`
- refactor pipeline admin page to use typed run info and step data
- type API helpers for run history loading and selection

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e9462d5d483259ba638af3fc5b167