### PR TITLE
Fix candidate comparison navigation

### DIFF
--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -139,14 +139,14 @@
 
 <div
   data-desktop-candidate-comparison
-  class="hidden overflow-x-auto rounded-2xl border border-stroke bg-surface shadow-sm lg:block"
+  class="hidden isolate overflow-x-auto rounded-2xl border border-stroke bg-surface shadow-sm lg:block"
 >
   <div style="min-width: {(compact ? 170 : 220) + candidates.length * 250}px">
     <div
       class:sticky={!compact}
       class:top-[57px]={!compact}
       class:md:top-[65px]={!compact}
-      class="z-30 w-full border-b border-stroke bg-surface/95 py-4 shadow-sm backdrop-blur-md"
+      class="z-30 w-full border-b border-stroke bg-surface py-4 shadow-sm"
     >
       <div
         class="grid items-center"
@@ -155,7 +155,7 @@
           : '220px'} repeat({candidates.length}, 1fr)"
       >
         <div
-          class="sticky left-0 z-40 border-r border-stroke bg-surface/95 px-5 text-xs font-bold uppercase tracking-wider text-content-subtle"
+          class="sticky left-0 z-40 border-r border-stroke bg-surface px-5 text-xs font-bold uppercase tracking-wider text-content-subtle"
         >
           {compact ? "Compare" : "Compare Directory"}
         </div>
@@ -210,7 +210,7 @@
             : '220px'} repeat({candidates.length}, 1fr)"
         >
           <div
-            class="sticky left-0 z-10 border-r border-stroke bg-emerald-50/70 p-5 text-sm font-bold text-content dark:bg-emerald-950/15"
+            class="sticky left-0 z-10 border-r border-stroke bg-emerald-50 p-5 text-sm font-bold text-content dark:bg-emerald-950"
           >
             Research review
             <span

--- a/web/src/lib/components/compare/CandidateComparison.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.test.ts
@@ -62,4 +62,30 @@ describe("CandidateComparison", () => {
       desktop.getByRole("button", { name: "Show less for Casey Candidate" }),
     ).toBeTruthy();
   });
+
+  it("uses opaque sticky labels so scrolled content does not show through", () => {
+    const reviewedRace: Race = {
+      ...race,
+      validation_grade: {
+        grade: "A",
+        score: 95,
+        passed: true,
+        summary: "Publication checks passed.",
+      },
+    };
+    const { container } = render(CandidateComparison, {
+      race: reviewedRace,
+      candidates: [candidate],
+      compact: true,
+      showQuality: true,
+    });
+    const desktop = within(
+      container.querySelector("[data-desktop-candidate-comparison]")!,
+    );
+
+    expect(desktop.getByText("Compare").classList).toContain("bg-surface");
+    expect(desktop.getByText("Research review").classList).toContain(
+      "bg-emerald-50",
+    );
+  });
 });

--- a/web/src/routes/races/[slug]/+page.svelte
+++ b/web/src/routes/races/[slug]/+page.svelte
@@ -559,7 +559,19 @@
 
     <!-- Candidates Section -->
     <section>
-      <h2 class="candidates-title">Candidates</h2>
+      <div class="candidates-heading">
+        <h2 class="candidates-title">Candidates</h2>
+        {#if activeCandidates.length > 1}
+          <a
+            href="/races/{race.id}/compare?candidates={activeCandidates
+              .map((candidate) => candidateSlug(candidate.name))
+              .join(',')}{isDraftPreview ? '&draft=true' : ''}"
+            class="compare-all-link"
+          >
+            Compare all <span aria-hidden="true">&rarr;</span>
+          </a>
+        {/if}
+      </div>
       <div class="candidate-grid">
         {#each activeCandidates as candidate}
           <CandidateCard
@@ -1380,8 +1392,16 @@
   }
 
   /* Candidates */
+  .candidates-heading {
+    @apply mb-4 flex items-center justify-between gap-4 sm:mb-6;
+  }
+
   .candidates-title {
-    @apply text-xl sm:text-2xl font-semibold text-content mb-4 sm:mb-6;
+    @apply text-xl font-semibold text-content sm:text-2xl;
+  }
+
+  .compare-all-link {
+    @apply inline-flex min-h-11 shrink-0 items-center gap-1 px-1 text-sm font-semibold text-blue-600 no-underline transition-colors hover:text-blue-800 hover:underline dark:text-blue-400 dark:hover:text-blue-300;
   }
 
   .candidate-grid {


### PR DESCRIPTION
## What changed

- make desktop comparison sticky labels opaque so horizontally scrolling candidate and review content does not show through
- add a subtle Compare all link beside the race-page Candidates heading
- add regression coverage for sticky-label opacity

## Why

The sticky cells used translucent backgrounds, allowing content moving underneath them to remain visible. Reaching the full comparison from a race page also required selecting candidates one at a time.

## Validation

- npm run check
- npm run test:unit -- --run src/lib/components/compare/CandidateComparison.test.ts
- Prettier and ESLint on touched files
- git diff --check