### PR TITLE
Fix featured comparison carousel fallbacks

### DIFF
--- a/web/src/lib/homepagePreview.test.ts
+++ b/web/src/lib/homepagePreview.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  gradeAHomepageFallbacks,
+  mergeGradeAHomepageRaces,
+} from "$lib/homepagePreview";
+
+describe("mergeGradeAHomepageRaces", () => {
+  it("keeps multiple carousel options after a partial production load", () => {
+    const [verified, fallback] = gradeAHomepageFallbacks;
+
+    expect(mergeGradeAHomepageRaces([verified])).toEqual([verified, fallback]);
+  });
+
+  it("deduplicates races and respects the display limit", () => {
+    const [first, second] = gradeAHomepageFallbacks;
+
+    expect(mergeGradeAHomepageRaces([first, second, first], [], 1)).toEqual([
+      first,
+    ]);
+  });
+});

--- a/web/src/lib/homepagePreview.ts
+++ b/web/src/lib/homepagePreview.ts
@@ -239,3 +239,18 @@ export const gradeAHomepageFallbacks: Race[] = [
 
 export const isGradeAHomepageRace = (race: Race) =>
   race.validation_grade?.grade === "A" && race.validation_grade.passed === true;
+
+export const mergeGradeAHomepageRaces = (
+  verified: Race[],
+  fallbacks: Race[] = gradeAHomepageFallbacks,
+  limit = 5,
+): Race[] => {
+  const seen = new Set<string>();
+  return [...verified, ...fallbacks]
+    .filter((race) => {
+      if (seen.has(race.id)) return false;
+      seen.add(race.id);
+      return true;
+    })
+    .slice(0, limit);
+};

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -3,6 +3,7 @@ import {
   gradeAHomepageFallbacks,
   gradeAHomepageRaceIds,
   isGradeAHomepageRace,
+  mergeGradeAHomepageRaces,
 } from "$lib/homepagePreview";
 import { loadPrerenderRace } from "$lib/prerenderData";
 import {
@@ -19,9 +20,9 @@ export const load: PageLoad = async ({ fetch, parent }) => {
     nationalRaces.filter((race) => race.quality_grade === "A"),
     5,
   ).map((race) => race.id);
-  const previewIds = indexedGradeAIds.length
-    ? indexedGradeAIds
-    : [...gradeAHomepageRaceIds];
+  const previewIds = [
+    ...new Set([...indexedGradeAIds, ...gradeAHomepageRaceIds]),
+  ];
 
   // Production syncs published race JSON into static/ before prerendering. Try
   // those local files even when VITE_PUBLIC_DATA_URL is unset; fast local/CI
@@ -37,7 +38,7 @@ export const load: PageLoad = async ({ fetch, parent }) => {
         result.status === "fulfilled" && isGradeAHomepageRace(result.value),
     )
     .map((result) => result.value);
-  if (verified.length) gradeARaces = verified;
+  gradeARaces = mergeGradeAHomepageRaces(verified);
 
   // The editorial list is driven by the published summary index, independently
   // of the stricter full-record requirements used by InteractiveRaceCompare.


### PR DESCRIPTION
## Summary
- merge verified Grade-A races with configured homepage fallbacks
- load indexed and configured preview IDs so partial production data cannot collapse the carousel
- add regression coverage for partial loads and deduplication

## Validation
- svelte-check: 0 errors and 0 warnings
- targeted Prettier and ESLint
- 82 unit tests passed
- production build passed