### PR TITLE
Add pipeline step list with run-from-step controls

### DIFF
--- a/web/src/lib/components/RunStepList.svelte
+++ b/web/src/lib/components/RunStepList.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import type { RunStep } from "$lib/types";
+  export let steps: RunStep[] = [];
+  export let currentStep: string | null = null;
+  export let runFromStep: (name: string) => void;
+  export let API_BASE: string;
+</script>
+
+<ul class="divide-y divide-gray-200 border border-gray-200 rounded-lg">
+  {#each steps as step}
+    <li
+      class="p-2 flex items-center justify-between {step.name === currentStep || step.status === 'running' ? 'bg-yellow-50' : ''}"
+    >
+      <div class="flex flex-col">
+        <span class="font-medium text-sm">{step.name}</span>
+        <span class="text-xs text-gray-600">
+          {step.status}
+          {#if step.duration_ms}
+            · {(step.duration_ms / 1000).toFixed(1)}s
+          {/if}
+          {#if step.artifact_id}
+            ·
+            <a
+              class="text-blue-600 hover:underline"
+              href={`${API_BASE}/artifact/${step.artifact_id}`}
+              target="_blank"
+              >artifact</a
+            >
+          {/if}
+        </span>
+      </div>
+      <button
+        class="btn-secondary ml-2 whitespace-nowrap"
+        on:click={() => runFromStep(step.name)}
+      >
+        Run from this step
+      </button>
+    </li>
+  {/each}
+</ul>


### PR DESCRIPTION
## Summary
- store step details when selecting a run
- show pipeline steps with status, duration and artifacts
- allow rerunning the pipeline from any step

## Testing
- `python -m pytest -v` *(fails: SourceDiscoveryEngine missing prefilter_with_mini_model)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e9879836883258cb933eb15d1cc11