### PR TITLE
[codex] Checkpoint review iteration candidates

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -646,15 +646,22 @@ async def run_agent(
 
                 did_iterate = True
                 log("info", f"Phase 5 (cycle {cycle}/{max_review_cycles}): Iterating on review feedback...")
-                _track("progress", "iteration", pct=int(cycle / max_review_cycles * 80))
                 cycle_budget = max_iterations if max_review_cycles == 1 else int(max_iterations / max_review_cycles)
+
+                def _on_iteration_progress(pct: int, message: str, checkpoint_race: Dict[str, Any]) -> None:
+                    cycle_pct = int(((cycle - 1) + pct / 100) / max_review_cycles * 100)
+                    _track("progress", "iteration", pct=cycle_pct, message=message, race_json=checkpoint_race)
+
                 improved = await _run_iteration_pass(
                     race_id,
                     race_json,
                     reviews,
                     model=model,
                     on_log=on_log,
+                    on_progress=_on_iteration_progress,
                     max_iterations=max(cycle_budget, 14),
+                    resume_partial=resume_partial,
+                    unit_prefix=f"iteration:{cycle}",
                     run_budget=run_budget,
                 )
                 if improved is not None:

--- a/pipeline_client/agent/phases.py
+++ b/pipeline_client/agent/phases.py
@@ -1578,7 +1578,10 @@ async def _run_iteration_pass(
     *,
     model: str,
     on_log: Any | None = None,
+    on_progress: Any | None = None,
     max_iterations: int = 20,
+    resume_partial: bool = False,
+    unit_prefix: str = "iteration:1",
     run_budget: RunBudget | None = None,
 ) -> Optional[Dict[str, Any]]:
     """Run a single iteration pass addressing review flags (tools mode)."""
@@ -1593,14 +1596,34 @@ async def _run_iteration_pass(
     log("info", f"  Iteration: addressing review flags for {n} candidates (tools mode)")
 
     working = copy.deepcopy(race_json)
+    completed_units = _pipeline_completed_units(working)
+    if not resume_partial:
+        completed_units = {unit for unit in completed_units if not unit.startswith(f"{unit_prefix}:")}
+        working["pipeline_state"]["completed_units"] = sorted(completed_units)
+
+    candidate_units = [
+        (candidate, f"{unit_prefix}:{_candidate_name(candidate)}")
+        for candidate in working.get("candidates", [])
+        if isinstance(candidate, dict) and _candidate_name(candidate)
+    ]
+    expected_units = {unit for _, unit in candidate_units}
+
+    def checkpoint_progress(label: str) -> None:
+        if on_progress is None:
+            return
+        completed = len(expected_units & _pipeline_completed_units(working))
+        pct = int(completed / max(len(expected_units), 1) * 100)
+        on_progress(pct, label, working)
+
     handlers = _make_editing_handlers(working, log)
     all_tools = (
         ROSTER_TOOLS + CANDIDATE_TOOLS + ISSUE_TOOLS + RECORD_TOOLS + BACKGROUND_TOOLS + RACE_TOOLS + [READ_PROFILE_TOOL]
     )
     any_success = False
 
-    for candidate in working.get("candidates", []):
-        if not isinstance(candidate, dict) or not _candidate_name(candidate):
+    for candidate, unit_id in candidate_units:
+        if unit_id in completed_units:
+            log("info", f"  Iteration checkpoint already complete for {_candidate_name(candidate)}; skipping")
             continue
         cname = _candidate_name(candidate)
         candidate_website, candidate_issue_urls = await _await_with_run_budget(
@@ -1640,6 +1663,10 @@ async def _run_iteration_pass(
         except Exception as exc:
             log("warning", f"  Iteration failed for {cname}: {exc} — keeping existing")
 
+        _mark_pipeline_unit_complete(working, unit_id)
+        completed_units.add(unit_id)
+        checkpoint_progress(f"Review iteration checkpoint: {cname}")
+
     log("info", "  Iterating on race metadata...")
     try:
         await _agent_loop(
@@ -1667,7 +1694,7 @@ async def _run_iteration_pass(
     except Exception as exc:
         log("warning", f"  Iteration meta failed: {exc} — keeping existing meta")
 
-    if not any_success:
+    if not any_success and not expected_units.issubset(_pipeline_completed_units(working)):
         log("warning", "  All iteration calls failed — keeping original")
         return None
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from pipeline_client.agent.agent import _load_existing, _normalize_schema_fields, _sanitize_polling, run_agent
-from pipeline_client.agent.phases import _reconcile_candidates_with_authoritative_roster, _sanitize_roster
+from pipeline_client.agent.phases import _reconcile_candidates_with_authoritative_roster, _run_iteration_pass, _sanitize_roster
 from pipeline_client.agent.prompts import CANONICAL_ISSUES
 from pipeline_client.backend.handlers.agent import HandoffTriggered
 
@@ -657,6 +657,40 @@ async def test_run_agent_iteration_continuation_preserves_reviews_and_computes_g
         "summary": "Validated by 1/1 reviewers with an average score of 95/100.",
     }
     assert result["pipeline_state"]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_iteration_pass_continuation_skips_completed_candidate_units():
+    race = {
+        "id": "iteration-units-2026",
+        "candidates": [{"name": "Alice"}, {"name": "Bob"}],
+        "pipeline_state": {"completed_units": ["iteration:1:Alice"]},
+    }
+    progress_updates = []
+
+    with (
+        patch("pipeline_client.agent.phases._candidate_source_hints", new_callable=AsyncMock, return_value=("", [])),
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock, return_value={}) as mock_loop,
+    ):
+        result = await _run_iteration_pass(
+            "iteration-units-2026",
+            race,
+            [{"model": "claude", "flags": [{"field": "summary", "severity": "warning"}]}],
+            model="test-model",
+            resume_partial=True,
+            unit_prefix="iteration:1",
+            on_progress=lambda pct, message, checkpoint: progress_updates.append((pct, message, checkpoint)),
+        )
+
+    assert result is not None
+    phases = [call.kwargs["phase_name"] for call in mock_loop.call_args_list]
+    assert phases == ["iterate-Bob", "iterate-meta"]
+    assert set(result["pipeline_state"]["completed_units"]) >= {
+        "iteration:1:Alice",
+        "iteration:1:Bob",
+    }
+    assert progress_updates[-1][0] == 100
+    assert progress_updates[-1][2]["pipeline_state"]["completed_units"] == result["pipeline_state"]["completed_units"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- persist `iteration:<cycle>:<candidate>` completion units in pipeline checkpoints
- skip completed candidates when review iteration resumes
- carry mutated race data through iteration progress callbacks so handoffs save current work
- add regression coverage for candidate-level iteration continuation

## Root cause
Review iteration used a copied race object and had no durable work units. A deadline handoff saved only the pre-iteration review checkpoint, so every continuation restarted at the first candidate.

## Validation
- `PYTHONPATH=. python -m pytest -q` (333 passed)
- Black, isort, and pre-commit hooks