### PR TITLE
[codex] Fix admin update CI regressions

### DIFF
--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -310,11 +310,7 @@ class AgentHandler:
                 if _run_manager:
                     _run_manager.update_step_status(run_id, step, RunStatus.RUNNING)
                 label = STEP_LABELS.get(step, step)
-                pct = 0
-                if _run_manager and _run_manager.get_run(run_id):
-                    pct = _compute_overall_progress(run_id, _run_manager, ALL_STEPS, STEP_WEIGHTS, enabled_set)
-                else:
-                    pct = _fallback_progress(step, 1)
+                pct = _overall_progress(step, 1)
                 _broadcast_progress(pct, label)
                 if _fs_logger:
                     remaining = [s for s in enabled_steps if s not in _completed_steps]
@@ -382,11 +378,7 @@ class AgentHandler:
                         estimated_usd=estimated_usd,
                     )
                 _completed_steps.append(step)
-                pct = 0
-                if _run_manager and _run_manager.get_run(run_id):
-                    pct = _compute_overall_progress(run_id, _run_manager, ALL_STEPS, STEP_WEIGHTS, enabled_set)
-                else:
-                    pct = _fallback_progress()
+                pct = _overall_progress()
                 label = STEP_LABELS.get(step, step) + " complete"
                 _broadcast_progress(pct, label)
 
@@ -451,11 +443,7 @@ class AgentHandler:
                             if s.name == step:
                                 s.progress_pct = pct
                                 break
-                overall = 0
-                if _run_manager and _run_manager.get_run(run_id):
-                    overall = _compute_overall_progress(run_id, _run_manager, ALL_STEPS, STEP_WEIGHTS, enabled_set, step, pct)
-                else:
-                    overall = _fallback_progress(step, pct)
+                overall = _overall_progress(step, pct)
                 label = message or STEP_LABELS.get(step, step)
                 _broadcast_progress(overall, label)
                 if _fs_logger:

--- a/web/src/lib/components/admin/RacesTab.status-flow.test.ts
+++ b/web/src/lib/components/admin/RacesTab.status-flow.test.ts
@@ -133,7 +133,7 @@ describe("RacesTab preview and render flow", () => {
 
     await waitFor(() =>
       expect(mockFetchWithAuth).toHaveBeenCalledWith(
-        "http://localhost:8080/api/races/queue",
+        expect.stringMatching(/\/api\/races\/queue$/),
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ race_ids: ["ready-to-run"], options: {} }),
@@ -163,7 +163,7 @@ describe("RacesTab preview and render flow", () => {
 
     await waitFor(() =>
       expect(mockFetchWithAuth).toHaveBeenCalledWith(
-        "http://localhost:8080/api/races/active-race/cancel",
+        expect.stringMatching(/\/api\/races\/active-race\/cancel$/),
         { method: "POST" },
         expect.any(Number)
       )


### PR DESCRIPTION
## What changed
- route all handler progress callbacks through the cloud-aware progress helper
- make RacesTab endpoint assertions independent of the configured localhost hostname

## Why
The preceding admin update left three callbacks bypassing its new helper and introduced brittle URL assertions, causing main CI to fail and blocking deployment of the review continuation fix.

## Validation
- `PYTHONPATH=. python -m pytest tests/test_handlers.py -q` (12 passed)
- `npm run test:unit -- --run src/lib/components/admin/RacesTab.status-flow.test.ts` (5 passed)
- Black, isort, and pre-commit hooks