### PR TITLE
[codex] Fix polling matchup validation

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -176,20 +176,24 @@ def _sanitize_polling(race_json: Dict[str, Any], log: Any | None = None) -> None
                         log("warning", f"Poll {poll_index} matchup {matchup_index} references non-roster candidates; dropping")
                     continue
             percentages = matchup.get("percentages")
-            if percentages is None:
-                matchup["percentages"] = []
+            if not isinstance(names, list) or not names:
+                if log:
+                    log("warning", f"Poll {poll_index} matchup {matchup_index} has no candidate names; dropping")
+                continue
+            if not isinstance(percentages, list) or not percentages:
+                if log:
+                    log("warning", f"Poll {poll_index} matchup {matchup_index} has no numeric percentages; dropping")
+                continue
+            if len(names) != len(percentages):
                 if log:
                     log(
-                        "warning",
-                        f"Poll {poll_index} matchup {matchup_index} had null percentages; normalized to an empty list",
+                        "warning", f"Poll {poll_index} matchup {matchup_index} has mismatched candidates/percentages; dropping"
                     )
-            if not isinstance(percentages, list):
-                matchup["percentages"] = []
+                continue
+            if any(not isinstance(pct, (int, float)) or not 0 <= pct <= 100 for pct in percentages):
                 if log:
-                    log(
-                        "warning",
-                        f"Poll {poll_index} matchup {matchup_index} percentages was not a list; normalized to an empty list",
-                    )
+                    log("warning", f"Poll {poll_index} matchup {matchup_index} has invalid percentages; dropping")
+                continue
             kept_matchups.append(matchup)
         poll["matchups"] = kept_matchups
 

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -454,13 +454,27 @@ def _make_editing_handlers(race_json: Dict[str, Any], log: Callable) -> Dict[str
             for candidate in race_json.get("candidates", [])
             if isinstance(candidate, dict) and str(candidate.get("name") or "").strip()
         }
-        matchup_names = {
-            str(name).strip()
-            for matchup in args.get("matchups", [])
-            if isinstance(matchup, dict)
-            for name in matchup.get("candidates", [])
-            if str(name).strip()
-        }
+        matchups = args.get("matchups")
+        if not isinstance(matchups, list):
+            return "ERROR: Poll matchups must be a list. Use an empty list only when the source does not publish numbers."
+
+        matchup_names = set()
+        for index, matchup in enumerate(matchups):
+            if not isinstance(matchup, dict):
+                return f"ERROR: Poll matchup {index + 1} must be an object with candidates and percentages."
+            candidates = matchup.get("candidates")
+            percentages = matchup.get("percentages")
+            if not isinstance(candidates, list) or not candidates:
+                return f"ERROR: Poll matchup {index + 1} must include candidate names."
+            if not isinstance(percentages, list) or not percentages:
+                return f"ERROR: Poll matchup {index + 1} must include numeric percentages."
+            if len(candidates) != len(percentages):
+                return f"ERROR: Poll matchup {index + 1} candidates and percentages must have the same length."
+            for percentage in percentages:
+                if not isinstance(percentage, (int, float)) or not 0 <= percentage <= 100:
+                    return f"ERROR: Poll matchup {index + 1} has an invalid percentage value: {percentage!r}."
+            matchup_names.update(str(name).strip() for name in candidates if str(name).strip())
+
         unknown_names = sorted(matchup_names - roster_names)
         if unknown_names:
             return (
@@ -470,7 +484,7 @@ def _make_editing_handlers(race_json: Dict[str, Any], log: Callable) -> Dict[str
         poll = {
             "pollster": args["pollster"],
             "date": args["date"],
-            "matchups": args["matchups"],
+            "matchups": matchups,
             "source_url": args["source_url"],
         }
         if args.get("sample_size"):

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -269,7 +269,10 @@ Existing polling:
 Find recent public polls from primary poll releases, reputable aggregators, or
 news coverage linking to the underlying poll. Add at most five useful recent
 polls. Every matchup candidate name must exactly match the roster above and the
-percentages array must align with the candidate array.
+percentages array must align with the candidate array. If a source confirms a
+poll but does not publish numeric candidate percentages, add the poll with
+matchups: [] so users can follow the source, and explain the missing numbers in
+polling_note.
 
 Remove duplicate or malformed existing polls. If no public polling exists, set
 polling_note to "No public polling found for this race as of {current_date}."

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -566,12 +566,14 @@ ADD_POLL_TOOL: Dict = {
                 "sample_size": {"type": "integer", "description": "Number of respondents."},
                 "matchups": {
                     "type": "array",
+                    "description": "Use an empty list only when the source confirms a poll but does not publish numeric candidate percentages.",
                     "items": {
                         "type": "object",
                         "properties": {
-                            "candidates": {"type": "array", "items": {"type": "string"}},
-                            "percentages": {"type": "array", "items": {"type": "number"}},
+                            "candidates": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+                            "percentages": {"type": "array", "items": {"type": "number"}, "minItems": 1},
                         },
+                        "required": ["candidates", "percentages"],
                     },
                 },
                 "source_url": {"type": "string", "description": "URL to poll source."},

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -383,6 +383,46 @@ def test_add_poll_requires_exact_roster_names():
     assert len(race_json["polling"]) == 1
 
 
+def test_add_poll_allows_source_only_poll_but_rejects_incomplete_matchups():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {
+        "candidates": [{"name": "Alice Smith"}, {"name": "Bob Jones"}],
+        "polling": [],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    source_only = handlers["add_poll"](
+        {
+            "pollster": "Example Source Only Poll",
+            "date": "2026-06-01",
+            "matchups": [],
+            "source_url": "https://example.com/source-only-poll",
+        }
+    )
+    missing = handlers["add_poll"](
+        {
+            "pollster": "Example Poll",
+            "date": "2026-06-01",
+            "matchups": [{"candidates": ["Alice Smith", "Bob Jones"]}],
+            "source_url": "https://example.com/poll",
+        }
+    )
+    mismatched = handlers["add_poll"](
+        {
+            "pollster": "Example Poll",
+            "date": "2026-06-01",
+            "matchups": [{"candidates": ["Alice Smith", "Bob Jones"], "percentages": [48]}],
+            "source_url": "https://example.com/poll",
+        }
+    )
+
+    assert source_only.startswith("Added poll")
+    assert missing.startswith("ERROR:")
+    assert mismatched.startswith("ERROR:")
+    assert [poll["pollster"] for poll in race_json["polling"]] == ["Example Source Only Poll"]
+
+
 def test_remove_candidate_deletes_malformed_entries():
     """remove_candidate physically deletes entries whose name looks like a metadata key."""
     from pipeline_client.agent.agent import _make_editing_handlers

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -305,3 +305,10 @@ def test_iteration_retains_polling_and_voter_resource_repair_access():
 
     assert "remove_poll" in ITERATE_META_USER
     assert "ballotpedia_url" in ITERATE_META_USER
+
+
+def test_polling_prompt_distinguishes_source_only_polls_from_numeric_matchups():
+    from pipeline_client.agent.prompts import POLLING_USER
+
+    assert "matchups: []" in POLLING_USER
+    assert "does not publish numeric candidate percentages" in POLLING_USER

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1066,6 +1066,29 @@ def test_sanitize_polling_requires_exact_roster_names():
     assert race_json["polling"][0]["matchups"] == []
 
 
+def test_sanitize_polling_keeps_source_only_polls_without_numeric_percentages():
+    race_json = {
+        "candidates": [{"name": "Alice Smith"}, {"name": "Bob Jones"}],
+        "polling": [
+            {
+                "pollster": "Example",
+                "date": "2026-06-01",
+                "matchups": [{"candidates": ["Alice Smith", "Bob Jones"], "percentages": []}],
+            },
+            {
+                "pollster": "Valid Poll",
+                "date": "2026-06-02",
+                "matchups": [{"candidates": ["Alice Smith", "Bob Jones"], "percentages": [48, 45]}],
+            },
+        ],
+    }
+
+    _sanitize_polling(race_json)
+
+    assert [poll["pollster"] for poll in race_json["polling"]] == ["Example", "Valid Poll"]
+    assert race_json["polling"][0]["matchups"] == []
+
+
 @pytest.mark.asyncio
 async def test_polling_step_runs_without_issue_finance_or_refinement():
     existing = {


### PR DESCRIPTION
## What changed
- Tightened `add_poll` so matchup objects must include candidate names and numeric percentages with matching lengths.
- Kept source-only poll entries valid by allowing `matchups: []` when a source confirms a poll but does not publish numbers.
- Updated polling prompt/tool schema and save-time sanitation so incomplete matchup objects are dropped instead of being displayed as empty numeric results.
- Added regression coverage for source-only polls, incomplete matchups, and the polling prompt wording.

## Root cause
The pipeline accepted poll matchup objects with missing or empty `percentages`. The model could therefore save poll shells that looked like structured matchup data but had no numbers. Pydantic tolerated that legacy shape, and the frontend had nothing numeric to render.

## Validation
- `PYTHONPATH=. python -m pytest tests/test_editing_tools.py tests/test_run_agent.py tests/test_prompts.py -q`
- `PYTHONPATH=. python -m pytest -q`
