### PR TITLE
[codex] Allow reviewed polling maintenance publishes

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -575,17 +575,26 @@ async def run_agent(
     _normalize_schema_fields(race_json, log)
     pipeline_state = race_json.setdefault("pipeline_state", pipeline_state)
 
-    semantic_steps_ran = bool(
-        _enabled & {"discovery", "images", "issues", "finance", "refinement", "polling", "voter_resources", "iteration"}
+    review_required_steps_ran = bool(_enabled & {"discovery", "images", "issues", "finance", "refinement", "iteration"})
+    maintenance_steps_ran = bool(_enabled & {"polling", "voter_resources"})
+    validation_grade = race_json.get("validation_grade")
+    if not isinstance(validation_grade, dict) and race_json.get("reviews"):
+        validation_grade = compute_validation_grade(race_json.get("reviews", []))
+    has_passing_validation = (
+        isinstance(validation_grade, dict) and validation_grade.get("passed") is True and bool(race_json.get("reviews"))
     )
     if should_review:
         pipeline_state["complete"] = True
         pipeline_state["remaining_candidates"] = []
         pipeline_state["remaining_steps"] = []
-    elif semantic_steps_ran:
+    elif review_required_steps_ran:
         pipeline_state["complete"] = False
         if "review" not in pipeline_state["remaining_steps"]:
             pipeline_state["remaining_steps"].append("review")
+    elif maintenance_steps_ran and has_passing_validation:
+        remaining_steps = [step for step in pipeline_state.get("remaining_steps", []) if step != "review"]
+        pipeline_state["remaining_steps"] = remaining_steps
+        pipeline_state["complete"] = not remaining_steps and not pipeline_state.get("remaining_candidates")
 
     if reject_empty_candidates and should_review and not race_json.get("candidates"):
         raise ValueError(

--- a/services/races-api/gcs_helpers.py
+++ b/services/races-api/gcs_helpers.py
@@ -244,6 +244,15 @@ def _assert_publishable_race(data: Dict[str, Any]) -> None:
     pipeline_state = data.get("pipeline_state")
     if isinstance(pipeline_state, dict) and pipeline_state.get("complete") is False:
         remaining = pipeline_state.get("remaining_steps") or []
+        validation_grade = data.get("validation_grade")
+        review_only_with_passing_grade = (
+            set(str(step) for step in remaining) <= {"review"}
+            and isinstance(validation_grade, dict)
+            and validation_grade.get("passed") is True
+            and bool(data.get("reviews"))
+        )
+        if review_only_with_passing_grade:
+            return
         detail = f" Remaining steps: {', '.join(str(step) for step in remaining)}." if remaining else ""
         raise ValueError(f"Race draft is operationally incomplete and cannot be published.{detail}")
     validation_grade = data.get("validation_grade")

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -2360,6 +2360,29 @@ def test_gcs_publish_helper_rejects_incomplete_pipeline_state():
         gcs_helpers.publish_race_to_gcs("nh-senate-2026", incomplete_race)
 
 
+def test_gcs_publish_helper_allows_review_only_remaining_with_passing_grade():
+    polling_only_race = {
+        "id": "nh-senate-2026",
+        "reviews": [{"model": "claude", "verdict": "approved", "score": 91, "flags": []}],
+        "validation_grade": {"grade": "A", "score": 91, "passed": True},
+        "pipeline_state": {
+            "complete": False,
+            "remaining_candidates": [],
+            "remaining_steps": ["review"],
+        },
+    }
+
+    with (
+        patch("gcs_helpers._gcs_archive_race"),
+        patch("gcs_helpers._gcs_put_race_json", return_value=True) as mock_put,
+        patch("gcs_helpers._gcs_delete_race_json", return_value=True),
+        patch("firestore_helpers._fs_update_race"),
+    ):
+        gcs_helpers.publish_race_to_gcs("nh-senate-2026", polling_only_race)
+
+    mock_put.assert_called_once()
+
+
 def test_summary_index_retries_concurrent_write():
     from google.api_core.exceptions import PreconditionFailed
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1134,8 +1134,8 @@ async def test_polling_step_runs_without_issue_finance_or_refinement():
         "passed": True,
         "summary": "Validated by 1/1 reviewers with an average score of 91/100.",
     }
-    assert result["pipeline_state"]["complete"] is False
-    assert "review" in result["pipeline_state"]["remaining_steps"]
+    assert result["pipeline_state"]["complete"] is True
+    assert result["pipeline_state"]["remaining_steps"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- Polling/voter-resource maintenance reruns no longer mark a race as needing expensive AI review when the draft already carries a passing validation grade and reviews.
- Publish guard now permits legacy maintenance drafts whose only remaining step is `review`, as long as they have a passing validation grade and review records.
- Research/iteration changes still block publishing until reviewed.

## Why
Polling-only updates are maintenance data updates. They should preserve the existing validation state and remain publishable without re-running the expensive review gate.

## Validation
- `PYTHONPATH=. python -m pytest tests/test_run_agent.py tests/test_races_api_admin.py -q`
- `PYTHONPATH=. python -m pytest -q`
