### PR TITLE
Curate homepage races and clarify AI review scores

### DIFF
--- a/design-system/src/components/FeaturedElections/FeaturedElections.tsx
+++ b/design-system/src/components/FeaturedElections/FeaturedElections.tsx
@@ -12,12 +12,8 @@ export interface FeaturedElectionsProps {
   races: FeaturedElectionsRace[];
 }
 
-function formatDate(date: string): string {
-  return new Date(date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-}
-
 /**
- * Homepage "recently updated" editorial section — one large featured race
+ * Homepage editorial section — one large featured race
  * beside a compact list of the next few. Renders nothing when `races` is empty.
  */
 export function FeaturedElections({ races }: FeaturedElectionsProps) {
@@ -26,58 +22,91 @@ export function FeaturedElections({ races }: FeaturedElectionsProps) {
   const sideRaces = rest.slice(0, 4);
 
   return (
-    <section className="border-t border-stroke py-20 sm:py-28" aria-labelledby="recent-elections">
+    <section
+      className="border-t border-stroke py-20 sm:py-28"
+      aria-labelledby="featured-elections"
+    >
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
         <header className="flex items-end justify-between gap-6 border-b border-stroke pb-6">
           <div>
-            <p className="text-xs font-bold uppercase tracking-[0.24em] text-blue-600 dark:text-blue-400">The research desk</p>
-            <h2 id="recent-elections" className="mt-3 text-3xl font-bold tracking-tight text-content sm:text-5xl">
-              Recently updated
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-blue-600 dark:text-blue-400">
+              The research desk
+            </p>
+            <h2
+              id="featured-elections"
+              className="mt-3 text-3xl font-bold tracking-tight text-content sm:text-5xl"
+            >
+              Featured races
             </h2>
           </div>
-          <a href="/elections/" className="hidden text-sm font-semibold text-blue-600 transition hover:text-blue-800 sm:block dark:text-blue-400">
+          <a
+            href="/elections/"
+            className="hidden text-sm font-semibold text-blue-600 transition hover:text-blue-800 sm:block dark:text-blue-400"
+          >
             View the full index →
           </a>
         </header>
 
         <div className="grid lg:grid-cols-[1.4fr_.8fr]">
-          <a href={`/races/${featured.id}/`} className="group border-b border-stroke py-8 lg:border-b-0 lg:border-r lg:pr-10">
+          <a
+            href={`/races/${featured.id}/`}
+            className="group border-b border-stroke py-8 lg:border-b-0 lg:border-r lg:pr-10"
+          >
             <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-widest text-content-subtle">
-              <span className="rounded-full bg-blue-600 px-3 py-1 text-white">Featured</span>
-              <span>Updated {formatDate(featured.updatedUtc)}</span>
+              <span className="rounded-full bg-blue-600 px-3 py-1 text-white">
+                Featured
+              </span>
+              <span>Competitive race</span>
             </div>
             <h3 className="mt-8 max-w-2xl text-3xl font-bold leading-tight tracking-tight text-content transition group-hover:text-blue-600 sm:text-5xl dark:group-hover:text-blue-400">
               {featured.title ?? featured.office ?? "Election research"}
             </h3>
-            <p className="mt-4 text-lg text-content-muted">{featured.jurisdiction ?? "United States"}</p>
+            <p className="mt-4 text-lg text-content-muted">
+              {featured.jurisdiction ?? "United States"}
+            </p>
             <div className="mt-10 flex flex-wrap gap-3">
               {featured.candidates.slice(0, 4).map((candidate) => (
-                <span key={candidate.name} className="rounded-full border border-stroke px-4 py-2 text-sm font-medium text-content">
+                <span
+                  key={candidate.name}
+                  className="rounded-full border border-stroke px-4 py-2 text-sm font-medium text-content"
+                >
                   {candidate.name}
                 </span>
               ))}
             </div>
             <p className="mt-10 font-semibold text-blue-600 dark:text-blue-400">
-              Open the election guide <span className="inline-block transition group-hover:translate-x-1">→</span>
+              Open the election guide{" "}
+              <span className="inline-block transition group-hover:translate-x-1">
+                →
+              </span>
             </p>
           </a>
 
           <div className="lg:pl-10">
             {sideRaces.map((race) => (
-              <a key={race.id} href={`/races/${race.id}/`} className="group block border-b border-stroke py-6 last:border-0">
+              <a
+                key={race.id}
+                href={`/races/${race.id}/`}
+                className="group block border-b border-stroke py-6 last:border-0"
+              >
                 <p className="text-xs font-semibold uppercase tracking-widest text-content-subtle">
-                  {race.jurisdiction ?? "National"} · {formatDate(race.updatedUtc)}
+                  {race.jurisdiction ?? "National"} · Competitive race
                 </p>
                 <h3 className="mt-2 text-xl font-bold leading-snug text-content transition group-hover:text-blue-600 dark:group-hover:text-blue-400">
                   {race.title ?? race.office}
                 </h3>
-                <p className="mt-2 text-sm text-content-muted">{race.candidates.length} candidates researched</p>
+                <p className="mt-2 text-sm text-content-muted">
+                  {race.candidates.length} candidates researched
+                </p>
               </a>
             ))}
           </div>
         </div>
 
-        <a href="/elections/" className="mt-8 inline-block text-sm font-semibold text-blue-600 sm:hidden dark:text-blue-400">
+        <a
+          href="/elections/"
+          className="mt-8 inline-block text-sm font-semibold text-blue-600 sm:hidden dark:text-blue-400"
+        >
           View the full index →
         </a>
       </div>

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ConfidenceIndicator from "$lib/components/ConfidenceIndicator.svelte";
   import MobileCandidateComparison from "$lib/components/compare/MobileCandidateComparison.svelte";
+  import ReviewScoreInfo from "$lib/components/compare/ReviewScoreInfo.svelte";
   import SourceLink from "$lib/components/SourceLink.svelte";
   import type { Candidate, Race } from "$lib/types";
   import { CANONICAL_ISSUES, getIssueDisplayName } from "$lib/types";
@@ -226,11 +227,14 @@
               class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-emerald-200 bg-white text-lg font-extrabold text-emerald-800 shadow-sm dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
               >{race.validation_grade.grade}</span
             >
-            <span>
+            <div>
               <strong class="text-content"
                 >{race.validation_grade.score}/100 review score.</strong
-              > Claims, sources, and consistency passed the publication review.
-            </span>
+              ><ReviewScoreInfo
+                panelId={`desktop-review-score-info-${race.id}`}
+              />
+              Methodology, sourcing, and bias checks passed the AI review.
+            </div>
           </div>
         </div>
       {/if}

--- a/web/src/lib/components/compare/CandidateComparison.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.test.ts
@@ -86,4 +86,35 @@ describe("CandidateComparison", () => {
       "bg-emerald-50",
     );
   });
+
+  it("explains the limits of the AI review score", async () => {
+    const reviewedRace: Race = {
+      ...race,
+      validation_grade: {
+        grade: "A",
+        score: 95,
+        passed: true,
+        summary: "Publication checks passed.",
+      },
+    };
+    const { container } = render(CandidateComparison, {
+      race: reviewedRace,
+      candidates: [candidate],
+      compact: true,
+      showQuality: true,
+    });
+    const desktop = within(
+      container.querySelector("[data-desktop-candidate-comparison]")!,
+    );
+
+    await fireEvent.click(
+      desktop.getByRole("button", { name: "About this AI review score" }),
+    );
+
+    const note = desktop.getByRole("note").textContent?.replace(/\s+/g, " ");
+    expect(note).toContain("It is not independent fact-checking");
+    expect(note).toContain(
+      "does not validate that the underlying information is correct",
+    );
+  });
 });

--- a/web/src/lib/components/compare/MobileCandidateComparison.svelte
+++ b/web/src/lib/components/compare/MobileCandidateComparison.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ConfidenceIndicator from "$lib/components/ConfidenceIndicator.svelte";
+  import ReviewScoreInfo from "$lib/components/compare/ReviewScoreInfo.svelte";
   import SourceLink from "$lib/components/SourceLink.svelte";
   import type { Candidate, CanonicalIssue, Race } from "$lib/types";
   import { CANONICAL_ISSUES, getIssueDisplayName } from "$lib/types";
@@ -67,10 +68,12 @@
         class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-emerald-200 bg-white font-extrabold text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
         >{race.validation_grade.grade}</span
       >
-      <p class="text-xs leading-5 text-content-muted">
+      <div class="text-xs leading-5 text-content-muted">
         <strong class="text-content">Research review:</strong>
-        {race.validation_grade.score}/100 after source and consistency checks.
-      </p>
+        {race.validation_grade.score}/100<ReviewScoreInfo
+          panelId={`mobile-review-score-info-${race.id}`}
+        /> after methodology, sourcing, and bias checks.
+      </div>
     </div>
   {/if}
 

--- a/web/src/lib/components/compare/ReviewScoreInfo.svelte
+++ b/web/src/lib/components/compare/ReviewScoreInfo.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  export let panelId: string;
+
+  let open = false;
+</script>
+
+<span class="ml-1 inline-flex align-middle">
+  <button
+    type="button"
+    class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-amber-400 bg-amber-50 text-[11px] font-extrabold leading-none text-amber-800 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+    aria-label="About this AI review score"
+    aria-expanded={open}
+    aria-controls={panelId}
+    title="About this AI review score"
+    on:click={() => (open = !open)}
+    on:keydown={(event) => event.key === "Escape" && (open = false)}>i</button
+  >
+</span>
+
+{#if open}
+  <span
+    id={panelId}
+    role="note"
+    class="mt-2 block rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs font-normal leading-5 text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
+  >
+    <strong>AI-generated research:</strong> This score comes from other AI models
+    reviewing the generating model's methodology, sourcing, completeness, and signs
+    of bias. It is not independent fact-checking and does not validate that the underlying
+    information is correct.
+  </span>
+{/if}

--- a/web/src/lib/components/home/FeaturedElections.svelte
+++ b/web/src/lib/components/home/FeaturedElections.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
   import type { RaceSummary } from "$lib/types";
   export let races: RaceSummary[] = [];
-
-  const formatDate = (date: string) =>
-    new Date(date).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
 </script>
 
 {#if races.length}
   <section
     class="border-t border-stroke py-20 sm:py-28"
-    aria-labelledby="recent-elections"
+    aria-labelledby="featured-elections"
   >
     <div class="mx-auto max-w-6xl px-4 sm:px-6">
       <header
@@ -26,10 +19,10 @@
             The research desk
           </p>
           <h2
-            id="recent-elections"
+            id="featured-elections"
             class="mt-3 text-3xl font-bold tracking-tight text-content sm:text-5xl"
           >
-            Recently updated
+            Featured races
           </h2>
         </div>
         <a
@@ -50,7 +43,7 @@
             <span class="rounded-full bg-blue-600 px-3 py-1 text-white"
               >Featured</span
             >
-            <span>Updated {formatDate(races[0].updated_utc)}</span>
+            <span>Competitive race</span>
           </div>
           <h3
             class="mt-8 max-w-2xl text-3xl font-bold leading-tight tracking-tight text-content transition group-hover:text-blue-600 sm:text-5xl dark:group-hover:text-blue-400"
@@ -84,9 +77,7 @@
               <p
                 class="text-xs font-semibold uppercase tracking-widest text-content-subtle"
               >
-                {race.jurisdiction ?? "National"} · {formatDate(
-                  race.updated_utc,
-                )}
+                {race.jurisdiction ?? "National"} · Competitive race
               </p>
               <h3
                 class="mt-2 text-xl font-bold leading-snug text-content transition group-hover:text-blue-600 dark:group-hover:text-blue-400"

--- a/web/src/lib/utils/homepage.test.ts
+++ b/web/src/lib/utils/homepage.test.ts
@@ -5,6 +5,7 @@ import {
   nationalElectionRaces,
   recentlyUpdated,
   rotateByDate,
+  selectFeaturedRaces,
 } from "./homepage";
 
 const race = (id: string, updated: string, state = "Iowa"): RaceSummary => ({
@@ -49,6 +50,19 @@ describe("homepage data", () => {
         race("newer", "2026-02-01T00:00:00Z"),
       ]).map(({ id }) => id),
     ).toEqual(["newer", "older"]);
+  });
+
+  it("selects featured races in manual editorial order", () => {
+    const newest = race("newest", "2026-03-01T00:00:00Z");
+    const first = race("first", "2026-01-01T00:00:00Z");
+    const second = race("second", "2026-02-01T00:00:00Z");
+
+    expect(
+      selectFeaturedRaces(
+        [newest, second, first],
+        ["first", "missing", "second"],
+      ).map(({ id }) => id),
+    ).toEqual(["first", "second"]);
   });
 
   it("computes reproducible published-data metrics", () => {

--- a/web/src/lib/utils/homepage.ts
+++ b/web/src/lib/utils/homepage.ts
@@ -8,6 +8,27 @@ export interface HomepageMetrics {
   snapshotDate: string;
 }
 
+// Editorial order for the homepage. Keep this list explicit so publishing or
+// refreshing another race does not unexpectedly change the featured section.
+export const featuredHomepageRaceIds = [
+  "co-house-08-2026",
+  "nv-governor-2026",
+  "pa-house-08-2026",
+  "nc-house-01-2026",
+  "ca-house-48-2026",
+] as const;
+
+export function selectFeaturedRaces(
+  races: RaceSummary[],
+  ids: readonly string[] = featuredHomepageRaceIds,
+): RaceSummary[] {
+  const racesById = new Map(races.map((race) => [race.id, race]));
+  return ids.flatMap((id) => {
+    const race = racesById.get(id);
+    return race ? [race] : [];
+  });
+}
+
 export function nationalElectionRaces(races: RaceSummary[]): RaceSummary[] {
   return races.filter((race) => {
     const office = race.office?.toLocaleLowerCase() ?? "";

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -12,6 +12,7 @@ import {
   homepageMetrics,
   nationalElectionRaces,
   recentlyUpdated,
+  selectFeaturedRaces,
 } from "$lib/utils/homepage";
 
 export const load: PageLoad = async ({ fetch }) => {
@@ -47,10 +48,9 @@ export const load: PageLoad = async ({ fetch }) => {
     .map((result) => result.value);
   gradeARaces = mergeGradeAHomepageRaces(verified);
 
-  // The editorial list is driven by the published summary index, independently
-  // of the stricter full-record requirements used by InteractiveRaceCompare.
-  // A partial preview load must not collapse "Recently updated" to one race.
-  const featuredRaces = recentlyUpdated(nationalRaces, 5);
+  // The editorial list is intentionally manual and independent of update time.
+  // Missing or unpublished races are skipped without changing the chosen order.
+  const featuredRaces = selectFeaturedRaces(nationalRaces);
 
   return {
     featuredRaces,


### PR DESCRIPTION
## What changed

- replace timestamp-driven homepage featured races with a fixed editorial list of competitive, Grade A races
- rename the section and remove the recently-updated framing
- add an accessible AI review-score disclosure on desktop and mobile
- clarify that review scores assess methodology, sourcing, completeness, and signs of bias rather than independently validating factual accuracy
- keep the standalone design-system example aligned with the production component

## Why

The homepage should highlight strong, competitive race guides intentionally instead of changing whenever another guide is refreshed. The AI review score also needed a clear explanation of what automated model review does and does not establish.

## Validation

- focused homepage utility tests
- desktop and mobile comparison component tests
- Svelte type and diagnostics check
- ESLint and Prettier
- design-system TypeScript check
- git diff and pre-commit checks
