### PR TITLE
[codex] Checkpoint refinement work units

### DIFF
--- a/pipeline_client/agent/phases.py
+++ b/pipeline_client/agent/phases.py
@@ -989,9 +989,20 @@ async def _run_shared_phases(
         cand_list = [c for c in race_json.get("candidates", []) if isinstance(c, dict) and c.get("name") in selected_name_set]
         cand_names_in_json = [c["name"] for c in cand_list]
         n_cands = len(cand_list)
+        refinement_units = _pipeline_completed_units(race_json)
         log("info", f"{prefix} 3: Refining profile (one candidate at a time, tools mode)...")
         for ci, candidate in enumerate(cand_list):
             cname = candidate["name"]
+            unit_id = f"refinement:{cname}"
+            if resume_partial and unit_id in refinement_units:
+                track(
+                    "progress",
+                    "refinement",
+                    pct=int(((ci + 1) / max(n_cands, 1)) * 100),
+                    message=f"Refinement checkpoint: {cname} ({ci + 1}/{n_cands})",
+                    race_json=race_json,
+                )
+                continue
             candidate_website, candidate_issue_urls = await _await_with_run_budget(
                 _candidate_source_hints(race_json, cname),
                 run_budget=run_budget,
@@ -1005,6 +1016,7 @@ async def _run_shared_phases(
                 "refinement",
                 pct=int((ci / max(n_cands, 1)) * 100),
                 message=f"Refinement: {cname} ({ci + 1}/{n_cands})",
+                race_json=race_json,
             )
             try:
                 refine_prefix = "upd-refine" if is_update else "refine"
@@ -1035,31 +1047,51 @@ async def _run_shared_phases(
                 raise
             except Exception as exc:
                 log("warning", f"  Refine failed for {cname}: {exc} — keeping existing")
+            _mark_pipeline_unit_complete(race_json, unit_id)
+            refinement_units.add(unit_id)
+            track(
+                "progress",
+                "refinement",
+                pct=int(((ci + 1) / max(n_cands, 1)) * 100),
+                message=f"Refinement checkpoint: {cname} ({ci + 1}/{n_cands})",
+                race_json=race_json,
+            )
 
         # Meta refinement (description only) — tools mode
-        log("info", "  Refining race metadata...")
-        try:
-            await _agent_loop(
-                REFINE_SYSTEM,
-                REFINE_META_USER.format(
+        meta_unit_id = "refinement:meta"
+        if not (resume_partial and meta_unit_id in refinement_units):
+            log("info", "  Refining race metadata...")
+            try:
+                await _agent_loop(
+                    REFINE_SYSTEM,
+                    REFINE_META_USER.format(
+                        race_id=race_id,
+                        race_description=race_json.get("description", ""),
+                    ),
+                    model=model,
+                    on_log=on_log,
                     race_id=race_id,
-                    race_description=race_json.get("description", ""),
-                ),
-                model=model,
-                on_log=on_log,
-                race_id=race_id,
-                max_iterations=max(6, refine_iters // 3),
-                phase_name=f"{'upd-' if is_update else ''}refine-meta",
-                max_tokens=4096,
-                extra_tools=DESCRIPTION_TOOLS + [READ_PROFILE_TOOL],
-                extra_tool_handlers=handlers,
-                tools_mode=True,
-                run_budget=run_budget,
+                    max_iterations=max(6, refine_iters // 3),
+                    phase_name=f"{'upd-' if is_update else ''}refine-meta",
+                    max_tokens=4096,
+                    extra_tools=DESCRIPTION_TOOLS + [READ_PROFILE_TOOL],
+                    extra_tool_handlers=handlers,
+                    tools_mode=True,
+                    run_budget=run_budget,
+                )
+            except RunBudgetExceeded:
+                raise
+            except Exception as exc:
+                log("warning", f"  Refine meta failed: {exc} — keeping existing meta")
+            _mark_pipeline_unit_complete(race_json, meta_unit_id)
+            refinement_units.add(meta_unit_id)
+            track(
+                "progress",
+                "refinement",
+                pct=100,
+                message="Refinement checkpoint: race metadata",
+                race_json=race_json,
             )
-        except RunBudgetExceeded:
-            raise
-        except Exception as exc:
-            log("warning", f"  Refine meta failed: {exc} — keeping existing meta")
         track("complete", "refinement", duration_ms=int((time.perf_counter() - ref_t0) * 1000), race_json=race_json)
     else:
         log("info", f"{prefix} 3: Refinement — SKIPPED")

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1154,6 +1154,40 @@ async def test_run_agent_continuation_caps_repeated_issue_attempts(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_agent_continuation_skips_completed_refinement_units():
+    existing = {
+        "id": "test-2026",
+        "election_date": "2026-11-03",
+        "office": "Governor",
+        "state": "Michigan",
+        "candidates": [
+            {"name": "Alice", "party": "D", "issues": {}},
+            {"name": "Bob", "party": "R", "issues": {}},
+        ],
+        "pipeline_state": {"completed_units": ["refinement:Alice"]},
+        "updated_utc": "2026-01-01T00:00:00Z",
+    }
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
+        patch("pipeline_client.agent.phases._candidate_source_hints", new_callable=AsyncMock, return_value=("", [])),
+    ):
+        result = await run_agent(
+            "test-2026",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["refinement"],
+            resume_partial=True,
+        )
+
+    phase_names = [call.kwargs["phase_name"] for call in mock_loop.call_args_list]
+    assert phase_names == ["upd-refine-Bob", "upd-refine-meta"]
+    assert "refinement:Alice" in result["pipeline_state"]["completed_units"]
+    assert "refinement:Bob" in result["pipeline_state"]["completed_units"]
+    assert "refinement:meta" in result["pipeline_state"]["completed_units"]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_continuation_does_not_report_skipped_issue_as_active():
     """Skipped checkpointed issue stances should not look like active research."""
     existing = {


### PR DESCRIPTION
﻿## What changed
- Add durable `refinement:<candidate>` and `refinement:meta` work-unit checkpoints.
- Skip completed refinement units on continuation.
- Include the current RaceJSON in refinement progress callbacks so handoff checkpoints contain all completed profile work.
- Leave budget-interrupted candidates incomplete and retryable; non-budget failures keep existing data and advance.

## Root cause
Refinement restarted its candidate loop from the first candidate on every Cloud Function invocation. Completed candidate refinements were neither marked durably nor pushed into the handoff checkpoint, so a difficult first candidate could consume unlimited continuations.

## Validation
- `PYTHONPATH=. python -m pytest` (331 passed)
- Black, isort, and pre-commit hooks passed
- Live Michigan governor verification reproduced the repeated-candidate failure
