### PR TITLE
Improve ballot comparison and search

### DIFF
--- a/web/src/lib/components/SiteHeader.svelte
+++ b/web/src/lib/components/SiteHeader.svelte
@@ -6,6 +6,7 @@
   import { getRaceSummaries } from "$lib/api";
   import { candidateSlug } from "$lib/utils/format";
   import { debounce } from "$lib/utils/debounce";
+  import { matchesSearchQuery } from "$lib/utils/search";
 
   export let races: RaceSummary[] = [];
   export let isAuthenticated = false;
@@ -47,9 +48,12 @@
   $: raceMatches = query.trim()
     ? searchRaces
         .filter((race) => {
-          const q = query.trim().toLowerCase();
-          return [race.title, race.office, race.state, race.jurisdiction].some(
-            (value) => value?.toLowerCase().includes(q),
+          return matchesSearchQuery(
+            query,
+            race.title,
+            race.office,
+            race.state,
+            race.jurisdiction,
           );
         })
         .slice(0, 5)
@@ -59,10 +63,14 @@
         .flatMap((race) =>
           race.candidates
             .filter((candidate) => {
-              const q = query.trim().toLowerCase();
-              return (
-                candidate.name.toLowerCase().includes(q) ||
-                candidate.party?.toLowerCase().includes(q)
+              return matchesSearchQuery(
+                query,
+                candidate.name,
+                candidate.party,
+                race.title,
+                race.office,
+                race.state,
+                race.jurisdiction,
               );
             })
             .map((candidate) => ({

--- a/web/src/lib/components/ballot/BallotExplorer.svelte
+++ b/web/src/lib/components/ballot/BallotExplorer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { replaceState } from "$app/navigation";
   import { onMount, tick } from "svelte";
   import { getRace } from "$lib/api";
   import CandidateComparison from "$lib/components/compare/CandidateComparison.svelte";
@@ -57,12 +58,14 @@
     };
   }
 
-  async function selectRace(raceId: string) {
+  async function selectRace(raceId: string, updateUrl = true) {
     selectedId = raceId;
     loadError = "";
-    const url = new URL(window.location.href);
-    url.searchParams.set("race", raceId);
-    window.history.replaceState({}, "", url);
+    if (updateUrl) {
+      const url = new URL(window.location.href);
+      url.searchParams.set("race", raceId);
+      replaceState(url, {});
+    }
     if (loadedRaces[raceId] || loadingId === raceId) return;
 
     loadingId = raceId;
@@ -105,7 +108,7 @@
     const initialId = races.some((race) => race.id === requestedId)
       ? requestedId
       : races[0]?.id;
-    if (initialId) void selectRace(initialId);
+    if (initialId) void selectRace(initialId, false);
   });
 
   $: selectedSummary = races.find((race) => race.id === selectedId);
@@ -206,16 +209,11 @@
               {formatElectionDate(selectedRace.election_date)}
             </p>
           </div>
-          <div class="grid shrink-0 gap-2 text-sm font-bold sm:grid-cols-2">
+          <div class="shrink-0 text-sm font-bold">
             <a
               href="/races/{selectedRace.id}/"
               class="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-blue-700 px-5 py-2.5 text-white shadow-md shadow-blue-900/10 transition hover:-translate-y-0.5 hover:bg-blue-800 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
               >View full race guide <span aria-hidden="true">→</span></a
-            >
-            <a
-              href="/races/{selectedRace.id}/compare/"
-              class="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-blue-200 bg-blue-50 px-5 py-2.5 text-blue-800 transition hover:-translate-y-0.5 hover:border-blue-300 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200 dark:hover:bg-blue-900"
-              >Open detailed comparison <span aria-hidden="true">↗</span></a
             >
           </div>
         </div>

--- a/web/src/lib/components/ballot/BallotExplorer.test.ts
+++ b/web/src/lib/components/ballot/BallotExplorer.test.ts
@@ -10,9 +10,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Candidate, Race, RaceSummary } from "$lib/types";
 import BallotExplorer from "./BallotExplorer.svelte";
 
-const { getRace } = vi.hoisted(() => ({ getRace: vi.fn() }));
+const { getRace, replaceState } = vi.hoisted(() => ({
+  getRace: vi.fn(),
+  replaceState: vi.fn(),
+}));
 
 vi.mock("$lib/api", () => ({ getRace }));
+vi.mock("$app/navigation", () => ({ replaceState }));
 
 function candidate(
   name: string,
@@ -74,6 +78,7 @@ describe("BallotExplorer", () => {
   beforeEach(() => {
     getRace.mockReset();
     getRace.mockResolvedValue(race);
+    replaceState.mockReset();
     window.history.replaceState({}, "", "/my-ballot/");
   });
 
@@ -87,6 +92,9 @@ describe("BallotExplorer", () => {
         screen.getByRole("checkbox", { name: /Indy Independent/ }),
       ).toBeTruthy(),
     );
+    expect(
+      screen.queryByRole("link", { name: /Open detailed comparison/ }),
+    ).toBeNull();
     const mobileCandidates = screen.getByLabelText(
       "Candidates in this comparison",
     );

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -6,6 +6,7 @@
   import { CANONICAL_ISSUES, getIssueDisplayName } from "$lib/types";
   import { candidateSlug } from "$lib/utils/format";
   import { partyAbbr } from "$lib/utils/party";
+  import { stancePreview } from "$lib/utils/stance";
   import { isExternalUrl } from "$lib/utils/url";
 
   export let race: Race;
@@ -17,7 +18,17 @@
     undefined;
 
   let expandedSources: Record<string, boolean> = {};
+  let expandedStances: Record<string, boolean> = {};
   let failedImages: Record<string, boolean> = {};
+
+  function stanceKey(issue: string, candidate: Candidate): string {
+    return `${issue}:${candidate.name}:stance`;
+  }
+
+  function toggleStance(issue: string, candidate: Candidate) {
+    const key = stanceKey(issue, candidate);
+    expandedStances = { ...expandedStances, [key]: !expandedStances[key] };
+  }
 
   function sourcesKey(issue: string, candidate: Candidate): string {
     return `${issue}:${candidate.name}`;
@@ -127,6 +138,7 @@
 />
 
 <div
+  data-desktop-candidate-comparison
   class="hidden overflow-x-auto rounded-2xl border border-stroke bg-surface shadow-sm lg:block"
 >
   <div style="min-width: {(compact ? 170 : 220) + candidates.length * 250}px">
@@ -270,6 +282,9 @@
           </div>
           {#each candidates as candidate}
             {@const stance = candidate.issues?.[issueKey]}
+            {@const preview = stance ? stancePreview(stance.stance) : ""}
+            {@const isStanceExpanded =
+              expandedStances[stanceKey(issueKey, candidate)] ?? false}
             <div
               class="flex flex-col gap-3 border-r border-stroke p-6 last:border-none"
             >
@@ -277,8 +292,19 @@
                 <p
                   class="whitespace-normal text-sm leading-relaxed text-content-muted"
                 >
-                  {stance.stance}
+                  {isStanceExpanded ? stance.stance : preview}
                 </p>
+                {#if preview !== stance.stance.trim()}
+                  <button
+                    type="button"
+                    aria-expanded={isStanceExpanded}
+                    on:click={() => toggleStance(issueKey, candidate)}
+                    class="inline-flex min-h-11 items-center self-start text-sm font-bold text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                  >
+                    {isStanceExpanded ? "Show less" : "Show more"}
+                    <span class="sr-only"> for {candidate.name}</span>
+                  </button>
+                {/if}
                 <div class="flex items-center gap-2 pt-1">
                   <span
                     class="text-[10px] font-medium uppercase tracking-wide text-content-subtle"

--- a/web/src/lib/components/compare/CandidateComparison.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.test.ts
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, within } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Candidate, Race } from "$lib/types";
+import CandidateComparison from "./CandidateComparison.svelte";
+
+const candidate: Candidate = {
+  name: "Casey Candidate",
+  party: "Independent",
+  incumbent: false,
+  summary: "Candidate summary",
+  summary_sources: [],
+  issues: {
+    Healthcare: {
+      stance:
+        "The first sentence explains the position. More detail follows here.",
+      confidence: "high",
+      sources: [],
+    },
+  },
+  career_history: [],
+  education: [],
+  links: [],
+  social_media: {},
+};
+
+const race: Race = {
+  id: "test-race-2026",
+  title: "Test Race",
+  office: "U.S. Senate",
+  election_date: "2026-11-03",
+  updated_utc: "2026-07-01T00:00:00Z",
+  generator: [],
+  candidates: [candidate],
+};
+
+describe("CandidateComparison", () => {
+  afterEach(cleanup);
+
+  it("expands and collapses desktop stance previews", async () => {
+    const { container } = render(CandidateComparison, {
+      race,
+      candidates: [candidate],
+    });
+    const desktop = within(
+      container.querySelector("[data-desktop-candidate-comparison]")!,
+    );
+
+    expect(
+      desktop.getByText("The first sentence explains the position."),
+    ).toBeTruthy();
+    const button = desktop.getByRole("button", {
+      name: "Show more for Casey Candidate",
+    });
+
+    await fireEvent.click(button);
+    expect(
+      desktop.getByText(
+        "The first sentence explains the position. More detail follows here.",
+      ),
+    ).toBeTruthy();
+    expect(
+      desktop.getByRole("button", { name: "Show less for Casey Candidate" }),
+    ).toBeTruthy();
+  });
+});

--- a/web/src/lib/components/compare/MobileCandidateComparison.svelte
+++ b/web/src/lib/components/compare/MobileCandidateComparison.svelte
@@ -204,8 +204,7 @@
     </div>
     {#if compact}
       <p class="mt-4 text-center text-xs text-content-subtle">
-        Choose another issue above, or open the full comparison for every
-        research field.
+        Choose another issue above to review more research fields.
       </p>
     {/if}
   </div>

--- a/web/src/lib/components/home/ElectionLookup.svelte
+++ b/web/src/lib/components/home/ElectionLookup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { replaceState } from "$app/navigation";
   import { createEventDispatcher, onMount } from "svelte";
   import BallotExplorer from "$lib/components/ballot/BallotExplorer.svelte";
   import type { RaceSummary } from "$lib/types";
@@ -119,7 +120,7 @@
     const url = new URL(window.location.href);
     url.searchParams.set("state", state);
     url.searchParams.set("district", district);
-    window.history.replaceState({}, "", url);
+    replaceState(url, {});
   }
 
   onMount(() => {
@@ -148,7 +149,8 @@
       results = restored;
       submitted = true;
       dispatch("exploring", true);
-      updateShareableUrl();
+      // SvelteKit initializes its router immediately after component mount.
+      window.setTimeout(updateShareableUrl);
     } catch {
       sessionStorage.removeItem(SESSION_KEY);
     }
@@ -201,7 +203,7 @@
     url.searchParams.delete("state");
     url.searchParams.delete("district");
     url.searchParams.delete("race");
-    window.history.replaceState({}, "", url);
+    replaceState(url, {});
     dispatch("exploring", false);
   }
 </script>
@@ -329,10 +331,7 @@
   {/if}
 
   {#if submitted}
-    <section
-      class="rounded-[2rem] border border-stroke bg-surface p-4 shadow-xl shadow-blue-950/5 sm:p-7 lg:p-9"
-      aria-live="polite"
-    >
+    <section class="py-2 sm:py-4" aria-live="polite">
       <div
         class="flex flex-col gap-5 border-b border-stroke pb-6 sm:flex-row sm:items-end sm:justify-between"
       >

--- a/web/src/lib/components/home/ElectionLookup.test.ts
+++ b/web/src/lib/components/home/ElectionLookup.test.ts
@@ -8,10 +8,14 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ElectionLookup from "./ElectionLookup.svelte";
 
-const { lookupElectionGeography, suggestUsAddresses } = vi.hoisted(() => ({
-  lookupElectionGeography: vi.fn(),
-  suggestUsAddresses: vi.fn(),
-}));
+const { lookupElectionGeography, replaceState, suggestUsAddresses } =
+  vi.hoisted(() => ({
+    lookupElectionGeography: vi.fn(),
+    replaceState: vi.fn(),
+    suggestUsAddresses: vi.fn(),
+  }));
+
+vi.mock("$app/navigation", () => ({ replaceState }));
 
 vi.mock("$lib/services/electionLookup", async () => {
   const actual = await vi.importActual<
@@ -41,6 +45,7 @@ const races = [
 describe("ElectionLookup", () => {
   beforeEach(() => {
     lookupElectionGeography.mockReset();
+    replaceState.mockReset();
     suggestUsAddresses.mockReset();
     suggestUsAddresses.mockResolvedValue([]);
     sessionStorage.clear();
@@ -85,12 +90,11 @@ describe("ElectionLookup", () => {
     expect(sessionStorage.getItem("smarterVote.ballot")).toContain(
       "md-house-04-2026",
     );
-    expect(new URLSearchParams(window.location.search).get("state")).toBe(
-      "Maryland",
-    );
-    expect(new URLSearchParams(window.location.search).get("district")).toBe(
-      "04",
-    );
+    const shareableUrl = replaceState.mock.calls
+      .map(([url]) => url as URL)
+      .find((url) => url.searchParams.get("state") === "Maryland");
+    expect(shareableUrl?.searchParams.get("state")).toBe("Maryland");
+    expect(shareableUrl?.searchParams.get("district")).toBe("04");
     expect(
       screen
         .getByRole("link", { name: /full ballot at VOTE411/i })

--- a/web/src/lib/utils/search.test.ts
+++ b/web/src/lib/utils/search.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { matchesSearchQuery } from "./search";
+
+describe("matchesSearchQuery", () => {
+  it("matches words regardless of their order in a race title", () => {
+    expect(
+      matchesSearchQuery("Texas Senate", "2026 U.S. Senate election in Texas"),
+    ).toBe(true);
+  });
+
+  it("matches a candidate using candidate and race fields together", () => {
+    expect(
+      matchesSearchQuery(
+        "Talarico Texas",
+        "James Talarico",
+        "Democratic",
+        "2026 U.S. Senate election in Texas",
+      ),
+    ).toBe(true);
+  });
+
+  it("normalizes punctuation and accents", () => {
+    expect(matchesSearchQuery("Jose US", "José", "U.S. House")).toBe(true);
+  });
+
+  it("does not match short terms inside unrelated words", () => {
+    expect(matchesSearchQuery("US", "State House")).toBe(false);
+  });
+
+  it("requires every query term", () => {
+    expect(matchesSearchQuery("Texas Florida", "Texas Senate")).toBe(false);
+  });
+});

--- a/web/src/lib/utils/search.ts
+++ b/web/src/lib/utils/search.ts
@@ -1,0 +1,27 @@
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\./g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/** Match every query term anywhere across the supplied searchable fields. */
+export function matchesSearchQuery(
+  query: string,
+  ...values: Array<string | null | undefined>
+): boolean {
+  const terms = normalizeSearchText(query).split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return false;
+
+  const searchableTerms = normalizeSearchText(values.filter(Boolean).join(" "))
+    .split(/\s+/)
+    .filter(Boolean);
+  return terms.every((term) =>
+    searchableTerms.some((candidate) =>
+      term.length <= 2 ? candidate === term : candidate.includes(term),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- remove the redundant detailed-comparison action and outer results border from My Ballot
- add expandable first-sentence stance previews to desktop comparisons
- improve multi-word search matching while avoiding short-token false positives
- use SvelteKit-supported URL state updates for ballot race selection
- update compact comparison copy and add focused regression coverage

## User impact

My Ballot now keeps its inline comparison as the primary experience, with a cleaner results layout. Desktop and mobile comparisons use consistent expandable stances, and searches such as `Texas Senate` return the expected race and candidates.

## Root cause

The My Ballot results nested two card treatments and linked to a second comparison UI. Desktop stances did not share the mobile preview behavior, and the header search required the entire query phrase to appear contiguously.

## Validation

- `npm run check`
- focused Vitest suite: 10 tests passed
- full frontend unit suite: 103 tests passed
- production build
- Playwright desktop/mobile smoke suite: 4 tests passed
- local responsive browser QA with clean console