### PR TITLE
Fix races API release image startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,6 +248,9 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Build ${{ matrix.name }}
         run: docker build --pull -f "${{ matrix.dockerfile }}" -t "smartervote/${{ matrix.name }}:${{ github.sha }}" .
+      - name: Smoke test races API image
+        if: matrix.name == 'races-api'
+        run: docker run --rm "smartervote/${{ matrix.name }}:${{ github.sha }}" python -c "import main"
       - name: Scan ${{ matrix.name }}
         run: |
           docker run --rm \

--- a/services/races-api/Dockerfile
+++ b/services/races-api/Dockerfile
@@ -20,6 +20,7 @@ COPY services/races-api/request_models.py .
 COPY services/races-api/firestore_helpers.py .
 COPY services/races-api/gcs_helpers.py .
 COPY services/races-api/cloud_run_jobs.py .
+COPY services/races-api/rate_limit.py .
 COPY services/races-api/routers ./routers
 COPY shared /app/shared
 # data/published is NOT baked into the image — deployed instances read from GCS.

--- a/services/races-api/test_races_api.py
+++ b/services/races-api/test_races_api.py
@@ -38,6 +38,9 @@ def _load_main_module(data_dir: str, monkeypatch) -> Any:
     monkeypatch.delenv("K_SERVICE", raising=False)
     monkeypatch.delenv("GAE_APPLICATION", raising=False)
     monkeypatch.delenv("SKIP_AUTH", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ANALYTICS_API_TOKEN", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ANALYTICS_ACCOUNT_TAG", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ANALYTICS_SITE_TAG", raising=False)
 
     import importlib
 


### PR DESCRIPTION
## Summary
- copy the shared rate limiter into the races API release image
- smoke-test the built API image in CI so missing runtime modules fail before deployment
- isolate Cloudflare analytics environment variables in API tests

## Verification
- built the image locally
- ran the image with \python -c 'import main'\`n- 24 focused races API tests passed

Follow-up to the failed infrastructure apply for #158.