### PR TITLE
Fix compare label overlap

### DIFF
--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -155,7 +155,7 @@
           : '220px'} repeat({candidates.length}, 1fr)"
       >
         <div
-          class="sticky left-0 z-40 border-r border-stroke bg-surface px-5 text-xs font-bold uppercase tracking-wider text-content-subtle"
+          class="sticky left-0 z-40 flex self-stretch items-center border-r border-stroke bg-surface px-5 text-xs font-bold uppercase tracking-wider text-content-subtle"
         >
           {compact ? "Compare" : "Compare Directory"}
         </div>

--- a/web/src/lib/components/compare/CandidateComparison.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.test.ts
@@ -84,6 +84,7 @@ describe("CandidateComparison", () => {
     );
 
     expect(desktop.getByText("Compare").classList).toContain("bg-surface");
+    expect(desktop.getByText("Compare").classList).toContain("self-stretch");
     expect(desktop.getByText("Research review").classList).toContain(
       "bg-emerald-50",
     );


### PR DESCRIPTION
## What changed

- stretch the sticky Compare label across the full candidate-header row
- keep the label vertically centered within that full-height cell
- extend the regression test to require the full-row layout class

## Root cause

The header grid uses centered item alignment, which collapsed the sticky label cell to the 16px text height. Candidate faces and names therefore remained visible above and below the otherwise opaque sticky background while horizontally scrolling.

## Validation

- npm ci
- npm run check
- npm run test:unit -- --run src/lib/components/compare/CandidateComparison.test.ts
- Prettier and ESLint on touched files
- git diff --check