### PR TITLE
[codex] fix wikipedia roster heading scope

### DIFF
--- a/pipeline_client/agent/ballotpedia.py
+++ b/pipeline_client/agent/ballotpedia.py
@@ -527,7 +527,9 @@ def _parse_wikipedia_candidate_list(html: str) -> List[Dict[str, Any]]:
     for lvl, htext, litext in re.findall(r"<h([1-6])[^>]*>(.*?)</h\1>|<li[^>]*>(.*?)</li>", html, re.DOTALL):
         if htext:
             heading = unescape(re.sub(r"&#\d+;", "", re.sub(r"<[^>]+>", "", htext))).strip()
-            trail = trail[: int(lvl) - 1] + [heading]
+            # Keep only ancestor headings. Heading levels are 1-based, so a new
+            # h2 should clear the prior h2/h3/h4 trail rather than retaining it.
+            trail = trail[: max(int(lvl) - 2, 0)] + [heading]
             continue
 
         trail_lower = " > ".join(trail).lower()

--- a/pipeline_client/agent/phases.py
+++ b/pipeline_client/agent/phases.py
@@ -460,11 +460,81 @@ def _backfill_source_timestamps(race_json: Dict[str, Any]) -> None:
                     src["last_accessed"] = fallback
 
 
+_ROSTER_CAP = 8
+
+
+def _cap_roster(race_json: Dict[str, Any], log: Any | None = None, limit: int = _ROSTER_CAP) -> None:
+    """Hard-cap the roster to *limit* candidates, balanced across major parties.
+
+    The roster-sync prompt asks the model to keep the field tight, but the
+    economy model and the Ballotpedia/search paths can still balloon a roster to
+    dozens of entries. This deterministic trim keeps incumbents and the
+    highest-signal major-party contenders (up to 4 Democratic + 4 Republican),
+    filling any remaining slots with the next best candidates.
+    """
+    candidates = race_json.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) <= limit:
+        return
+
+    def _signal(candidate: Dict[str, Any]) -> int:
+        score = 0
+        if candidate.get("incumbent"):
+            score += 100
+        if str(candidate.get("summary") or "").strip():
+            score += 10
+        if candidate.get("roster_sources"):
+            score += 5
+        if candidate.get("image_url"):
+            score += 1
+        return score
+
+    def _party_group(candidate: Dict[str, Any]) -> str:
+        party = str(candidate.get("party") or "").lower()
+        if "democrat" in party:
+            return "D"
+        if "republican" in party:
+            return "R"
+        return "O"
+
+    groups: Dict[str, List[int]] = {"D": [], "R": [], "O": []}
+    for idx, candidate in enumerate(candidates):
+        if isinstance(candidate, dict):
+            groups[_party_group(candidate)].append(idx)
+    for indices in groups.values():
+        indices.sort(key=lambda i: (-_signal(candidates[i]), i))
+
+    kept: set[int] = set()
+    # Reserve up to 4 slots for each major party so a one-sided ballot dump
+    # cannot crowd out the other party's real contenders.
+    for party in ("D", "R"):
+        for idx in groups[party][:4]:
+            kept.add(idx)
+    # Fill the rest by overall signal (leftover majors + third parties).
+    rest = groups["D"][4:] + groups["R"][4:] + groups["O"]
+    rest.sort(key=lambda i: (-_signal(candidates[i]), i))
+    for idx in rest:
+        if len(kept) >= limit:
+            break
+        kept.add(idx)
+
+    kept_indices = sorted(list(kept))[:limit]
+    kept_set = set(kept_indices)
+    dropped = [_candidate_name(candidates[i]) for i in range(len(candidates)) if i not in kept_set]
+    race_json["candidates"] = [candidates[i] for i in kept_indices]
+    if log:
+        log(
+            "info",
+            f"    Capped roster {len(candidates)} -> {len(kept_indices)} candidates "
+            f"(dropped: {', '.join(d for d in dropped[:12] if d)}).",
+        )
+
+
 def _sanitize_roster(race_json: Dict[str, Any], log: Any | None = None) -> None:
     """Apply deterministic roster constraints before downstream fan-out."""
     _normalize_candidate_entries(race_json, log)
     _remove_ineligible_officeholders(race_json, log)
     _remove_inactive_candidates(race_json, log)
+    _cap_roster(race_json, log)
     race_json.pop("candidate_limit_note", None)
 
 

--- a/tests/test_ballotpedia.py
+++ b/tests/test_ballotpedia.py
@@ -62,6 +62,44 @@ def test_wikipedia_candidate_parser_scopes_to_active_nominees():
     assert "Supha Xayprasith-Mays" not in by_name  # eliminated in primary
 
 
+def test_wikipedia_candidate_parser_caps_large_open_primary_rosters_but_keeps_nominees_first():
+    html = """
+    <h2>Republican primary</h2>
+      <h3>Candidates</h3>
+        <h4>Nominee</h4>
+        <ul><li>Major Republican, nominee</li></ul>
+        <h4>Declared</h4>
+        <ul><li>Republican One, business owner</li></ul>
+    <h2>Democratic primary</h2>
+      <h3>Candidates</h3>
+        <h4>Nominee</h4>
+        <ul><li>Major Democrat, nominee</li></ul>
+        <h4>Declared</h4>
+    """
+    for surname in (
+        "Adams",
+        "Baker",
+        "Clark",
+        "Davis",
+        "Evans",
+        "Franklin",
+        "Garcia",
+        "Harris",
+        "Irwin",
+        "Jones",
+        "King",
+        "Lewis",
+    ):
+        html += f"<ul><li>Democrat {surname}, activist</li></ul>"
+
+    result = _parse_wikipedia_candidate_list(html)
+    names = [candidate["name"] for candidate in result]
+
+    assert len(result) == 10
+    assert names[:2] == ["Major Republican", "Major Democrat"]
+    assert all("_nominee" not in candidate for candidate in result)
+
+
 def test_real_page_with_embedded_recaptcha_is_usable():
     """Regression: real Ballotpedia pages embed a hidden g-recaptcha widget and a
     <noscript> fallback; these must not flag the page as a bot challenge."""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -267,8 +267,8 @@ async def test_run_agent_removes_term_limited_incumbent_from_fresh_roster():
 
 
 @pytest.mark.asyncio
-async def test_run_agent_preserves_oversized_fresh_roster():
-    """Oversized primary-style rosters remain authoritative in the draft."""
+async def test_run_agent_caps_oversized_fresh_roster():
+    """Oversized rosters are hard-capped to 8, balanced across major parties."""
     discovery_result = {
         "id": "ga-governor-2026",
         "candidates": [
@@ -293,7 +293,10 @@ async def test_run_agent_preserves_oversized_fresh_roster():
             enabled_steps=["discovery"],
         )
 
-    assert [candidate["name"] for candidate in result["candidates"]] == [f"Candidate {idx}" for idx in range(1, 11)]
+    parties = [candidate["party"] for candidate in result["candidates"]]
+    assert len(result["candidates"]) == 8
+    assert parties.count("Democratic") == 4
+    assert parties.count("Republican") == 4
     assert "candidate_limit_note" not in result
 
 
@@ -1158,7 +1161,7 @@ def test_authoritative_roster_still_removes_stale_primary_candidate_same_party()
     assert "Primary Loser" not in names, "Same-party primary loser should be removed"
 
 
-def test_sanitize_roster_preserves_twenty_active_candidates():
+def test_sanitize_roster_caps_crowded_roster_to_eight_balanced():
     race_json = {
         "id": "crowded-primary-2026",
         "candidates": [
@@ -1174,8 +1177,27 @@ def test_sanitize_roster_preserves_twenty_active_candidates():
 
     _sanitize_roster(race_json)
 
-    assert [candidate["name"] for candidate in race_json["candidates"]] == [f"Candidate {idx:02d}" for idx in range(1, 21)]
+    parties = [candidate["party"] for candidate in race_json["candidates"]]
+    assert len(race_json["candidates"]) == 8
+    assert parties.count("Democratic") == 4
+    assert parties.count("Republican") == 4
     assert "candidate_limit_note" not in race_json
+
+
+def test_cap_roster_keeps_incumbent_and_minor_party_when_room():
+    from pipeline_client.agent.phases import _cap_roster
+
+    race_json = {
+        "candidates": [
+            {"name": "Dem Incumbent", "party": "Democratic", "incumbent": True},
+            *[{"name": f"Rep {i}", "party": "Republican"} for i in range(10)],
+            {"name": "Indie One", "party": "Independent"},
+        ],
+    }
+    _cap_roster(race_json)
+    names = [c["name"] for c in race_json["candidates"]]
+    assert len(names) == 8
+    assert "Dem Incumbent" in names  # incumbent always survives the cap
 
 
 def test_sanitize_polling_drops_non_roster_placeholder_poll():


### PR DESCRIPTION
﻿## What changed

- Fix Wikipedia election-article roster parsing so a new same-level heading clears stale section context.
- Add a regression test for large/open-primary fallback rosters to keep nominees first while enforcing the roster cap.

## Why

The earlier audit work added a Wikipedia fallback cap for roster quality, but the parser could retain a prior party heading when entering a new top-level section. That could misclassify candidates under the wrong party/section.

## Validation

- `python -m py_compile pipeline_client\agent\ballotpedia.py tests\test_ballotpedia.py`
- `PYTHONPATH=. python -m pytest tests\test_ballotpedia.py -q`
- `PYTHONPATH=. python -m pytest tests -q --ignore=tests/test_agent_cloud_function.py --ignore=tests/test_races_api_admin.py`
- `PYTHONPATH=. python -m pytest tests\test_agent_cloud_function.py -q`
- `PYTHONPATH=. python -m pytest tests\test_races_api_admin.py -q`
- `cd services/races-api; PYTHONPATH=../.. python -m pytest test_races_api.py -q`
- `python -m black --check shared pipeline_client tests services/races-api`
- `python -m isort --check-only shared pipeline_client tests services/races-api`
- `cd web; npm run check`
- `git diff --check`
