### PR TITLE
Preserve My Ballot comparison issues

### DIFF
--- a/web/src/lib/components/ballot/BallotExplorer.test.ts
+++ b/web/src/lib/components/ballot/BallotExplorer.test.ts
@@ -13,14 +13,32 @@ const { getRace } = vi.hoisted(() => ({ getRace: vi.fn() }));
 
 vi.mock("$lib/api", () => ({ getRace }));
 
-function candidate(name: string, party: string): Candidate {
+function candidate(
+  name: string,
+  party: string,
+  hasHealthcareResearch = false,
+): Candidate {
   return {
     name,
     party,
     incumbent: false,
     summary: `${name} summary`,
     summary_sources: [],
-    issues: {},
+    issues: hasHealthcareResearch
+      ? {
+          Healthcare: {
+            stance: `${name} healthcare position`,
+            confidence: "high",
+            sources: [
+              {
+                url: "https://example.com/healthcare",
+                type: "website",
+                last_accessed: "2026-07-01",
+              },
+            ],
+          },
+        }
+      : {},
     career_history: [],
     education: [],
     links: [],
@@ -36,8 +54,8 @@ const race: Race = {
   updated_utc: "2026-07-01T00:00:00Z",
   generator: [],
   candidates: [
-    candidate("Dana Democrat", "Democratic"),
-    candidate("Riley Republican", "Republican"),
+    candidate("Dana Democrat", "Democratic", true),
+    candidate("Riley Republican", "Republican", true),
     candidate("Indy Independent", "Independent"),
   ],
 };
@@ -69,11 +87,14 @@ describe("BallotExplorer", () => {
       ).toBeTruthy(),
     );
     expect(screen.queryByRole("link", { name: "Indy Independent" })).toBeNull();
+    expect(screen.getByText("Healthcare")).toBeTruthy();
 
     await fireEvent.click(
       screen.getByRole("checkbox", { name: /Indy Independent/ }),
     );
 
     expect(screen.getByRole("link", { name: "Indy Independent" })).toBeTruthy();
+    expect(screen.getByText("Healthcare")).toBeTruthy();
+    expect(screen.getByText("No stance researched yet.")).toBeTruthy();
   });
 });

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -37,7 +37,7 @@
 
   $: issueKeys = compact
     ? CANONICAL_ISSUES.filter((key) =>
-        candidates.every((candidate) => {
+        candidates.some((candidate) => {
           const stance = candidate.issues?.[key];
           return stance && stance.sources && stance.sources.length > 0;
         }),


### PR DESCRIPTION
## What changed

- Keep compact My Ballot issue rows when at least one selected candidate has cited research for the issue.
- Show the existing no-research placeholder for a selected candidate whose issue record is missing.
- Extend the ballot comparison regression test with two researched candidates and one sparse Independent candidate.

## Why

The compact comparison filtered to the intersection of cited issues across every selected candidate. Adding a candidate with sparse research therefore removed all issue rows, even though the other candidates still had sourced positions.

## User impact

Voters can add third-party or less-researched candidates without losing the researched issue comparisons already on screen.

## Validation

- Focused ballot explorer unit test
- `npm run check`
- Prettier and ESLint on touched files
- `git diff --check`
