### PR TITLE
[codex] Fix pipeline continuation and admin status tracking

### DIFF
--- a/pipeline_client/agent/phases.py
+++ b/pipeline_client/agent/phases.py
@@ -366,6 +366,20 @@ def _mark_pipeline_unit_complete(race_json: Dict[str, Any], unit: str) -> None:
         units.append(unit)
 
 
+def _issue_stance_is_complete(value: Any) -> bool:
+    return isinstance(value, dict) and bool(str(value.get("stance") or "").strip())
+
+
+def _pipeline_issue_attempts(race_json: Dict[str, Any]) -> Dict[str, int]:
+    state = race_json.setdefault("pipeline_state", {})
+    attempts = state.get("issue_attempts")
+    if not isinstance(attempts, dict):
+        attempts = {}
+    normalized = {str(unit): max(0, int(count or 0)) for unit, count in attempts.items()}
+    state["issue_attempts"] = normalized
+    return normalized
+
+
 def _build_handoff_context(
     handoffs: List[Dict[str, Any]],
     cached_info: Dict[str, Any] | None,
@@ -733,8 +747,23 @@ async def _run_shared_phases(
         track("start", "issues")
         iss_t0 = time.perf_counter()
         completed_units = _pipeline_completed_units(race_json)
+        issue_attempts = _pipeline_issue_attempts(race_json)
         if not resume_partial:
             completed_units = {unit for unit in completed_units if not unit.startswith("issues:")}
+            race_json["pipeline_state"]["completed_units"] = sorted(completed_units)
+            issue_attempts.clear()
+        else:
+            candidates_by_name = {
+                str(candidate.get("name")): candidate
+                for candidate in race_json.get("candidates", [])
+                if isinstance(candidate, dict) and candidate.get("name")
+            }
+            for name in candidate_names:
+                issues = candidates_by_name.get(name, {}).get("issues", {})
+                for issue in CANONICAL_ISSUES:
+                    unit_id = f"issues:{name}:{issue}"
+                    if unit_id in completed_units and not _issue_stance_is_complete(issues.get(issue)):
+                        completed_units.discard(unit_id)
             race_json["pipeline_state"]["completed_units"] = sorted(completed_units)
         pending_candidate_names = [
             name
@@ -758,6 +787,7 @@ async def _run_shared_phases(
         total_units = max(rn * n_issues, 1)
         configured_concurrency = int(os.getenv("PIPELINE_ISSUE_CONCURRENCY", "3"))
         issue_concurrency = max(1, min(configured_concurrency, 8))
+        max_issue_attempts = max(1, int(os.getenv("PIPELINE_ISSUE_MAX_ATTEMPTS", "3")))
         semaphore = asyncio.Semaphore(issue_concurrency)
         candidates_by_name = {
             str(candidate.get("name")): candidate
@@ -781,7 +811,33 @@ async def _run_shared_phases(
             for issue_idx, issue in enumerate(CANONICAL_ISSUES):
                 unit_id = f"issues:{cand_name}:{issue}"
                 existing_issue = candidate.get("issues", {}).get(issue)
-                if unit_id in completed_units or (resume_partial and isinstance(existing_issue, dict)):
+                if unit_id in completed_units or (resume_partial and _issue_stance_is_complete(existing_issue)):
+                    _mark_pipeline_unit_complete(race_json, unit_id)
+                    completed_units.add(unit_id)
+                    completed_count += 1
+                    track(
+                        "progress",
+                        "issues",
+                        pct=int(completed_count / total_units * 100),
+                        message=(
+                            f"Issues checkpoint - {cand_name} ({ci + 1}/{rn}) - " f"{issue} ({issue_idx + 1}/{n_issues})"
+                        ),
+                        race_json=race_json,
+                    )
+                    continue
+
+                if issue_attempts.get(unit_id, 0) >= max_issue_attempts:
+                    log(
+                        "warning",
+                        f"    Issue retry limit reached for {cand_name}/{issue}; "
+                        "recording a low-confidence no-position result",
+                    )
+                    candidate.setdefault("issues", {})[issue] = {
+                        "issue": issue,
+                        "stance": "No public position found after repeated research attempts.",
+                        "confidence": "low",
+                        "sources": [],
+                    }
                     _mark_pipeline_unit_complete(race_json, unit_id)
                     completed_units.add(unit_id)
                     completed_count += 1
@@ -805,7 +861,13 @@ async def _run_shared_phases(
                     website: str = candidate_website,
                     issue_urls: List[str] = list(candidate_issue_urls),
                 ) -> tuple[str, str, int, int, Dict[str, Any] | None]:
+                    nonlocal completed_count
+                    prior_attempts = issue_attempts.get(f"issues:{candidate_name}:{issue_name}", 0)
+                    if prior_attempts:
+                        await asyncio.sleep(prior_attempts * 0.01)
                     async with semaphore:
+                        unit_id = f"issues:{candidate_name}:{issue_name}"
+                        issue_attempts[unit_id] = issue_attempts.get(unit_id, 0) + 1
                         track(
                             "progress",
                             "issues",
@@ -814,6 +876,7 @@ async def _run_shared_phases(
                                 f"Issues · {candidate_name} ({candidate_index + 1}/{rn}) · "
                                 f"{issue_name} ({canonical_issue_index + 1}/{n_issues})"
                             ),
+                            race_json=race_json,
                         )
                         log(
                             "info",
@@ -833,28 +896,29 @@ async def _run_shared_phases(
                             candidate_issue_urls=issue_urls,
                             run_budget=run_budget,
                         )
+                        if _issue_stance_is_complete(patch):
+                            candidate = candidates_by_name[candidate_name]
+                            candidate.setdefault("issues", {})[issue_name] = patch
+                            _mark_pipeline_unit_complete(race_json, unit_id)
+                            completed_units.add(unit_id)
+                            completed_count += 1
+                            track(
+                                "progress",
+                                "issues",
+                                pct=int(completed_count / total_units * 100),
+                                message=(
+                                    f"Issues checkpoint - {candidate_name} ({candidate_index + 1}/{rn}) - "
+                                    f"{issue_name} ({canonical_issue_index + 1}/{n_issues})"
+                                ),
+                                race_json=race_json,
+                            )
                         return candidate_name, issue_name, candidate_index, canonical_issue_index, patch
 
                 tasks.append(asyncio.create_task(_run_unit()))
 
         try:
             for completed_task in asyncio.as_completed(tasks):
-                cand_name, issue, ci, issue_idx, issue_patch = await completed_task
-                candidate = candidates_by_name[cand_name]
-                if issue_patch is not None:
-                    candidate.setdefault("issues", {})[issue] = issue_patch
-                    unit_id = f"issues:{cand_name}:{issue}"
-                    _mark_pipeline_unit_complete(race_json, unit_id)
-                    completed_units.add(unit_id)
-                completed_count += 1
-                pct = int(completed_count / total_units * 100)
-                track(
-                    "progress",
-                    "issues",
-                    pct=pct,
-                    message=f"Issues checkpoint - {cand_name} ({ci + 1}/{rn}) - {issue} ({issue_idx + 1}/{n_issues})",
-                    race_json=race_json,
-                )
+                await completed_task
         except BaseException:
             for task in tasks:
                 if not task.done():

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -211,6 +211,20 @@ class AgentHandler:
 
             return min(98, int((done_weight + partial_weight) / total_weight * 100))
 
+        def _overall_progress(current_step: str | None = None, current_step_pct: int = 0) -> int:
+            """Use local run state when present; Cloud Functions rely on checkpoint state."""
+            if _run_manager and _run_manager.get_run(run_id):
+                return _compute_overall_progress(
+                    run_id,
+                    _run_manager,
+                    ALL_STEPS,
+                    STEP_WEIGHTS,
+                    enabled_set,
+                    current_step,
+                    current_step_pct,
+                )
+            return _fallback_progress(current_step, current_step_pct)
+
         def _broadcast_progress(pct: int, label: str) -> None:
             if run_id and _safe_broadcast:
                 _safe_broadcast({"type": "run_progress", "run_id": run_id, "progress": pct, "message": label})
@@ -263,11 +277,7 @@ class AgentHandler:
                 if _run_manager:
                     _run_manager.update_step_status(run_id, step, RunStatus.RUNNING)
                 label = STEP_LABELS.get(step, step)
-                pct = (
-                    _compute_overall_progress(run_id, _run_manager, ALL_STEPS, STEP_WEIGHTS, enabled_set)
-                    if _run_manager
-                    else _fallback_progress(step, 1)
-                )
+                pct = _overall_progress(step, 1)
                 _broadcast_progress(pct, label)
                 if _fs_logger:
                     remaining = [s for s in enabled_steps if s not in _completed_steps]
@@ -296,11 +306,7 @@ class AgentHandler:
                 if _run_manager:
                     _run_manager.update_step_status(run_id, step, RunStatus.COMPLETED, duration_ms=duration_ms)
                 _completed_steps.append(step)
-                pct = (
-                    _compute_overall_progress(run_id, _run_manager, ALL_STEPS, STEP_WEIGHTS, enabled_set)
-                    if _run_manager
-                    else _fallback_progress()
-                )
+                pct = _overall_progress()
                 label = STEP_LABELS.get(step, step) + " complete"
                 _broadcast_progress(pct, label)
 
@@ -365,11 +371,7 @@ class AgentHandler:
                             if s.name == step:
                                 s.progress_pct = pct
                                 break
-                overall = (
-                    _compute_overall_progress(run_id, _run_manager, ALL_STEPS, STEP_WEIGHTS, enabled_set, step, pct)
-                    if _run_manager
-                    else _fallback_progress(step, pct)
-                )
+                overall = _overall_progress(step, pct)
                 label = message or STEP_LABELS.get(step, step)
                 _broadcast_progress(overall, label)
                 if _fs_logger:
@@ -559,13 +561,16 @@ class AgentHandler:
         # Save as draft (not published) — admin must explicitly publish
         draft_path = await self._save_draft(race_id, race_json)
 
-        # Update race record metadata from the new draft data
-        try:
-            from pipeline_client.backend.race_manager import race_manager
+        # Durable queue executions finalize race/catalog state in the Cloud
+        # Function after this handler returns. Avoid a competing asynchronous
+        # full-document write from the legacy local runner's RaceManager.
+        if not queue_item_id:
+            try:
+                from pipeline_client.backend.race_manager import race_manager
 
-            race_manager.update_race_metadata(race_id, race_json)
-        except Exception:
-            logger.warning("Failed to update race metadata after draft save", exc_info=True)
+                race_manager.update_race_metadata(race_id, race_json)
+            except Exception:
+                logger.warning("Failed to update race metadata after draft save", exc_info=True)
 
         duration_ms = int((time.perf_counter() - t0) * 1000)
         logger.info(f"Agent: saved draft {race_id} to {draft_path} in {duration_ms}ms")

--- a/services/races-api/routers/runs.py
+++ b/services/races-api/routers/runs.py
@@ -50,6 +50,15 @@ def _run_sort_key(run: Dict[str, Any]) -> tuple[datetime, str]:
     return (activity_at, str(run.get("run_id") or ""))
 
 
+def _derive_logical_duration(run: Dict[str, Any]) -> Dict[str, Any]:
+    """Use logical run timestamps instead of the final invocation duration."""
+    started_at = _coerce_datetime(run.get("started_at"))
+    completed_at = _coerce_datetime(run.get("completed_at"))
+    if started_at and completed_at and completed_at >= started_at:
+        run["duration_ms"] = int((completed_at - started_at).total_seconds() * 1000)
+    return run
+
+
 def _collapse_continuation_chains(runs: list[Dict[str, Any]]) -> list[Dict[str, Any]]:
     """Present legacy continuation documents as one logical run."""
     by_id = {str(run.get("run_id")): run for run in runs if run.get("run_id")}
@@ -98,7 +107,7 @@ def _collapse_continuation_chains(runs: list[Dict[str, Any]]) -> list[Dict[str, 
             representative["started_at"] = min(starts).isoformat()
         if starts and ends:
             representative["duration_ms"] = int((max(ends) - min(starts)).total_seconds() * 1000)
-        collapsed.append(representative)
+        collapsed.append(_derive_logical_duration(representative))
     return collapsed
 
 
@@ -264,7 +273,7 @@ async def get_run(run_id: str) -> Dict[str, Any]:
     data = firestore_helpers._doc_to_plain(doc)
     if data is None:
         raise HTTPException(status_code=404, detail="Run not found")
-    return data
+    return _derive_logical_duration(data)
 
 
 @router.get("/runs/{run_id}/logs", dependencies=[Depends(verify_token)])
@@ -277,10 +286,10 @@ async def get_run_logs(run_id: str, since: int = 0, limit: int = 1000) -> Dict[s
     db = firestore_helpers._get_fs()
     logs_ref = db.collection("pipeline_runs").document(run_id).collection("logs")
     limit = max(1, min(limit, 5000))
-    entries = [firestore_helpers._doc_to_plain(d) for d in logs_ref.limit(limit).stream()]
+    entries = [firestore_helpers._doc_to_plain(d) for d in logs_ref.stream()]
     entries = [e for e in entries if e is not None]
     entries.sort(key=_log_sort_key)
-    sliced = entries[since:] if since < len(entries) else []
+    sliced = entries[since : since + limit] if since < len(entries) else []
     return {"logs": sliced, "total": len(entries)}
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -188,6 +188,55 @@ async def test_v2_handler_tracks_step_progress_in_firestore_without_run_manager(
 
 
 @pytest.mark.asyncio
+async def test_v2_handler_uses_fallback_progress_when_run_manager_has_no_local_run():
+    """Cloud Function handlers have a run manager module but no in-memory RunInfo."""
+    handler = AgentHandler()
+
+    async def _fake_run_agent(*_args, **kwargs):
+        tracker = kwargs["step_tracker"]
+        tracker["start"]("issues")
+        tracker["progress"]("issues", pct=42, message="Working issues")
+        return {"id": "test-race", "candidates": [{"name": "Alice", "issues": {}}]}
+
+    with (
+        patch("pipeline_client.agent.agent.run_agent", side_effect=_fake_run_agent),
+        patch.object(handler, "_save_draft", new_callable=AsyncMock, return_value=Path("/tmp/test-race.json")),
+        patch("pipeline_client.backend.firestore_logger.FirestoreLogger") as mock_fs_logger_cls,
+        patch("pipeline_client.backend.run_manager.run_manager.get_run", return_value=None),
+    ):
+        await handler.handle(
+            {"race_id": "test-race"},
+            {"run_id": "run-cloud", "enabled_steps": ["issues"]},
+        )
+
+    progress_updates = mock_fs_logger_cls.return_value.update_progress.call_args_list
+    issue_update = next(call for call in progress_updates if call.kwargs.get("current_step_progress") == 42)
+    assert issue_update.args[0] == 42
+
+
+@pytest.mark.asyncio
+async def test_v2_handler_leaves_durable_race_finalization_to_cloud_function():
+    """Queue executions must not race the Cloud Function with a stale full-document write."""
+    handler = AgentHandler()
+
+    with (
+        patch(
+            "pipeline_client.agent.agent.run_agent",
+            new_callable=AsyncMock,
+            return_value={"id": "test-race", "candidates": [{"name": "Alice"}]},
+        ),
+        patch.object(handler, "_save_draft", new_callable=AsyncMock, return_value=Path("/tmp/test-race.json")),
+        patch("pipeline_client.backend.race_manager.race_manager.update_race_metadata") as mock_update_metadata,
+    ):
+        await handler.handle(
+            {"race_id": "test-race"},
+            {"run_id": "run-cloud", "queue_item_id": "queue-cloud"},
+        )
+
+    mock_update_metadata.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_v2_handler_stops_when_queue_item_cancelled():
     """Cloud Function runs should stop at the next step boundary after cancellation."""
     from pipeline_client.backend.handlers.agent import AgentCancelled

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -2579,6 +2579,74 @@ def test_get_run_logs_since():
     assert body["logs"][0]["message"] == "msg 2"
 
 
+def test_get_run_logs_pages_after_sorting_full_log_set():
+    """Pagination must not apply the Firestore limit before the since offset."""
+    os.environ["SKIP_AUTH"] = "true"
+    os.environ["ADMIN_API_KEY"] = "test-key"
+
+    entries = [{"timestamp": f"2026-01-01T00:00:0{i}Z", "level": "info", "message": f"msg {i}"} for i in range(5)]
+    log_docs = [_make_existing_doc(entry) for entry in entries]
+
+    log_coll = MagicMock()
+    log_coll.stream.return_value = iter(log_docs)
+    run_doc_ref = MagicMock()
+    run_doc_ref.collection.return_value = log_coll
+    runs_coll = MagicMock()
+    runs_coll.document.return_value = run_doc_ref
+    db = _build_empty_firestore_mock()
+    db.collection.side_effect = lambda name: runs_coll if name == "pipeline_runs" else MagicMock()
+
+    import main as app_module
+
+    firestore_helpers._fs_db = None
+
+    from fastapi.testclient import TestClient
+
+    with patch("firestore_helpers._get_fs", return_value=db):
+        tc = TestClient(app_module.app)
+        resp = tc.get("/runs/run-abc/logs?since=2&limit=2")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 5
+    assert [entry["message"] for entry in body["logs"]] == ["msg 2", "msg 3"]
+
+
+def test_get_run_detail_uses_logical_duration_across_continuations():
+    """Run detail should show wall-clock duration, not only the final invocation."""
+    os.environ["SKIP_AUTH"] = "true"
+    os.environ["ADMIN_API_KEY"] = "test-key"
+
+    run_doc = _make_existing_doc(
+        {
+            "run_id": "run-abc",
+            "status": "completed",
+            "started_at": "2026-01-01T00:00:00Z",
+            "completed_at": "2026-01-01T00:30:00Z",
+            "duration_ms": 2500,
+        }
+    )
+    run_ref = MagicMock()
+    run_ref.get.return_value = run_doc
+    runs_coll = MagicMock()
+    runs_coll.document.return_value = run_ref
+    db = _build_empty_firestore_mock()
+    db.collection.side_effect = lambda name: runs_coll if name == "pipeline_runs" else MagicMock()
+
+    import main as app_module
+
+    firestore_helpers._fs_db = None
+
+    from fastapi.testclient import TestClient
+
+    with patch("firestore_helpers._get_fs", return_value=db):
+        tc = TestClient(app_module.app)
+        resp = tc.get("/runs/run-abc")
+
+    assert resp.status_code == 200
+    assert resp.json()["duration_ms"] == 1_800_000
+
+
 def test_delete_active_run_cancels_matching_queue_item():
     """Deleting an active run should cancel its Firestore queue item so the Cloud Function stops."""
     os.environ["SKIP_AUTH"] = "true"

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1070,6 +1070,90 @@ async def test_run_agent_continuation_skips_completed_issue_stances():
 
 
 @pytest.mark.asyncio
+async def test_run_agent_continuation_retries_blank_issue_stances():
+    existing = {
+        "id": "test-2024",
+        "candidates": [
+            {
+                "name": "Alice",
+                "party": "D",
+                "issues": {
+                    CANONICAL_ISSUES[0]: {
+                        "issue": CANONICAL_ISSUES[0],
+                        "stance": "",
+                        "confidence": "low",
+                        "sources": [],
+                    }
+                },
+            }
+        ],
+        "pipeline_state": {
+            "completed_units": [f"issues:Alice:{CANONICAL_ISSUES[0]}"],
+        },
+        "updated_utc": "2024-01-01T00:00:00Z",
+    }
+
+    with patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = {}
+        result = await run_agent(
+            "test-2024",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["issues"],
+            resume_partial=True,
+        )
+
+    assert mock_loop.call_count == len(CANONICAL_ISSUES)
+    assert f"issues:Alice:{CANONICAL_ISSUES[0]}" not in result["pipeline_state"]["completed_units"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_continuation_caps_repeated_issue_attempts(monkeypatch):
+    capped_issue = CANONICAL_ISSUES[0]
+    completed_issues = {
+        issue: {
+            "issue": issue,
+            "stance": f"Existing stance on {issue}",
+            "confidence": "high",
+            "sources": [],
+        }
+        for issue in CANONICAL_ISSUES[1:]
+    }
+    existing = {
+        "id": "test-2024",
+        "candidates": [
+            {
+                "name": "Alice",
+                "party": "D",
+                "issues": {
+                    capped_issue: {"issue": capped_issue, "stance": "", "confidence": "low", "sources": []},
+                    **completed_issues,
+                },
+            }
+        ],
+        "pipeline_state": {
+            "completed_units": [f"issues:Alice:{issue}" for issue in CANONICAL_ISSUES],
+            "issue_attempts": {f"issues:Alice:{capped_issue}": 3},
+        },
+        "updated_utc": "2024-01-01T00:00:00Z",
+    }
+    monkeypatch.setenv("PIPELINE_ISSUE_MAX_ATTEMPTS", "3")
+
+    with patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop:
+        result = await run_agent(
+            "test-2024",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["issues"],
+            resume_partial=True,
+        )
+
+    assert mock_loop.call_count == 0
+    assert "repeated research attempts" in result["candidates"][0]["issues"][capped_issue]["stance"]
+    assert f"issues:Alice:{capped_issue}" in result["pipeline_state"]["completed_units"]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_continuation_does_not_report_skipped_issue_as_active():
     """Skipped checkpointed issue stances should not look like active research."""
     existing = {
@@ -1242,12 +1326,24 @@ async def test_issue_checkpoint_progress_includes_partial_race_json():
     progress_payloads = []
 
     def _progress(step: str, **kwargs):
-        if step == "issues" and "race_json" in kwargs:
+        if step == "issues" and "race_json" in kwargs and kwargs.get("message", "").startswith("Issues checkpoint"):
             progress_payloads.append(kwargs["race_json"])
 
-    with patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop:
-        mock_loop.return_value = {}
+    async def fake_loop(_system, user, **kwargs):
+        candidate = re.search(r"^Candidate: (.+)$", user, re.MULTILINE).group(1)
+        issue = re.search(r"^Issue to (?:research|update): (.+)$", user, re.MULTILINE).group(1)
+        kwargs["extra_tool_handlers"]["set_issue_stance"](
+            {
+                "candidate_name": candidate,
+                "issue": issue,
+                "stance": f"{candidate} stance on {issue}",
+                "confidence": "low",
+                "sources": [],
+            }
+        )
+        return {}
 
+    with patch("pipeline_client.agent.phases._agent_loop", side_effect=fake_loop):
         await run_agent(
             "test-2024",
             cheap_mode=True,

--- a/web/src/lib/components/admin/RacesTab.svelte
+++ b/web/src/lib/components/admin/RacesTab.svelte
@@ -30,8 +30,8 @@
   let sorting: SortingState = [{ id: "draft_updated_at", desc: true }];
   let columnFilters: ColumnFiltersState = [];
 
-  export async function refresh() {
-    loading = true;
+  export async function refresh(showLoading = true) {
+    if (showLoading) loading = true;
     await loadData();
   }
 
@@ -343,7 +343,7 @@
       <button
         type="button"
         class="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium shadow-sm"
-        on:click={refresh}
+        on:click={() => refresh()}
       >
         Retry
       </button>

--- a/web/src/lib/services/pipelineApiService.test.ts
+++ b/web/src/lib/services/pipelineApiService.test.ts
@@ -95,6 +95,19 @@ describe("PipelineApiService production admin API contract", () => {
     );
   });
 
+  it("reconciles active race state when loading the admin race list", async () => {
+    fetchWithAuth.mockResolvedValueOnce(jsonResponse({ races: [] }));
+
+    const api = new PipelineApiService("https://api.example.test");
+    await api.listRaces();
+
+    expect(fetchWithAuth).toHaveBeenCalledWith(
+      "https://api.example.test/api/races?reconcile_active=true",
+      {},
+      expect.any(Number)
+    );
+  });
+
   it("parses admin chat action responses", async () => {
     fetchWithAuth.mockResolvedValueOnce(
       jsonResponse({

--- a/web/src/lib/services/pipelineApiService.ts
+++ b/web/src/lib/services/pipelineApiService.ts
@@ -467,7 +467,11 @@ export class PipelineApiService {
    * List all race records (unified view)
    */
   async listRaces(): Promise<RaceRecord[]> {
-    const res = await fetchWithAuth(`${this.apiBase}/api/races`, {}, API_TIMEOUT_DEFAULT);
+    const res = await fetchWithAuth(
+      `${this.apiBase}/api/races?reconcile_active=true`,
+      {},
+      API_TIMEOUT_DEFAULT
+    );
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
     const data: RaceListResponse = await res.json();
     return data.races || [];

--- a/web/src/routes/admin/pipeline/+page.svelte
+++ b/web/src/routes/admin/pipeline/+page.svelte
@@ -22,6 +22,7 @@
   let connected = false;
   let queueTimer: ReturnType<typeof setInterval> | null = null;
   let cancellingItemId: string | null = null;
+  let racesTab: RacesTab | null = null;
 
   $: if (activeTab === "runs" && apiService) {
     void refreshRuns();
@@ -45,7 +46,7 @@
     let newIntervalMs = 0;
     if (activeItemsCount > 0) {
       newIntervalMs = 12000;
-    } else if (currentTab === "dashboard" || currentTab === "runs") {
+    } else if (currentTab === "dashboard" || currentTab === "races" || currentTab === "runs") {
       newIntervalMs = 30000;
     } else {
       newIntervalMs = 0;
@@ -63,7 +64,7 @@
 
     if (pollingIntervalMs > 0) {
       queueTimer = setInterval(() => {
-        if (!document.hidden) void refreshQueue();
+        if (!document.hidden) void refreshOperationalState();
       }, pollingIntervalMs);
     }
   }
@@ -104,6 +105,16 @@
     }
   }
 
+  async function refreshOperationalState() {
+    const refreshes: Promise<void>[] = [refreshQueue()];
+    if (activeTab === "runs") {
+      refreshes.push(refreshRuns());
+    } else if (activeTab === "races" && racesTab) {
+      refreshes.push(racesTab.refresh(false));
+    }
+    await Promise.allSettled(refreshes);
+  }
+
   async function cancelQueueItem(item: QueueItem) {
     if (!confirm(`Cancel ${item.race_id || item.run_id || "this queue item"}?`)) return;
     cancellingItemId = item.id;
@@ -118,7 +129,7 @@
   }
 
   async function refreshRuns() {
-    if (!apiService) return;
+    if (!apiService || isRefreshingRuns) return;
     isRefreshingRuns = true;
     try {
       runs = await apiService.loadRunHistory();
@@ -216,7 +227,7 @@
     />
   {:else if activeTab === "races" && apiService}
     <div class="card p-6">
-      <RacesTab />
+      <RacesTab bind:this={racesTab} />
     </div>
   {:else if activeTab === "runs" && apiService}
     <RunsTab


### PR DESCRIPTION
﻿## What changed
- Persist per-issue continuation attempts and stop repeatedly scheduling the same failing units.
- Treat blank issue stances as incomplete and checkpoint successful concurrent issue work immediately.
- Use checkpoint-derived progress in Cloud Function runs and avoid stale legacy race metadata writes.
- Correct logical run duration and log pagination in the admin API.
- Refresh and reconcile race/run state in the admin UI.

## Root cause
Continuation payloads retained completed work, but failing issue units had no durable retry state and restarted in the same order. Concurrent successes were only merged by the coordinator, leaving a loss window during deadline handoff. Separately, Cloud Function progress incorrectly depended on an in-memory local run and the admin UI did not regularly reconcile stale operational state.

## Validation
- `PYTHONPATH=. python -m pytest` (329 passed)
- Black and isort checks for touched Python files
- Frontend `npm run check` and production build
- Targeted Vitest suites: 10 passed

The full frontend Vitest run is currently blocked by unrelated concurrent edits in `RunsTab.svelte`; those edits are not part of this PR.
