### PR TITLE
Prevent autocomplete attribution clipping

### DIFF
--- a/web/src/lib/components/home/ElectionLookup.svelte
+++ b/web/src/lib/components/home/ElectionLookup.svelte
@@ -141,7 +141,8 @@
 <div class="min-w-0">
   {#if !submitted}
     <div
-      class="relative overflow-hidden rounded-[2rem] border border-blue-100 bg-surface/95 p-6 shadow-2xl shadow-blue-950/10 backdrop-blur sm:p-10 dark:border-blue-900"
+      data-address-search-card
+      class="relative rounded-[2rem] border border-blue-100 bg-surface/95 p-6 shadow-2xl shadow-blue-950/10 backdrop-blur sm:p-10 dark:border-blue-900"
     >
       <div
         class="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-blue-700 via-blue-500 to-sky-400"

--- a/web/src/lib/components/home/ElectionLookup.test.ts
+++ b/web/src/lib/components/home/ElectionLookup.test.ts
@@ -44,6 +44,11 @@ describe("ElectionLookup", () => {
     render(ElectionLookup, { races });
 
     expect(screen.getByLabelText("Home address")).toBeTruthy();
+    expect(
+      document
+        .querySelector("[data-address-search-card]")
+        ?.classList.contains("overflow-hidden"),
+    ).toBe(false);
     expect(screen.getByText(/Smarter\.Vote does not save/i)).toBeTruthy();
     expect(screen.getByText(/not yet a complete local ballot/i)).toBeTruthy();
 


### PR DESCRIPTION
## Fix
Remove the address card's overflow clipping so the autocomplete dropdown and required Google attribution can extend beyond the card boundary. The dropdown retains its own rounded overflow styling.

## Regression coverage
Assert that the address search card does not regain `overflow-hidden`.

## Validation
- `npm run check`
- focused ElectionLookup test
- targeted ESLint
- `npm run build`
- `git diff --check`