### PR TITLE
feat: make allowed origins configurable

### DIFF
--- a/pipeline_client/backend/main.py
+++ b/pipeline_client/backend/main.py
@@ -69,7 +69,7 @@ async def get_artifact_details(artifact_id: str) -> Dict[str, Any]:
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/pipeline_client/backend/settings.py
+++ b/pipeline_client/backend/settings.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
@@ -10,6 +11,7 @@ class Settings(BaseSettings):
     skip_external_apis: bool = False
     skip_network_calls: bool = False
     skip_cloud_services: bool = False
+    allowed_origins: list[str] = Field(default_factory=lambda: ["*"])
 
     class Config:
         env_prefix = ""


### PR DESCRIPTION
## Summary
- allow configuring permitted CORS origins in pipeline client settings
- use settings-defined origins in backend CORSMiddleware

## Testing
- `python -m pytest -v` *(fails: ImportError: cannot import name 'SourceDiscoveryEngine' from 'pipeline.app.step01_ingest.DiscoveryService')*

------
https://chatgpt.com/codex/tasks/task_e_689e9dd2e1648325a2f7fe1cd161884b