### PR TITLE
docs: update vector db test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Setup
   - Web: `cd web && npm install`
 
 Dev commands
-- Test vector DB: `python test_vector_db.py`
+- Test vector DB: `python -m pytest pipeline/app/step02_corpus/test_service.py -v`
 - Run all tests: `python -m pytest -v`
 - Start web: `cd web && npm run dev`
 - Start races API: `cd services/races-api && python main.py`


### PR DESCRIPTION
## Summary
- update README to use pytest command for vector DB tests

## Testing
- `python -m pytest -v`
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c5a6bdb08325bfd2daaf391af7e5