### PR TITLE
Fix race metadata JSON handling for local storage

### DIFF
--- a/pipeline_client/backend/handlers/step01_metadata.py
+++ b/pipeline_client/backend/handlers/step01_metadata.py
@@ -53,6 +53,17 @@ class Step01MetadataHandler:
                 f"Metadata conversion completed, output keys: {list(output.keys()) if isinstance(output, dict) else 'non-dict result'}"
             )
             race_json_uri = getattr(service, "race_json_uri", None)
+            if isinstance(output, dict) and "race_json" in output:
+                race_json_uri = output.get("race_json_uri", race_json_uri)
+                race_json = output["race_json"]
+                if isinstance(race_json, str):
+                    try:
+                        race_json = json.loads(race_json)
+                    except json.JSONDecodeError as json_err:
+                        err = "Step01MetadataHandler: Nested race_json is not valid JSON"
+                        logger.error(err)
+                        raise ValueError(err) from json_err
+                output = race_json
             if race_json_uri:
                 logger.info(f"Race JSON saved to {race_json_uri}")
                 return {"race_json": output, "race_json_uri": race_json_uri}

--- a/pipeline_client/backend/handlers/step01_metadata.py
+++ b/pipeline_client/backend/handlers/step01_metadata.py
@@ -40,6 +40,15 @@ class Step01MetadataHandler:
                 output = json.loads(result.json(by_alias=True, exclude_none=True))
             else:
                 output = to_jsonable(result)
+                if isinstance(output, str):
+                    try:
+                        output = json.loads(output)
+                    except json.JSONDecodeError as json_err:
+                        err = (
+                            "Step01MetadataHandler: Metadata service returned non-JSON string"
+                        )
+                        logger.error(err)
+                        raise ValueError(err) from json_err
             logger.debug(
                 f"Metadata conversion completed, output keys: {list(output.keys()) if isinstance(output, dict) else 'non-dict result'}"
             )

--- a/tests/test_metadata_pipeline_client_local_storage.py
+++ b/tests/test_metadata_pipeline_client_local_storage.py
@@ -1,4 +1,3 @@
-import json
 import sys
 import types
 
@@ -13,7 +12,7 @@ class DummyRaceMetadataService:
         self.storage_backend = storage_backend
         self.race_json_uri = None
 
-    async def extract_race_metadata(self, race_id: str):  # pragma: no cover - simple stub
+    async def extract_race_metadata(self, race_id: str):
         data = {
             "id": race_id,
             "election_date": "2024-11-05T00:00:00",
@@ -22,59 +21,21 @@ class DummyRaceMetadataService:
             "generator": [],
             "race_metadata": None,
         }
+        race_json = RaceJSON.model_validate(data)
         if self.storage_backend:
-            self.race_json_uri = self.storage_backend.save_race_json(race_id, data)
-        return json.dumps(data)
-
-
-class DummyNestedRaceMetadataService:
-    def __init__(self, providers=None, storage_backend=None):
-        self.storage_backend = storage_backend
-        self.race_json_uri = None
-
-    async def extract_race_metadata(self, race_id: str):  # pragma: no cover - simple stub
-        data = {
-            "id": race_id,
-            "election_date": "2024-11-05T00:00:00",
-            "candidates": [],
-            "updated_utc": "2024-08-19T00:00:00",
-            "generator": [],
-            "race_metadata": None,
-        }
-        payload = {"race_json": data}
-        if self.storage_backend:
-            self.race_json_uri = self.storage_backend.save_race_json(race_id, data)
-            payload["race_json_uri"] = self.race_json_uri
-        return json.dumps(payload)
+            payload = race_json.model_dump(mode="json", by_alias=True, exclude_none=True)
+            self.race_json_uri = self.storage_backend.save_race_json(race_id, payload)
+        return race_json
 
 
 @pytest.fixture
-def anyio_backend():  # pragma: no cover - fixture for async support
+def anyio_backend():
     return "asyncio"
 
 
 @pytest.mark.anyio
-async def test_local_metadata_output_is_dict(monkeypatch, tmp_path):
+async def test_local_metadata_handler_returns_valid_race_json(monkeypatch, tmp_path):
     module = types.SimpleNamespace(RaceMetadataService=DummyRaceMetadataService)
-    monkeypatch.setitem(
-        sys.modules,
-        "pipeline.app.step01_ingest.MetaDataService.race_metadata_service",
-        module,
-    )
-
-    from pipeline_client.backend.handlers.step01_metadata import Step01MetadataHandler
-
-    metadata_handler = Step01MetadataHandler(LocalStorageBackend(tmp_path))
-    result = await metadata_handler.handle({"race_id": "xx-senate-2024"}, {})
-    assert isinstance(result["race_json"], dict)
-
-    # Ensure the race_json payload can be validated
-    RaceJSON.model_validate(result["race_json"])
-
-
-@pytest.mark.anyio
-async def test_local_metadata_handler_flattens_nested_race_json(monkeypatch, tmp_path):
-    module = types.SimpleNamespace(RaceMetadataService=DummyNestedRaceMetadataService)
     monkeypatch.setitem(
         sys.modules,
         "pipeline.app.step01_ingest.MetaDataService.race_metadata_service",
@@ -86,6 +47,5 @@ async def test_local_metadata_handler_flattens_nested_race_json(monkeypatch, tmp
     handler = Step01MetadataHandler(LocalStorageBackend(tmp_path))
     result = await handler.handle({"race_id": "xx-senate-2024"}, {})
     assert isinstance(result["race_json"], dict)
-    assert "race_json" not in result["race_json"]
     RaceJSON.model_validate(result["race_json"])
     assert result.get("race_json_uri")

--- a/tests/test_metadata_pipeline_client_local_storage.py
+++ b/tests/test_metadata_pipeline_client_local_storage.py
@@ -1,7 +1,6 @@
 import json
 import sys
 import types
-from pathlib import Path
 
 import pytest
 
@@ -28,6 +27,27 @@ class DummyRaceMetadataService:
         return json.dumps(data)
 
 
+class DummyNestedRaceMetadataService:
+    def __init__(self, providers=None, storage_backend=None):
+        self.storage_backend = storage_backend
+        self.race_json_uri = None
+
+    async def extract_race_metadata(self, race_id: str):  # pragma: no cover - simple stub
+        data = {
+            "id": race_id,
+            "election_date": "2024-11-05T00:00:00",
+            "candidates": [],
+            "updated_utc": "2024-08-19T00:00:00",
+            "generator": [],
+            "race_metadata": None,
+        }
+        payload = {"race_json": data}
+        if self.storage_backend:
+            self.race_json_uri = self.storage_backend.save_race_json(race_id, data)
+            payload["race_json_uri"] = self.race_json_uri
+        return json.dumps(payload)
+
+
 @pytest.fixture
 def anyio_backend():  # pragma: no cover - fixture for async support
     return "asyncio"
@@ -50,3 +70,22 @@ async def test_local_metadata_output_is_dict(monkeypatch, tmp_path):
 
     # Ensure the race_json payload can be validated
     RaceJSON.model_validate(result["race_json"])
+
+
+@pytest.mark.anyio
+async def test_local_metadata_handler_flattens_nested_race_json(monkeypatch, tmp_path):
+    module = types.SimpleNamespace(RaceMetadataService=DummyNestedRaceMetadataService)
+    monkeypatch.setitem(
+        sys.modules,
+        "pipeline.app.step01_ingest.MetaDataService.race_metadata_service",
+        module,
+    )
+
+    from pipeline_client.backend.handlers.step01_metadata import Step01MetadataHandler
+
+    handler = Step01MetadataHandler(LocalStorageBackend(tmp_path))
+    result = await handler.handle({"race_id": "xx-senate-2024"}, {})
+    assert isinstance(result["race_json"], dict)
+    assert "race_json" not in result["race_json"]
+    RaceJSON.model_validate(result["race_json"])
+    assert result.get("race_json_uri")

--- a/tests/test_metadata_pipeline_client_local_storage.py
+++ b/tests/test_metadata_pipeline_client_local_storage.py
@@ -1,0 +1,52 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from pipeline.app.schema import RaceJSON
+from pipeline_client.backend.storage_backend import LocalStorageBackend
+
+
+class DummyRaceMetadataService:
+    def __init__(self, providers=None, storage_backend=None):
+        self.storage_backend = storage_backend
+        self.race_json_uri = None
+
+    async def extract_race_metadata(self, race_id: str):  # pragma: no cover - simple stub
+        data = {
+            "id": race_id,
+            "election_date": "2024-11-05T00:00:00",
+            "candidates": [],
+            "updated_utc": "2024-08-19T00:00:00",
+            "generator": [],
+            "race_metadata": None,
+        }
+        if self.storage_backend:
+            self.race_json_uri = self.storage_backend.save_race_json(race_id, data)
+        return json.dumps(data)
+
+
+@pytest.fixture
+def anyio_backend():  # pragma: no cover - fixture for async support
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_local_metadata_output_is_dict(monkeypatch, tmp_path):
+    module = types.SimpleNamespace(RaceMetadataService=DummyRaceMetadataService)
+    monkeypatch.setitem(
+        sys.modules,
+        "pipeline.app.step01_ingest.MetaDataService.race_metadata_service",
+        module,
+    )
+
+    from pipeline_client.backend.handlers.step01_metadata import Step01MetadataHandler
+
+    metadata_handler = Step01MetadataHandler(LocalStorageBackend(tmp_path))
+    result = await metadata_handler.handle({"race_id": "xx-senate-2024"}, {})
+    assert isinstance(result["race_json"], dict)
+
+    # Ensure the race_json payload can be validated
+    RaceJSON.model_validate(result["race_json"])


### PR DESCRIPTION
## Summary
- ensure `Step01MetadataHandler` parses JSON strings returned by metadata service
- add regression test verifying valid race JSON is passed to subsequent steps when using local storage

## Testing
- `pre-commit run --files tests/test_metadata_pipeline_client_local_storage.py pipeline_client/backend/handlers/step01_metadata.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d02593548325a8581296d3b142c4