### PR TITLE
feat: publish race metadata and relevant files

### DIFF
--- a/pipeline_client/backend/handlers/step01_relevance.py
+++ b/pipeline_client/backend/handlers/step01_relevance.py
@@ -1,28 +1,79 @@
-import logging
+import hashlib
 import json
+import logging
 import time
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from pipeline.app.schema import RaceJSON
 from pipeline.app.step01_ingest.RelevanceCheck import AIRelevanceFilter
+from shared.models import ExtractedContent, Source
+
 from pipeline_client.backend.handlers.utils import to_jsonable
 
+
 class Step01RelevanceHandler:
-    def __init__(self) -> None:
+    def __init__(self, storage_backend) -> None:
         self.filter_cls = AIRelevanceFilter
+        self.storage_backend = storage_backend
 
     async def handle(self, payload: Dict[str, Any], options: Dict[str, Any]) -> Any:
         logger = logging.getLogger("pipeline")
-        raw_content = payload.get("raw_content")
-        race_name = payload.get("race_name")
-        candidates = payload.get("candidates", [])
-        if not raw_content or not isinstance(raw_content, list):
-            error_msg = f"Step01RelevanceHandler: Missing 'raw_content' in payload.\nPayload received: {payload}"
+        processed = payload.get("processed_content") or payload.get("raw_content")
+        race_id = payload.get("race_id")
+        race_json_payload = payload.get("race_json")
+        if not processed or not isinstance(processed, list):
+            error_msg = (
+                "Step01RelevanceHandler: Missing 'processed_content' in payload.\n"
+                f"Payload received: {payload}"
+            )
             logger.error(error_msg)
             raise ValueError(error_msg)
-        if not race_name:
-            error_msg = f"Step01RelevanceHandler: Missing 'race_name' in payload.\nPayload received: {payload}"
+        if not race_id:
+            error_msg = (
+                "Step01RelevanceHandler: Missing 'race_id' in payload.\n"
+                f"Payload received: {payload}"
+            )
             logger.error(error_msg)
             raise ValueError(error_msg)
-        logger.info(f"Initializing AIRelevanceFilter for {len(raw_content)} items")
+        if not race_json_payload:
+            error_msg = (
+                "Step01RelevanceHandler: Missing 'race_json' in payload."
+            )
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        try:
+            if isinstance(race_json_payload, RaceJSON):
+                race_json = race_json_payload
+            elif hasattr(RaceJSON, "model_validate"):
+                race_json = RaceJSON.model_validate(race_json_payload)
+            else:
+                race_json = RaceJSON.parse_obj(race_json_payload)  # type: ignore[arg-type]
+        except Exception as e:  # noqa: BLE001
+            error_msg = f"Step01RelevanceHandler: Invalid race_json provided: {e}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        race_name = (
+            race_json.race_metadata.full_office_name
+            if race_json.race_metadata
+            else race_id
+        )
+        candidates = [c.name for c in race_json.candidates]
+
+        docs: List[ExtractedContent] = []
+        for item in processed:
+            try:
+                if isinstance(item, ExtractedContent):
+                    docs.append(item)
+                elif hasattr(ExtractedContent, "model_validate"):
+                    docs.append(ExtractedContent.model_validate(item))
+                else:
+                    docs.append(ExtractedContent.parse_obj(item))  # type: ignore[arg-type]
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Step01RelevanceHandler: Invalid content skipped: %s", e)
+
+        logger.info(f"Initializing AIRelevanceFilter for {len(docs)} items")
         try:
             filter_service = self.filter_cls()
             logger.debug("AIRelevanceFilter instantiated successfully")
@@ -30,23 +81,42 @@ class Step01RelevanceHandler:
             error_msg = f"Step01RelevanceHandler: Failed to instantiate AIRelevanceFilter: {e}"
             logger.error(error_msg)
             raise RuntimeError(error_msg)
+
         try:
             logger.info("Filtering content by relevance")
             t0 = time.perf_counter()
-            result = await filter_service.filter_content(raw_content, race_name, candidates)
+            result = await filter_service.filter_content(docs, race_name, candidates)
             duration_ms = int((time.perf_counter() - t0) * 1000)
             logger.info(f"Relevance filtering completed in {duration_ms}ms")
             output = []
             for item in result:
+                uri = self.storage_backend.save_web_content(
+                    race_id,
+                    _filename_from_source(item.source),
+                    item.text,
+                    content_type="text/plain",
+                    kind="relevant",
+                )
+                item.metadata["storage_uri"] = uri
                 if hasattr(item, "model_dump"):
-                    output.append(item.model_dump(mode="json", by_alias=True, exclude_none=True))
+                    output.append(
+                        item.model_dump(mode="json", by_alias=True, exclude_none=True)
+                    )
                 elif hasattr(item, "json"):
                     output.append(json.loads(item.json(by_alias=True, exclude_none=True)))
                 else:
                     output.append(to_jsonable(item))
-            logger.debug(f"Relevance filter conversion completed, items: {len(output)}")
+            logger.debug(
+                f"Relevance filter conversion completed, items: {len(output)}"
+            )
             return output
         except Exception as e:
             error_msg = f"Step01RelevanceHandler: Error filtering relevance: {e}"
             logger.error(error_msg, exc_info=True)
             raise RuntimeError(error_msg)
+
+
+def _filename_from_source(source: Source) -> str:
+    url = str(source.url)
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+    return f"{digest}.txt"

--- a/pipeline_client/backend/step_orchestrator.py
+++ b/pipeline_client/backend/step_orchestrator.py
@@ -42,7 +42,11 @@ def build_payload(step: str, state: Dict[str, Any]) -> Dict[str, Any]:
     if step == "step01d_extract":
         return {"race_id": state["race_id"], "raw_content": state["raw_content"]}
     if step == "step01e_relevance":
-        return {"race_id": state["race_id"], "processed_content": state["processed_content"]}
+        return {
+            "race_id": state["race_id"],
+            "processed_content": state["processed_content"],
+            "race_json": state.get("race_json"),
+        }
 
     raise KeyError(f"Unknown step '{step}'")
 

--- a/pipeline_client/backend/step_registry.py
+++ b/pipeline_client/backend/step_registry.py
@@ -40,7 +40,7 @@ REGISTRY: Dict[str, StepHandler] = {
     "step01b_discovery": Step01DiscoveryHandler(),
     "step01c_fetch": Step01FetchHandler(),
     "step01d_extract": Step01ExtractHandler(),
-    "step01e_relevance": Step01RelevanceHandler(),
+    "step01e_relevance": Step01RelevanceHandler(_STORAGE_BACKEND),
 }
 
 

--- a/pipeline_client/backend/storage_backend.py
+++ b/pipeline_client/backend/storage_backend.py
@@ -39,6 +39,8 @@ class LocalStorageBackend:
         self.raw_dir.mkdir(parents=True, exist_ok=True)
         self.extracted_dir = self.artifacts_dir / "extracted"
         self.extracted_dir.mkdir(parents=True, exist_ok=True)
+        self.relevant_dir = self.artifacts_dir / "relevant"
+        self.relevant_dir.mkdir(parents=True, exist_ok=True)
 
     def _artifact_path(self, artifact_id: str) -> Path:
         return self.artifacts_dir / f"{artifact_id}.json"
@@ -83,6 +85,7 @@ class LocalStorageBackend:
         base_dir = {
             "raw": self.raw_dir,
             "extracted": self.extracted_dir,
+            "relevant": self.relevant_dir,
         }.get(kind, self.raw_dir)
 
         race_dir = base_dir / race_id

--- a/tests/test_storage_integration.py
+++ b/tests/test_storage_integration.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from pipeline.app.schema import Candidate, ConfidenceLevel, RaceJSON, RaceMetadata
+from pipeline_client.backend.handlers.step01_relevance import Step01RelevanceHandler
+from pipeline_client.backend.storage_backend import LocalStorageBackend
+from shared.models import ExtractedContent, Source, SourceType
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_metadata_service_saves_race_json(tmp_path):
+    module = pytest.importorskip("pipeline.app.step01_ingest.MetaDataService.race_metadata_service")
+    storage = LocalStorageBackend(tmp_path)
+    service = module.RaceMetadataService(providers=None, storage_backend=storage)
+
+    # Avoid network calls by patching internals
+    service._seed_urls = lambda *a, **k: []
+
+    async def mock_fetch_and_extract_docs(urls, trace_id):
+        return []
+
+    async def mock_llm_candidates(**kwargs):
+        cand = Candidate(name="Jane Doe", party="Democratic", incumbent=False)
+        return [cand], "Democratic", []
+
+    service._fetch_and_extract_docs = mock_fetch_and_extract_docs
+    service._llm_candidates = mock_llm_candidates
+
+    race_json = await service.extract_race_metadata("xx-senate-2024")
+    assert race_json.id == "xx-senate-2024"
+    assert service.race_json_uri
+    assert Path(service.race_json_uri).exists()
+
+
+@pytest.mark.anyio
+async def test_relevance_handler_uploads_files(tmp_path):
+    storage = LocalStorageBackend(tmp_path)
+    handler = Step01RelevanceHandler(storage)
+
+    class DummyFilter:
+        async def filter_content(self, docs, race_name, candidates):
+            for d in docs:
+                d.metadata["relevance"] = {"is_relevant": True}
+            return docs
+
+    handler.filter_cls = DummyFilter
+
+    src = Source(url="http://example.com", type=SourceType.WEBSITE, last_accessed=datetime.utcnow())
+    doc = ExtractedContent(
+        source=src,
+        text="hello world",
+        metadata={},
+        extraction_timestamp=datetime.utcnow(),
+        word_count=2,
+    )
+    race_json = RaceJSON(
+        id="xx-senate-2024",
+        election_date=datetime.utcnow(),
+        candidates=[Candidate(name="Jane Doe", party="Democratic", incumbent=False)],
+        updated_utc=datetime.utcnow(),
+        generator=[],
+        race_metadata=RaceMetadata(
+            race_id="xx-senate-2024",
+            state="XX",
+            office_type="senate",
+            year=2024,
+            full_office_name="U.S. Senate",
+            jurisdiction="XX",
+            district=None,
+            election_date=datetime.utcnow(),
+            race_type="federal",
+            is_primary=False,
+            primary_date=None,
+            is_special_election=False,
+            is_runoff=False,
+            incumbent_party=None,
+            major_issues=[],
+            geographic_keywords=[],
+            confidence=ConfidenceLevel.LOW,
+            extracted_at=datetime.utcnow(),
+        ),
+    )
+    payload = {
+        "race_id": "xx-senate-2024",
+        "processed_content": [doc.model_dump(mode="json", by_alias=True, exclude_none=True)],
+        "race_json": race_json.model_dump(mode="json", by_alias=True, exclude_none=True),
+    }
+    result = await handler.handle(payload, {})
+    uri = result[0]["metadata"]["storage_uri"]
+    assert Path(uri).exists()


### PR DESCRIPTION
## Summary
- persist race metadata using storage backend and expose saved URI
- store relevance-filtered documents via storage backend
- route step orchestrator and registry through configured backend; add tests

## Testing
- `pre-commit run --files pipeline/app/step01_ingest/MetaDataService/race_metadata_service.py pipeline_client/backend/handlers/step01_metadata.py pipeline_client/backend/handlers/step01_relevance.py pipeline_client/backend/step_registry.py pipeline_client/backend/step_orchestrator.py pipeline_client/backend/storage_backend.py tests/test_storage_integration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a28d3f6f508325b545465ec331fa23