### PR TITLE
Use Serper as default search provider

### DIFF
--- a/docs/enhanced-metadata-service.md
+++ b/docs/enhanced-metadata-service.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-The Race Metadata Service has been significantly enhanced to include Google search integration and candidate discovery capabilities. This service now provides comprehensive race metadata extraction with real candidate identification through targeted web searches.
+The Race Metadata Service has been significantly enhanced to include web search integration (Serper by default with optional Google Custom Search) and candidate discovery capabilities. This service now provides comprehensive race metadata extraction with real candidate identification through targeted web searches.
 
 ## Key Enhancements
 
-### 1. Google Search Integration
-- **Real API Integration**: Uses Google Custom Search API with proper authentication
+### 1. Web Search Integration
+- **Real API Integration**: Uses the Serper API by default (Google CSE supported as a fallback)
 - **Intelligent Query Generation**: Creates targeted search queries for candidate discovery
 - **Site-Specific Searches**: Prioritizes authoritative sources like Ballotpedia, FEC, Vote411
 - **Fallback Handling**: Gracefully handles API failures and missing configuration
@@ -73,8 +73,9 @@ The enhanced service successfully discovered candidates for multiple race types:
 
 ### Required Environment Variables
 ```bash
-GOOGLE_SEARCH_API_KEY=your_google_api_key
-GOOGLE_SEARCH_ENGINE_ID=your_search_engine_id
+SERPER_API_KEY=your_serper_api_key
+GOOGLE_SEARCH_API_KEY=your_google_api_key  # optional fallback
+GOOGLE_SEARCH_ENGINE_ID=your_search_engine_id  # optional fallback
 ```
 
 ### API Quotas

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -42,7 +42,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 XAI_API_KEY=your_xai_grok_api_key_here
 
-# Google Search API (Required for fresh content discovery)
+# Serper Search API (default web search provider)
+SERPER_API_KEY=your_serper_api_key
+
+# Google Search API (optional fallback)
 GOOGLE_SEARCH_API_KEY=your_google_search_api_key
 GOOGLE_SEARCH_CX=your_custom_search_engine_id
 

--- a/pipeline/app/utils/search_utils.py
+++ b/pipeline/app/utils/search_utils.py
@@ -116,8 +116,8 @@ class SearchUtils:
         self.cache_ttl = search_config.get("cache_ttl_seconds", 300)
         self.per_host_concurrency = search_config.get("per_host_concurrency", 5)
         self._host_semaphores: Dict[str, asyncio.Semaphore] = defaultdict(lambda: asyncio.Semaphore(self.per_host_concurrency))
-        # Choose which external search provider to use. Defaults to Google CSE.
-        self.search_provider = search_config.get("search_provider", "google").lower()
+        # Choose which external search provider to use. Defaults to Serper, with Google CSE as a fallback option.
+        self.search_provider = search_config.get("search_provider", "serper").lower()
 
         self.issue_synonyms: Dict[CanonicalIssue, List[str]] = {
             CanonicalIssue.HEALTHCARE: ["health care", "medical", "medicare", "medicaid"],

--- a/pipeline/app/utils/test_search_utils.py
+++ b/pipeline/app/utils/test_search_utils.py
@@ -21,8 +21,8 @@ def test_deduplicate_sources_ignores_query_params():
     assert str(deduped[0].url) == url2
 
 
-def test_serper_mode_returns_mock_when_no_key():
-    utils = SearchUtils({"search_provider": "serper"})
+def test_default_serper_mode_returns_mock_when_no_key():
+    utils = SearchUtils({})
     query = FreshSearchQuery(race_id="tx-sen-2024", text="test")
     results = asyncio.run(utils.search_google_custom(query, CanonicalIssue.ECONOMY))
     assert len(results) == 1


### PR DESCRIPTION
## Summary
- default SearchUtils to Serper with Google CSE fallback
- adjust tests for new default search provider
- document Serper API key and optional Google fallback

## Testing
- `python -m isort pipeline/app/utils/search_utils.py pipeline/app/utils/test_search_utils.py`
- `python -m black pipeline/app/utils/search_utils.py pipeline/app/utils/test_search_utils.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8c20b5ec832585957f3527ff0241