### PR TITLE
Inject storage backend into metadata handler

### DIFF
--- a/pipeline_client/backend/step_orchestrator.py
+++ b/pipeline_client/backend/step_orchestrator.py
@@ -51,7 +51,12 @@ def update_state(step: str, state: Dict[str, Any], output: Any) -> Dict[str, Any
 
     new_state = dict(state)
     if step == "step01a_metadata":
-        new_state["race_json"] = output
+        if isinstance(output, dict) and "race_json" in output:
+            new_state["race_json"] = output["race_json"]
+            if "race_json_uri" in output:
+                new_state["race_json_uri"] = output["race_json_uri"]
+        else:
+            new_state["race_json"] = output
     elif step == "step01b_discovery":
         new_state["sources"] = output
     elif step == "step01c_fetch":

--- a/pipeline_client/backend/step_registry.py
+++ b/pipeline_client/backend/step_registry.py
@@ -3,6 +3,7 @@ import json
 import logging
 import time
 from datetime import date, datetime
+from pathlib import Path
 from typing import Any, Dict, Protocol, runtime_checkable
 
 from pipeline.app.providers import registry
@@ -14,6 +15,9 @@ from pipeline.app.step01_ingest.IngestService import IngestService
 from pipeline.app.step01_ingest.MetaDataService.race_metadata_service import (
     RaceMetadataService,
 )
+
+from .settings import settings
+from .storage_backend import GCPStorageBackend, LocalStorageBackend, StorageBackend
 
 
 def to_jsonable(obj):
@@ -36,10 +40,23 @@ class StepHandler(Protocol):
     async def handle(self, payload: Dict[str, Any], options: Dict[str, Any]) -> Any: ...
 
 
+def _init_storage_backend() -> StorageBackend:
+    if settings.storage_mode == "gcp":
+        if not settings.gcs_bucket:
+            raise ValueError("gcs_bucket must be configured for gcp storage mode")
+        return GCPStorageBackend(
+            bucket=settings.gcs_bucket,
+            firestore_project=settings.firestore_project,
+        )
+    published_dir = Path(__file__).resolve().parents[2] / "data/published"
+    return LocalStorageBackend(settings.artifacts_dir, races_dir=published_dir)
+
+
 class Step01MetadataHandler:
-    def __init__(self) -> None:
+    def __init__(self, storage_backend: StorageBackend) -> None:
         # Swap to the LLM-first service class
         self.service_cls = RaceMetadataService
+        self.storage_backend = storage_backend
 
     async def handle(self, payload: Dict[str, Any], options: Dict[str, Any]) -> Any:
         logger = logging.getLogger("pipeline")
@@ -79,7 +96,9 @@ class Step01MetadataHandler:
             logger.debug(
                 f"Metadata conversion completed, output keys: {list(output.keys()) if isinstance(output, dict) else 'non-dict result'}"
             )
-            return output
+            race_json_uri = self.storage_backend.save_race_json(race_id, output)
+            logger.info(f"Race JSON saved to {race_json_uri}")
+            return {"race_json": output, "race_json_uri": race_json_uri}
 
         except Exception as e:
             error_msg = f"Step01MetadataHandler: Error running extract_race_metadata(race_id='{race_id}'): {e}"
@@ -332,8 +351,11 @@ class Step01IngestHandler:
             raise RuntimeError(error_msg)
 
 
+_STORAGE_BACKEND = _init_storage_backend()
+
+
 REGISTRY: Dict[str, StepHandler] = {
-    "step01a_metadata": Step01MetadataHandler(),
+    "step01a_metadata": Step01MetadataHandler(_STORAGE_BACKEND),
     "step01b_discovery": Step01DiscoveryHandler(),
     "step01c_fetch": Step01FetchHandler(),
     "step01d_extract": Step01ExtractHandler(),

--- a/pipeline_client/backend/storage_backend.py
+++ b/pipeline_client/backend/storage_backend.py
@@ -29,10 +29,10 @@ class StorageBackend(Protocol):
 class LocalStorageBackend:
     """Local filesystem storage implementation."""
 
-    def __init__(self, artifacts_dir: Path) -> None:
+    def __init__(self, artifacts_dir: Path, races_dir: Path | None = None) -> None:
         self.artifacts_dir = artifacts_dir
         self.artifacts_dir.mkdir(parents=True, exist_ok=True)
-        self.races_dir = self.artifacts_dir / "races"
+        self.races_dir = races_dir or self.artifacts_dir / "races"
         self.races_dir.mkdir(parents=True, exist_ok=True)
         self.web_dir = self.artifacts_dir / "web"
         self.web_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- inject configurable StorageBackend into metadata step
- publish race JSON via backend and record storage URI
- track metadata output URI in orchestrator state

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68a27b4b54a88325a9072287748ddfcb