### PR TITLE
feat(web): configure pipeline API via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,7 +102,7 @@ CONTENT_CACHE_TTL=24
 
 # ===== Web Frontend =====
 # API base URL for frontend
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE=http://localhost:8001
 
 # Enable analytics
 VITE_ENABLE_ANALYTICS=false

--- a/web/README.md
+++ b/web/README.md
@@ -247,10 +247,10 @@ npm run test:unit -- --watch
 
 ```bash
 # Development
-VITE_API_BASE_URL=http://localhost:3000
+VITE_API_BASE=http://localhost:3000
 
 # Production
-VITE_API_BASE_URL=https://api.smarter.vote
+VITE_API_BASE=https://api.smarter.vote
 ```
 
 ### SvelteKit Configuration (`svelte.config.js`)

--- a/web/src/routes/admin/pipeline/+page.svelte
+++ b/web/src/routes/admin/pipeline/+page.svelte
@@ -3,7 +3,7 @@
   import type { RunInfo, RunStatus, RunStep } from "$lib/types";
   import RunStepList from "$lib/components/RunStepList.svelte";
 
-  const API_BASE = "http://127.0.0.1:8001"; // FastAPI local
+  const API_BASE = import.meta.env.VITE_API_BASE || "http://127.0.0.1:8001"; // FastAPI local
 
   let steps: string[] = [];
   let inputJson = '{\n  "race_id": "mo-senate-2024"\n}';
@@ -90,7 +90,7 @@
   }
 
   function connectWebSocket() {
-    const wsUrl = `ws://127.0.0.1:8001/ws/logs`;
+    const wsUrl = API_BASE.replace(/^http/, "ws") + "/ws/logs";
     ws = new WebSocket(wsUrl);
 
     ws.onopen = () => {


### PR DESCRIPTION
## Summary
- add `VITE_API_BASE` to environment template and docs
- reference `VITE_API_BASE` in admin pipeline page instead of hard-coded URL

## Testing
- `python -m pytest -v` *(fails: ImportError: SourceDiscoveryEngine)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e9dd995e88325b83f6d31241a9996