### PR TITLE
feat: secure pipeline client with Auth0

### DIFF
--- a/pipeline_client/backend/requirements.txt
+++ b/pipeline_client/backend/requirements.txt
@@ -4,3 +4,5 @@ pydantic==2.8.2
 pydantic-settings==2.4.0
 python-multipart==0.0.9
 websockets==12.0
+httpx==0.27.0
+python-jose[cryptography]==3.3.0

--- a/pipeline_client/backend/settings.py
+++ b/pipeline_client/backend/settings.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     gcs_bucket: str | None = None
     firestore_project: str | None = None
     allowed_origins: list[str] = Field(default_factory=lambda: ["*"])
+    auth0_domain: str | None = None
+    auth0_audience: str | None = None
 
     class Config:
         env_prefix = ""


### PR DESCRIPTION
## Summary
- secure pipeline client endpoints and websockets with Auth0 token validation
- add Auth0 configuration settings and dependencies
- send bearer tokens from frontend pipeline dashboard for API and websocket calls

## Testing
- `python -m pytest -v`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c27c36d0832590bae9c34cfdbbdc