### PR TITLE
Feature Texas Senate on homepage

### DIFF
--- a/web/src/lib/utils/homepage.test.ts
+++ b/web/src/lib/utils/homepage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { RaceSummary } from "$lib/types";
 import {
+  featuredHomepageRaceIds,
   homepageMetrics,
   nationalElectionRaces,
   recentlyUpdated,
@@ -21,6 +22,16 @@ const race = (id: string, updated: string, state = "Iowa"): RaceSummary => ({
 });
 
 describe("homepage data", () => {
+  it("keeps Texas Senate first in the curated featured races", () => {
+    expect(featuredHomepageRaceIds).toEqual([
+      "tx-senate-2026",
+      "me-senate-2026",
+      "nv-governor-2026",
+      "co-house-08-2026",
+      "ia-senate-2026",
+    ]);
+  });
+
   it("keeps federal and gubernatorial contests in launch coverage", () => {
     const federal = {
       ...race("house", "2026-01-01T00:00:00Z"),

--- a/web/src/lib/utils/homepage.ts
+++ b/web/src/lib/utils/homepage.ts
@@ -11,11 +11,11 @@ export interface HomepageMetrics {
 // Editorial order for the homepage. Keep this list explicit so publishing or
 // refreshing another race does not unexpectedly change the featured section.
 export const featuredHomepageRaceIds = [
-  "co-house-08-2026",
+  "tx-senate-2026",
+  "me-senate-2026",
   "nv-governor-2026",
-  "pa-house-08-2026",
-  "nc-house-01-2026",
-  "ca-house-48-2026",
+  "co-house-08-2026",
+  "ia-senate-2026",
 ] as const;
 
 export function selectFeaturedRaces(


### PR DESCRIPTION
## What changed

- make Texas Senate the lead homepage feature
- replace the weaker supporting choices with Maine Senate, Nevada governor, Colorado 8, and Iowa Senate
- add a regression test that locks the curated order and keeps Texas first

## Why

The previous featured set was selected from an incomplete local-data comparison. This revision audits the live published records used by production across validation score, contest stage, competitiveness, polling and market evidence, candidate summaries and rosters, issue completeness and sourcing, confidence, finance coverage, and candidate images.

Texas Senate is the strongest available flagship: Grade A/95, post-primary toss-up, five polls, two market signals, 36/36 sourced issue positions, complete finance coverage, and 98 unique issue sources.

## Validation

- six homepage utility tests
- Svelte diagnostics and type check
- ESLint
- Prettier
- diff and pre-commit checks
