### PR TITLE
[codex] Preserve review grades on step reruns

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -529,6 +529,8 @@ async def run_agent(
         race_json = race_json["race_json"]
 
     race_json.setdefault("id", race_id)
+    race_json.setdefault("reviews", [])
+    race_json.setdefault("validation_grade", None)
     now_iso = datetime.now(timezone.utc).isoformat()
     race_json["updated_utc"] = now_iso
 
@@ -571,6 +573,7 @@ async def run_agent(
     _sanitize_roster(race_json, log)
     race_json.setdefault("polling", [])
     _normalize_schema_fields(race_json, log)
+    pipeline_state = race_json.setdefault("pipeline_state", pipeline_state)
 
     semantic_steps_ran = bool(
         _enabled & {"discovery", "images", "issues", "finance", "refinement", "polling", "voter_resources", "iteration"}
@@ -583,8 +586,6 @@ async def run_agent(
         pipeline_state["complete"] = False
         if "review" not in pipeline_state["remaining_steps"]:
             pipeline_state["remaining_steps"].append("review")
-        race_json["reviews"] = []
-        race_json["validation_grade"] = None
 
     if reject_empty_candidates and should_review and not race_json.get("candidates"):
         raise ValueError(
@@ -719,12 +720,11 @@ async def run_agent(
         else:
             _track("skip", "iteration")
     else:
-        race_json["reviews"] = []
         _track("skip", "review")
         _track("skip", "iteration")
 
     # Compute aggregate validation grade from review scores
-    grade = compute_validation_grade(race_json.get("reviews", [])) if pipeline_state.get("complete") else None
+    grade = compute_validation_grade(race_json.get("reviews", [])) if race_json.get("reviews") else None
     race_json["validation_grade"] = grade
 
     elapsed = time.perf_counter() - t0

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1091,12 +1091,29 @@ def test_sanitize_polling_keeps_source_only_polls_without_numeric_percentages():
 
 @pytest.mark.asyncio
 async def test_polling_step_runs_without_issue_finance_or_refinement():
+    reviews = [
+        {
+            "model": "claude",
+            "reviewed_at": "2026-06-01T00:00:00Z",
+            "verdict": "approved",
+            "score": 91,
+            "flags": [],
+            "summary": "Looks good.",
+        }
+    ]
     existing = {
         "id": "poll-only-2026",
         "election_date": "2026-11-03",
         "updated_utc": "2026-06-01T00:00:00Z",
         "candidates": [{"name": "Alice Smith"}, {"name": "Bob Jones"}],
         "polling": [],
+        "reviews": reviews,
+        "validation_grade": {
+            "grade": "A",
+            "score": 91,
+            "passed": True,
+            "summary": "Validated by 1/1 reviewers with an average score of 91/100.",
+        },
     }
 
     with (
@@ -1110,6 +1127,15 @@ async def test_polling_step_runs_without_issue_finance_or_refinement():
     tool_names = {tool["function"]["name"] for tool in mock_loop.call_args.kwargs["extra_tools"]}
     assert tool_names == {"add_poll", "remove_poll", "update_race_field", "read_profile"}
     assert result["candidates"][0]["name"] == "Alice Smith"
+    assert result["reviews"] == reviews
+    assert result["validation_grade"] == {
+        "grade": "A",
+        "score": 91,
+        "passed": True,
+        "summary": "Validated by 1/1 reviewers with an average score of 91/100.",
+    }
+    assert result["pipeline_state"]["complete"] is False
+    assert "review" in result["pipeline_state"]["remaining_steps"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- Preserve carried `reviews` and recompute `validation_grade` from them during step-only reruns such as polling-only updates.
- Keep marking drafts as incomplete with `remaining_steps: ["review"]` when semantic steps run without review, so the admin UI can still see review is due.
- Fixed a `pipeline_state` object replacement edge case after schema normalization.

## Root cause
Step-only reruns were clearing review state whenever review was disabled. That made polling-only drafts lose grade metadata even when the published race already had valid review results.

## Validation
- `PYTHONPATH=. python -m pytest tests/test_run_agent.py tests/test_editing_tools.py tests/test_prompts.py -q`
- `PYTHONPATH=. python -m pytest -q`
