### PR TITLE
Improve ballot candidate comparisons

### DIFF
--- a/web/src/lib/components/ballot/BallotExplorer.svelte
+++ b/web/src/lib/components/ballot/BallotExplorer.svelte
@@ -34,7 +34,7 @@
     race: Race,
     selections: Record<string, Candidate[]>,
   ): Candidate[] {
-    return selections[race.id] ?? activeCandidates(race).slice(0, 2);
+    return selections[race.id] ?? activeCandidates(race);
   }
 
   function toggleCandidate(race: Race, candidateName: string) {

--- a/web/src/lib/components/ballot/BallotExplorer.test.ts
+++ b/web/src/lib/components/ballot/BallotExplorer.test.ts
@@ -61,7 +61,7 @@ const race: Race = {
   candidates: [
     candidate("Dana Democrat", "Democratic", true),
     candidate("Riley Republican", "Republican", true),
-    candidate("Indy Independent", "Independent"),
+    candidate("Libby Libertarian", "Libertarian"),
   ],
 };
 
@@ -84,12 +84,12 @@ describe("BallotExplorer", () => {
 
   afterEach(cleanup);
 
-  it("adds a third-party candidate to the inline comparison", async () => {
+  it("includes every active candidate in the inline comparison by default", async () => {
     render(BallotExplorer, { races: [summary] });
 
     await waitFor(() =>
       expect(
-        screen.getByRole("checkbox", { name: /Indy Independent/ }),
+        screen.getByRole("checkbox", { name: /Libby Libertarian/ }),
       ).toBeTruthy(),
     );
     expect(
@@ -99,11 +99,23 @@ describe("BallotExplorer", () => {
       "Candidates in this comparison",
     );
     expect(
-      within(mobileCandidates).queryByRole("link", {
-        name: "Indy Independent",
+      within(mobileCandidates).getByRole("link", {
+        name: "Libby Libertarian",
       }),
-    ).toBeNull();
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("checkbox", {
+          name: /Libby Libertarian/,
+        }) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
     expect(screen.getAllByText("Healthcare")).toHaveLength(2);
+    expect(
+      screen.getAllByText(
+        /No (sourced position available|stance researched) yet\./,
+      ),
+    ).toHaveLength(2);
 
     const danaPosition = screen.getByRole("article", {
       name: "Dana Democrat position on Healthcare",
@@ -123,17 +135,19 @@ describe("BallotExplorer", () => {
     ).toBeTruthy();
 
     await fireEvent.click(
-      screen.getByRole("checkbox", { name: /Indy Independent/ }),
+      screen.getByRole("checkbox", { name: /Libby Libertarian/ }),
     );
 
     expect(
-      within(mobileCandidates).getByRole("link", { name: "Indy Independent" }),
-    ).toBeTruthy();
+      within(mobileCandidates).queryByRole("link", {
+        name: "Libby Libertarian",
+      }),
+    ).toBeNull();
     expect(screen.getAllByText("Healthcare")).toHaveLength(2);
     expect(
-      screen.getAllByText(
+      screen.queryAllByText(
         /No (sourced position available|stance researched) yet\./,
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(0);
   });
 });

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -282,29 +282,33 @@
           </div>
           {#each candidates as candidate}
             {@const stance = candidate.issues?.[issueKey]}
-            {@const preview = stance ? stancePreview(stance.stance) : ""}
+            {@const preview = stance
+              ? stancePreview(stance.stance, 320, 220)
+              : ""}
             {@const isStanceExpanded =
               expandedStances[stanceKey(issueKey, candidate)] ?? false}
             <div
               class="flex flex-col gap-3 border-r border-stroke p-6 last:border-none"
             >
               {#if stance}
-                <p
-                  class="whitespace-normal text-sm leading-relaxed text-content-muted"
-                >
-                  {isStanceExpanded ? stance.stance : preview}
-                </p>
-                {#if preview !== stance.stance.trim()}
-                  <button
-                    type="button"
-                    aria-expanded={isStanceExpanded}
-                    on:click={() => toggleStance(issueKey, candidate)}
-                    class="inline-flex min-h-11 items-center self-start text-sm font-bold text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                <div>
+                  <p
+                    class="whitespace-normal text-sm leading-relaxed text-content-muted"
                   >
-                    {isStanceExpanded ? "Show less" : "Show more"}
-                    <span class="sr-only"> for {candidate.name}</span>
-                  </button>
-                {/if}
+                    {isStanceExpanded ? stance.stance : preview}
+                  </p>
+                  {#if preview !== stance.stance.trim()}
+                    <button
+                      type="button"
+                      aria-expanded={isStanceExpanded}
+                      on:click={() => toggleStance(issueKey, candidate)}
+                      class="inline-flex min-h-11 items-start pt-1 text-sm font-bold leading-5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                    >
+                      {isStanceExpanded ? "Show less" : "Show more"}
+                      <span class="sr-only"> for {candidate.name}</span>
+                    </button>
+                  {/if}
+                </div>
                 <div class="flex items-center gap-2 pt-1">
                   <span
                     class="text-[10px] font-medium uppercase tracking-wide text-content-subtle"

--- a/web/src/lib/components/compare/CandidateComparison.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.test.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { Candidate, Race } from "$lib/types";
 import CandidateComparison from "./CandidateComparison.svelte";
 
+const desktopPreview =
+  "The first sentence explains the position. The second sentence adds context about implementation and likely effects. The third sentence explains funding and accountability for the proposal. The fourth sentence provides further evidence about the expected outcome.";
+const fullStance = `${desktopPreview} The final sentence contains additional detail for voters who want the complete record.`;
+
 const candidate: Candidate = {
   name: "Casey Candidate",
   party: "Independent",
@@ -11,8 +15,7 @@ const candidate: Candidate = {
   summary_sources: [],
   issues: {
     Healthcare: {
-      stance:
-        "The first sentence explains the position. More detail follows here.",
+      stance: fullStance,
       confidence: "high",
       sources: [],
     },
@@ -45,19 +48,13 @@ describe("CandidateComparison", () => {
       container.querySelector("[data-desktop-candidate-comparison]")!,
     );
 
-    expect(
-      desktop.getByText("The first sentence explains the position."),
-    ).toBeTruthy();
+    expect(desktop.getByText(desktopPreview)).toBeTruthy();
     const button = desktop.getByRole("button", {
       name: "Show more for Casey Candidate",
     });
 
     await fireEvent.click(button);
-    expect(
-      desktop.getByText(
-        "The first sentence explains the position. More detail follows here.",
-      ),
-    ).toBeTruthy();
+    expect(desktop.getByText(fullStance)).toBeTruthy();
     expect(
       desktop.getByRole("button", { name: "Show less for Casey Candidate" }),
     ).toBeTruthy();

--- a/web/src/lib/utils/stance.test.ts
+++ b/web/src/lib/utils/stance.test.ts
@@ -16,6 +16,18 @@ describe("stancePreview", () => {
     ).toBe("The first position is clear!");
   });
 
+  it("can include complete sentences until a minimum preview length", () => {
+    expect(
+      stancePreview(
+        "One short sentence. A second complete sentence reaches the requested preview length. More detail follows.",
+        180,
+        50,
+      ),
+    ).toBe(
+      "One short sentence. A second complete sentence reaches the requested preview length.",
+    );
+  });
+
   it("truncates a long sentence on a word boundary", () => {
     const preview = stancePreview("word ".repeat(50), 40);
     expect(preview.endsWith("…")).toBe(true);

--- a/web/src/lib/utils/stance.ts
+++ b/web/src/lib/utils/stance.ts
@@ -22,8 +22,12 @@ function isAbbreviation(textThroughPeriod: string): boolean {
   );
 }
 
-/** Return a readable first sentence without splitting common abbreviations. */
-export function stancePreview(stance: string, fallbackLength = 180): string {
+/** Return a readable sentence-bounded preview without splitting abbreviations. */
+export function stancePreview(
+  stance: string,
+  fallbackLength = 180,
+  minimumLength = 0,
+): string {
   const normalized = stance.trim();
 
   for (let index = 0; index < normalized.length; index += 1) {
@@ -35,7 +39,7 @@ export function stancePreview(stance: string, fallbackLength = 180): string {
     if (character === "." && isAbbreviation(normalized.slice(0, index + 1)))
       continue;
 
-    return normalized.slice(0, index + 1);
+    if (index + 1 >= minimumLength) return normalized.slice(0, index + 1);
   }
 
   if (normalized.length <= fallbackLength) return normalized;


### PR DESCRIPTION
## What changed

- include every active candidate in My Ballot comparisons by default, including Libertarian and other third-party candidates
- retain manual candidate deselection
- show longer sentence-bounded stance previews on desktop while preserving the concise mobile behavior
- move the visible desktop Show more label closer to stance text without reducing its accessible target

## Why

My Ballot previously selected only the first two candidates, which hid later-listed candidates by default. Desktop stance previews also collapsed after the first sentence and placed the expansion label farther from its text than intended.

## Validation

- npm ci
- npm run check
- focused ballot, desktop comparison, mobile comparison, and stance utility tests (9 passed)
- Prettier and ESLint on touched files
- git diff --check