### PR TITLE
Use curated races in homepage comparison

### DIFF
--- a/web/src/lib/homepagePreview.test.ts
+++ b/web/src/lib/homepagePreview.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it } from "vitest";
 import {
   gradeAHomepageFallbacks,
-  mergeGradeAHomepageRaces,
+  isHomepagePreviewRace,
+  mergeHomepagePreviewRaces,
 } from "$lib/homepagePreview";
 
-describe("mergeGradeAHomepageRaces", () => {
-  it("keeps multiple carousel options after a partial production load", () => {
-    const [verified, fallback] = gradeAHomepageFallbacks;
+describe("homepage preview races", () => {
+  it("accepts a strong reviewed race without requiring a letter grade of A", () => {
+    const race = {
+      ...gradeAHomepageFallbacks[0],
+      validation_grade: {
+        grade: "B" as const,
+        score: 89,
+        passed: true,
+        summary: "Validated by reviewers.",
+      },
+    };
 
-    expect(mergeGradeAHomepageRaces([verified])).toEqual([verified, fallback]);
+    expect(isHomepagePreviewRace(race)).toBe(true);
   });
 
   it("deduplicates races and respects the display limit", () => {
     const [first, second] = gradeAHomepageFallbacks;
 
-    expect(mergeGradeAHomepageRaces([first, second, first], [], 1)).toEqual([
+    expect(mergeHomepagePreviewRaces([first, second, first], 1)).toEqual([
       first,
     ]);
   });

--- a/web/src/lib/homepagePreview.ts
+++ b/web/src/lib/homepagePreview.ts
@@ -1,11 +1,5 @@
 import type { Candidate, IssueKey, Race, Source } from "$lib/types";
 
-export const gradeAHomepageRaceIds = [
-  "ak-senate-2026",
-  "ak-governor-2026",
-  "al-governor-2026",
-] as const;
-
 const source = (
   url: string,
   title: string,
@@ -237,16 +231,15 @@ export const gradeAHomepageFallbacks: Race[] = [
   },
 ];
 
-export const isGradeAHomepageRace = (race: Race) =>
-  race.validation_grade?.grade === "A" && race.validation_grade.passed === true;
+export const isHomepagePreviewRace = (race: Race) =>
+  race.validation_grade?.passed === true && race.validation_grade.score >= 85;
 
-export const mergeGradeAHomepageRaces = (
+export const mergeHomepagePreviewRaces = (
   verified: Race[],
-  fallbacks: Race[] = gradeAHomepageFallbacks,
   limit = 5,
 ): Race[] => {
   const seen = new Set<string>();
-  return [...verified, ...fallbacks]
+  return verified
     .filter((race) => {
       if (seen.has(race.id)) return false;
       seen.add(race.id);

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -1,17 +1,15 @@
 import type { PageLoad } from "./$types";
 import { loadPrerenderSummaries } from "$lib/prerenderData";
-import type { RaceSummary } from "$lib/types";
+import type { Race, RaceSummary } from "$lib/types";
 import {
-  gradeAHomepageFallbacks,
-  gradeAHomepageRaceIds,
-  isGradeAHomepageRace,
-  mergeGradeAHomepageRaces,
+  isHomepagePreviewRace,
+  mergeHomepagePreviewRaces,
 } from "$lib/homepagePreview";
 import { loadPrerenderRace } from "$lib/prerenderData";
 import {
+  featuredHomepageRaceIds,
   homepageMetrics,
   nationalElectionRaces,
-  recentlyUpdated,
   selectFeaturedRaces,
 } from "$lib/utils/homepage";
 
@@ -23,30 +21,20 @@ export const load: PageLoad = async ({ fetch }) => {
     // Keep the homepage renderable in fast local builds without published data.
   }
   const nationalRaces = nationalElectionRaces(races);
-  let gradeARaces = gradeAHomepageFallbacks;
-  const indexedGradeAIds = recentlyUpdated(
-    nationalRaces.filter((race) => race.quality_grade === "A"),
-    5,
-  ).map((race) => race.id);
-  const previewIds = [
-    ...new Set([...indexedGradeAIds, ...gradeAHomepageRaceIds]),
-  ];
 
-  // Production syncs published race JSON into static/ before prerendering. Try
-  // those local files even when VITE_PUBLIC_DATA_URL is unset; fast local/CI
-  // builds can still fall back when the per-race fixtures are unavailable.
+  // The top comparison and editorial section share one explicit race order.
+  // Production syncs these published race files into static/ before prerendering.
   const published = await Promise.allSettled(
-    previewIds.map((id) => loadPrerenderRace(id, fetch)),
+    featuredHomepageRaceIds.map((id) => loadPrerenderRace(id, fetch)),
   );
-  const verified = published
-    .filter(
-      (
-        result,
-      ): result is PromiseFulfilledResult<(typeof gradeARaces)[number]> =>
-        result.status === "fulfilled" && isGradeAHomepageRace(result.value),
-    )
-    .map((result) => result.value);
-  gradeARaces = mergeGradeAHomepageRaces(verified);
+  const previewRaces = mergeHomepagePreviewRaces(
+    published
+      .filter(
+        (result): result is PromiseFulfilledResult<Race> =>
+          result.status === "fulfilled" && isHomepagePreviewRace(result.value),
+      )
+      .map((result) => result.value),
+  );
 
   // The editorial list is intentionally manual and independent of update time.
   // Missing or unpublished races are skipped without changing the chosen order.
@@ -54,7 +42,7 @@ export const load: PageLoad = async ({ fetch }) => {
 
   return {
     featuredRaces,
-    gradeARaces,
+    gradeARaces: previewRaces,
     metrics: homepageMetrics(nationalRaces, new Date().toISOString()),
   };
 };


### PR DESCRIPTION
## What changed

- make the prominent homepage comparison use the same manual race IDs as the lower featured section
- remove recently-updated Grade A races from the top-carousel selection path
- prevent obsolete Alaska/Alabama fallback races from filling missing production slots
- allow strongly reviewed B-grade data such as Maine Senate when it passes review with a score of at least 85

## Root cause

The previous correction changed only the lower Featured races section. The top Featured comparison independently selected the five most recently updated Grade A summaries before considering its hardcoded IDs. In production that rendered Montana, New Mexico, Utah, Kansas, and Colorado Senate and exhausted every carousel slot before Texas was reached.

## Result

Both homepage surfaces now share this exact order: Texas Senate, Maine Senate, Nevada governor, Colorado 8, and Iowa Senate.

## Validation

- eight focused homepage tests
- Svelte diagnostics and type check
- ESLint
- Prettier
- diff and pre-commit checks
