### PR TITLE
[codex] Fix Cloud Function progress fallback

### DIFF
--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -213,7 +213,8 @@ class AgentHandler:
 
         def _overall_progress(current_step: str | None = None, current_step_pct: int = 0) -> int:
             """Use local run state when present; Cloud Functions rely on checkpoint state."""
-            if _run_manager and _run_manager.get_run(run_id):
+            local_runs = getattr(_run_manager, "active_runs", {}) if _run_manager else {}
+            if run_id in local_runs:
                 return _compute_overall_progress(
                     run_id,
                     _run_manager,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -202,7 +202,7 @@ async def test_v2_handler_uses_fallback_progress_when_run_manager_has_no_local_r
         patch("pipeline_client.agent.agent.run_agent", side_effect=_fake_run_agent),
         patch.object(handler, "_save_draft", new_callable=AsyncMock, return_value=Path("/tmp/test-race.json")),
         patch("pipeline_client.backend.firestore_logger.FirestoreLogger") as mock_fs_logger_cls,
-        patch("pipeline_client.backend.run_manager.run_manager.get_run", return_value=None),
+        patch("pipeline_client.backend.run_manager.run_manager.get_run", return_value=MagicMock()),
     ):
         await handler.handle(
             {"race_id": "test-race"},


### PR DESCRIPTION
﻿## What changed
- Distinguish actual in-memory `RunManager.active_runs` state from Firestore fallback records.
- Use checkpoint-derived weighted progress for Cloud Function runs even when `get_run()` can load a persisted document.
- Strengthen the regression test to reproduce the production Firestore fallback behavior.

## Root cause
`RunManager.get_run()` loads Firestore when a run is not active locally. The previous fix treated any returned record as local step state, but Cloud Function run documents do not contain the in-memory step objects needed by `_compute_overall_progress`, so overall progress remained zero.

## Validation
- `PYTHONPATH=. python -m pytest` (329 passed)
- Black, isort, and pre-commit hooks passed
