### PR TITLE
Improve pipeline update defaults and operations

### DIFF
--- a/PIPELINE_MODES.md
+++ b/PIPELINE_MODES.md
@@ -1,6 +1,9 @@
 # Pipeline Modes
 
 The SmarterVote pipeline supports local development and cloud production modes.
+For the end-to-end operator workflow, including queue options, monitoring,
+quality review, publication, cost accounting, and failure recovery, use
+[`docs/pipeline-operations.md`](docs/pipeline-operations.md).
 
 ## Local Mode (Default)
 
@@ -116,6 +119,86 @@ discovery -> images -> issues -> finance -> refinement -> polling -> forecast ->
 ```
 
 The `/steps` endpoint returns the same order with labels and progress weights from `shared/pipeline_config.py`.
+
+### Fresh and update defaults
+
+The worker resolves defaults after it loads the requested baseline, so a race
+with no usable baseline still receives complete fresh research while an
+existing profile receives a bounded maintenance pass.
+
+| Run shape | Default steps | Use when |
+| --- | --- | --- |
+| Fresh | All steps | The existing profile is unusable, the roster belongs to the wrong contest, or no profile exists |
+| Update | `discovery`, `images`, `finance`, `refinement`, `polling`, `forecast`, `voter_resources` | The baseline roster and issue record are usable and only current facts need refreshing |
+| Explicit | Exactly `enabled_steps` | A human or automation has a narrower repair goal |
+
+Ordinary updates intentionally skip `issues`, `review`, and `iteration`.
+Existing issue stances and source evidence are preserved. Include `issues`
+only when the run goal explicitly calls for issue-position research; include
+`review` and `iteration` after material issue or narrative changes that justify
+multi-model review cost. Explicit selections always override the defaults.
+
+The admin Batch Queue dialog opens with the update default selected and offers
+**All on**, **Update default**, and **Discovery only** presets. `force_fresh`
+controls baseline use, not step selection: a fresh run with explicitly selected
+update steps still skips issue research.
+
+### Baselines and targeted repairs
+
+- `baseline_source=latest` prefers an existing draft and falls back to the
+  published profile. This is the normal incremental-update behavior.
+- `baseline_source=published` ignores draft drift and is preferred when a
+  targeted repair must start from the known public record.
+- `force_fresh=true` supplies an empty baseline. Use verified
+  `candidate_names` for post-primary repairs so discovery cannot silently keep
+  primary losers, running mates, or candidates from a nearby office.
+- A correction `goal` should state the office, contest stage, verified roster,
+  fields to refresh, and fields that must remain unchanged.
+- Every run saves a draft first. Research runs never publish automatically;
+  publishing remains a separate authenticated admin action.
+
+For post-primary races, verify the roster against an official candidate list
+or official primary results before queueing. A bad roster is a fresh-run
+problem; a correct roster with aging finance, polling, images, forecast, or
+voter links is an update-run problem.
+
+### Cost controls
+
+- Economy/cheap mode is the normal queue default. Quality/custom profiles must
+  be selected explicitly.
+- Issue research is the largest weighted phase and fans out across every
+  candidate and canonical issue; skipping it is the primary update-run saving.
+- Multi-model review and iteration are paid opt-ins on updates.
+- Search results are cached for seven days and fetched page text for 24 hours.
+- Target one or a few races and pass verified candidate names instead of using
+  broad discovery as a roster oracle.
+- Prefer source-specific deterministic refreshes and stale-field thresholds
+  for future optimization. Current update discovery can still spend several
+  model iterations proving that a recent baseline has not changed.
+- Firestore progress writes are coalesced, log polling is cursor-based, live
+  logs are bounded, and diagnostics reads have a hard cap as described below.
+
+### Run lifecycle, recovery, and health
+
+Queue items are leased atomically. Workers renew leases, checkpoint durable
+state, and create continuation items when work cannot finish in the current
+execution window. Continuations keep the logical `run_id`, completed-step set,
+prior cost metrics, and only the remaining enabled steps. Do not restart a
+continuation with `force_fresh`; the checkpoint must win over the original
+fresh-run option.
+
+Completion and quality are separate signals. `status=completed` means the
+worker returned without an unhandled error; `run_health` classifies whether
+the result was healthy, degraded, failed, or unknown and records provider,
+budget, validation, placeholder, roster, and no-data failures. Draft review
+should check run health, `pipeline_state.complete`, validation grade, candidate
+roster, sources, polling semantics, and the original correction goal before
+publication.
+
+Confirmed 404/410 candidate sources are removed and tombstoned so incremental
+evidence preservation does not restore them. Other baseline citations are
+merged monotonically into update output when a model omits them. Election
+returns and primary vote totals are rejected as opinion polling.
 
 ## Debug Capture and Diagnostics Export
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation Map
 
-Last reviewed: 2026-07-18.
+Last reviewed: 2026-07-26.
 
 Use this page to decide which documents describe current behavior. Code, deployed GCP resources, and CI remain the final source of truth; documentation should be updated alongside behavior changes.
 
@@ -14,6 +14,7 @@ Use this page to decide which documents describe current behavior. Code, deploye
 | Authentication | [auth0-configuration.md](auth0-configuration.md) | Auth0 and admin-key behavior |
 | Infrastructure | [../infra/README.md](../infra/README.md) | Terraform components and defaults |
 | Pipeline modes | [../PIPELINE_MODES.md](../PIPELINE_MODES.md) | Local/GCP execution and storage modes |
+| Pipeline operations | [pipeline-operations.md](pipeline-operations.md) | Queueing, monitoring, quality review, publication, cost accounting, and recovery |
 | Search indexing | [indexnow.md](indexnow.md) | IndexNow setup and deployment integration |
 | Marketing design system | [../design-system/README.md](../design-system/README.md) | React export used by Claude to create branded marketing material; not production frontend code |
 

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -1,0 +1,445 @@
+# Pipeline Operations Runbook
+
+This is the canonical operator guide for running, monitoring, reviewing, costing,
+and publishing SmarterVote race research. Architecture details live in
+`docs/architecture.md`; deployment mechanics live in `docs/deployment-guide.md`.
+
+## Non-Negotiable Rules
+
+- Runs write drafts. They do not publish automatically.
+- Review the complete draft and every warning/error before publishing.
+- A passing numeric grade is not sufficient by itself. Publication rejects any
+  unresolved warning-or-higher review flag, including deterministic link and
+  profile-quality flags.
+- Use the deployed `races-api` and GCS data as operational truth. Local files are
+  fixtures unless a local-only direct run was explicitly requested.
+- Preserve unrelated worktree changes. Do not reset a dirty tree to deploy.
+- Record model/search cost and cloud compute separately, then report the combined
+  total without double counting.
+
+## Execution Paths
+
+### Local Docker worker against the cloud queue
+
+This is the preferred workstation path. It uses the same Firestore queue,
+`AgentHandler`, storage, run records, and logs as Cloud Run, but claims only
+items queued with `runner=local`.
+
+```powershell
+docker compose -f docker-compose.worker.yml up -d --build
+docker compose -f docker-compose.worker.yml ps
+docker compose -f docker-compose.worker.yml logs -f pipeline-worker
+```
+
+The worker reads credentials and configuration from the compose environment.
+Confirm `ADMIN_API_KEY`, OpenRouter/search keys, GCP project/storage settings,
+and application-default GCP credentials before assuming a pending item is stuck.
+
+### Cloud Run Job
+
+The production-shaped path is:
+
+```text
+races-api queue request
+  -> Firestore pipeline_queue
+  -> pipeline-job-{environment}, with QUEUE_ITEM_ID override
+  -> pipeline_client.worker
+  -> shared queue processor and AgentHandler
+  -> Firestore pipeline_runs and logs
+  -> GCS drafts/{race_id}.json
+```
+
+Queue with `runner=cloud_run`. The races API service account needs permission to
+execute the job with overrides. The job and API must use matching, tested source
+revisions. A successful dispatch is not a successful run; monitor the run record
+to terminal status.
+
+### Direct local development API
+
+Use only for in-process debugging:
+
+```powershell
+python -m uvicorn pipeline_client.backend.main:app --host 0.0.0.0 --port 8001 --reload
+```
+
+Production admin behavior belongs in `services/races-api`, not this local API.
+
+## Choosing a Run
+
+The ordered steps are:
+
+```text
+discovery -> images -> issues -> finance -> refinement -> polling
+  -> forecast -> voter_resources -> review -> iteration
+```
+
+Fetch the current step list from `/steps` or the `list_pipeline_steps` MCP tool
+instead of hard-coding UI labels or weights.
+
+### Fresh run
+
+Use a fresh run for a new/bad race whose roster and full profile cannot be
+trusted:
+
+- `force_fresh=true`
+- full ordered steps
+- `baseline_source` is irrelevant when no baseline is used
+- bound candidate count only when intentionally testing
+
+Fresh runs should establish the roster from authoritative election sources
+before researching candidates. Election returns and primary results are roster
+evidence, never polling.
+
+### Update run
+
+Use an update when the existing race is generally good:
+
+- default `baseline_source=latest` loads the draft first, then published data
+- use `baseline_source=published` when an existing draft must be ignored
+- when `enabled_steps` is omitted, the worker defaults to `discovery`,
+  `images`, `finance`, `refinement`, `polling`, `forecast`, and
+  `voter_resources`
+- ordinary updates skip `issues`, `review`, and `iteration`; opt into them only
+  when the correction goal justifies their cost
+- explicit `enabled_steps` always override the update default
+- pass `candidate_names` for candidate-specific repair
+- use `review` after material issue or narrative changes and `iteration` only
+  when model-assisted correction is appropriate
+
+Update evidence is monotonic: ordinary updates merge source lists and preserve
+existing citations. An obsolete URL must be removed explicitly. Confirmed HTTP
+404/410 candidate sources are removed deterministically and tombstoned so
+baseline restoration cannot reintroduce them.
+
+### Economy versus quality models
+
+`cheap_mode=true` is the default for routine and targeted work. It selects the
+economy model profile but does not bypass review or quality gates. Set
+`cheap_mode=false` only when intentionally using a non-economy profile. Model
+overrides should be exceptional and recorded in the run note.
+
+The largest update cost drivers are issue research across every
+candidate/issue pair and repeated whole-profile review. A narrow research step
+can still be expensive when the complete review packet is sent to three
+reviewers before and after iteration. Prefer one well-specified targeted run
+over a sequence of speculative reruns.
+
+### Post-primary decision rule
+
+Verify the general-election roster against official candidate lists or official
+primary results before queueing:
+
+- use fresh research when the profile mixes offices, retains primary losers,
+  treats running mates as candidates, or otherwise has an untrustworthy roster
+- pass a verified `candidate_names` list to constrain the repair
+- use an update when the roster and issue record are usable but finance,
+  polling, forecast, images, voter resources, or current metadata are aging
+- election returns are roster evidence, never opinion polling
+- keep both outputs as drafts until the roster and refreshed fields are
+  reviewed
+
+The admin Batch Queue dialog opens on the low-cost update preset. **All on**
+restores the complete step set, **Update default** restores the maintenance
+preset, and **Discovery only** isolates roster/metadata work. `force_fresh`
+changes baseline loading but does not silently change an explicit step list.
+
+## Queueing Through MCP
+
+Common tools:
+
+- `queue_races`: one or more races with full options
+- `run_race`: one race
+- `list_active_runs`, `get_queue`: queue/worker state
+- `get_run`, `get_run_logs`: status and cursor-based logs
+- `get_race_data(draft=true)`: inspect output
+- `publish_race`, `publish_races`: publish only after approval
+- `get_pipeline_metrics`, `get_pipeline_metrics_summary`: cost reporting
+
+Example targeted update:
+
+```json
+{
+  "race_ids": ["ca-house-03-2026"],
+  "runner": "local",
+  "cheap_mode": true,
+  "baseline_source": "latest",
+  "candidate_names": ["Candidate One", "Candidate Two"],
+  "enabled_steps": [
+    "discovery",
+    "images",
+    "finance",
+    "refinement",
+    "polling",
+    "forecast",
+    "voter_resources"
+  ],
+  "goal": "Refresh time-sensitive non-issue fields while preserving the verified roster and issue evidence.",
+  "note": "Low-cost post-primary maintenance update",
+  "save_artifact": true
+}
+```
+
+Example fresh cloud run:
+
+```json
+{
+  "race_ids": ["state-house-00-2026"],
+  "runner": "cloud_run",
+  "cheap_mode": true,
+  "force_fresh": true,
+  "enabled_steps": [
+    "discovery",
+    "images",
+    "issues",
+    "finance",
+    "refinement",
+    "polling",
+    "forecast",
+    "voter_resources",
+    "review",
+    "iteration"
+  ],
+  "goal": "Build and validate a complete current profile.",
+  "save_artifact": true
+}
+```
+
+Use `debug_mode` for a small diagnostic run when investigating cost, retries,
+handoffs, or context behavior. Debug mode increases observability, not quality,
+and does not reduce cost.
+
+## Monitoring
+
+Track the returned `run_id`, not only the queue item ID.
+
+1. Confirm the item moves from `pending` to `running`.
+2. Inspect `current_step`, overall progress, step progress, and
+   `progress_updated_at`.
+3. Fetch logs with the opaque `next_cursor`; do not repeatedly download the
+   entire log history.
+4. Treat a long research/tool call as active when logs and progress timestamps
+   continue moving.
+5. On terminal status, inspect `completed_at`, error data, draft output, and
+   `agent_metrics`.
+
+Do not leave required command sessions or runs unobserved. A queue dispatch can
+fail before job start; a worker can lose its lease; a job can complete without a
+publishable draft.
+
+For diagnostics, download
+`GET /runs/{run_id}/diagnostics` or use **Export diagnostics** in the admin UI.
+The sanitized `smartervote.pipeline-diagnostics.v1` bundle includes run, queue,
+logs, timeline, catalog data, draft, and computed quality summary. It excludes
+raw prompts, model responses, fetched page bodies, and secrets.
+
+## Detailed Quality Review
+
+Review the draft, not only run logs.
+
+### Race and roster
+
+- office, district, election date, and contest stage are correct
+- candidate roster matches authoritative current-cycle sources
+- incumbent status means the exact office being contested
+- withdrawn, defeated, or prior-cycle candidates are absent
+
+### Candidates and evidence
+
+- every candidate has a supported summary
+- all 12 canonical issues exist
+- every substantive stance has at least one reliable source
+- a documented absence uses the canonical no-public-position wording
+- finance and voting/public-record narratives have their own sources
+- source URLs belong to the correct candidate
+- update source counts have not regressed unexpectedly
+
+### Polling and forecast
+
+- pollster is real and named, never `Example`, `Unknown`, or a placeholder
+- election/primary results are not stored as polls
+- matchup names match the roster exactly
+- forecast poll count agrees with accepted polling
+- years served are not confused with completed terms
+- forecast rationale, winner, probabilities, margin, rating, and cited inputs
+  are internally consistent
+
+### Reviews
+
+- all model reviewer verdicts and flags are examined
+- automated link validator has no warning/error
+- automated profile-quality validator has no warning/error
+- `validation_grade.passed` is true
+- grade is recomputed after deterministic validators
+
+If any warning/error remains, do not publish. Repair the cause and rerun the
+smallest sufficient steps.
+
+## Publication
+
+Publishing copies the approved draft into the published GCS race path, updates
+the summaries index/catalog, and removes or supersedes draft state according to
+the API implementation.
+
+Before publish:
+
+1. Fetch the final draft again.
+2. Confirm candidate/source counts, forecast semantics, polling, reviews, and
+   grade.
+3. Confirm the run being reviewed is the latest run for that draft.
+4. Record its costs.
+5. Publish through `races-api`/MCP, never by manually copying JSON.
+
+After publish:
+
+1. Fetch with `draft=false`.
+2. Confirm the published payload matches the approved draft.
+3. Confirm the race is absent from unpublished-draft listings.
+4. Verify the public/static-data path after the web deployment when applicable.
+
+## Cost Accounting
+
+The authoritative per-run model/search fields are under `agent_metrics`:
+
+- `llm_cost_usd`: provider-reported model cost
+- `search_cost_usd`: metered search cost
+- `cost_usd`: combined provider model plus search cost
+- `cost_source`: `provider` or `estimated`
+- `estimated_usd`: catalog estimate for comparison/fallback
+- prompt, completion, and total tokens
+- `serper_calls`, model breakdown, duration, context, retry, and review metrics
+
+Use `cost_usd` as the API total when present. Do not add `llm_cost_usd` and
+`search_cost_usd` to it again. If `cost_usd` is absent, report the estimate and
+label it estimated.
+
+Cloud compute is separate. Obtain attributable Cloud Run/other GCP spend from
+the billing export or `/pipeline/gcp-costs`; local worker compute is not a GCP
+charge. Report:
+
+```text
+run API cost = agent_metrics.cost_usd
+cloud infrastructure cost = attributable billed/estimated GCP compute
+run all-in cost = API cost + cloud infrastructure cost
+multi-run total = sum of each all-in cost
+```
+
+The metrics API reconciles `pipeline_metrics` with `pipeline_runs` by `run_id`
+so recent runs are not hidden by a populated but stale cost collection. It
+supports both top-level and payload-nested legacy `agent_metrics` layouts.
+
+When comparing update versus fresh cost, include:
+
+- enabled steps and candidate count
+- total tokens and search calls
+- number and models of review calls
+- whether iteration caused a second full review packet
+- runner and cloud compute
+- failed/diagnostic attempts, reported separately from successful runs
+
+Firestore cost is bounded independently of model/search cost:
+
+- active log polling uses the opaque `next_cursor` and reads only newer logs
+- routine progress writes are coalesced; step boundaries and terminal state
+  still write immediately
+- live and per-run log buffers are capped and long messages are truncated
+- diagnostics exports read at most 2,000 log documents and report truncation
+- retention defaults expire completed queue records, checkpoints, debug
+  artifacts, and run logs instead of retaining them indefinitely
+
+Do not poll from the beginning with numeric `since`, repeatedly stream full
+collections, or enable debug capture for broad batches.
+
+## Known Update-Run Optimization Opportunities
+
+The low-cost step default removes the largest avoidable phases, but update
+discovery can still spend multiple model iterations proving that a recent
+baseline has not changed. Improvements should be implemented in this order:
+
+1. Add deterministic staleness gates per field so a recent image, voter link,
+   finance snapshot, or forecast can be skipped without an LLM call.
+2. Check official roster/results feeds before invoking open-ended discovery;
+   stop roster work early when the verified names and contest stage are
+   unchanged.
+3. Use source-specific deterministic adapters for FEC/state finance and polling
+   catalogs, then ask the model only to interpret changed records.
+4. Build a compact baseline delta packet instead of repeatedly sending the
+   whole profile to metadata/refinement agents.
+5. Persist per-step fingerprints, source access times, and no-change outcomes
+   so subsequent runs can make explainable skip decisions.
+6. Run review only for changed sections and only when a publication-quality
+   decision needs it; retain the deterministic quality gate for all drafts.
+
+Measure each improvement with debug diagnostics: wall time, iterations, model
+calls, prompt/completion tokens, search calls, Firestore writes/reads, changed
+fields, and quality findings. A cheaper no-op update is successful only if it
+preserves roster correctness and evidence.
+
+## Deployment and Runtime Verification
+
+Normal deployment is CI/Terraform; see `docs/deployment-guide.md`. For an
+explicit development hotfix, build immutable worker/API tags from the same
+source state, push both, update the Cloud Run job/service, and record the
+revision. Do not deploy a dirty tree accidentally.
+
+Required verification:
+
+```powershell
+pytest -q
+docker compose -f docker-compose.worker.yml up -d --build
+docker compose -f docker-compose.worker.yml ps
+```
+
+Smoke-test the API image before deployment:
+
+```powershell
+docker run --rm <races-api-image> python -c "import main; import gcs_helpers"
+```
+
+After deployment:
+
+- Cloud Run service routes 100% traffic to the intended revision
+- Cloud Run job points at the intended worker image digest
+- `/health` and `/health/ready` pass
+- metrics endpoints return current runs and costs
+- one bounded run succeeds through the intended runner
+
+## Failure Recovery
+
+### Pending local item
+
+- verify the local worker container is running
+- verify it was rebuilt from current source
+- confirm the item has `runner=local`
+- inspect worker logs and GCP credentials
+
+### Cloud dispatch failure
+
+- inspect queue `dispatch_status` and operation/error fields
+- verify job name, region, image, and service-account permission to execute with
+  overrides
+- do not mark the run failed solely from an HTTP client timeout if a Cloud Run
+  operation was created
+
+### Stalled or expired run
+
+- check lease and progress timestamps
+- inspect cursor-based logs and Cloud Run execution state
+- let the queue processor reclaim an expired lease when safe
+- cancel only when the active execution is known not to be writing
+
+### Bad draft
+
+- keep it unpublished
+- state the concrete blocking findings
+- use `baseline_source=latest` for a targeted repair unless the bad draft itself
+  must be ignored
+- avoid repeating full discovery when only finance, sourcing, polling, forecast,
+  or review needs repair
+
+### Cost discrepancy
+
+- compare draft `agent_metrics`, run document, and `pipeline_metrics` record by
+  `run_id`
+- check both legacy agent-metrics layouts
+- verify `cost_usd` includes search before summing components
+- distinguish API spend from GCP compute and from failed attempts

--- a/docs/pipeline-result-quality-plan.md
+++ b/docs/pipeline-result-quality-plan.md
@@ -2,6 +2,11 @@
 
 Last reviewed: 2026-07-26.
 
+Delivered operational behavior is documented in
+[`pipeline-operations.md`](pipeline-operations.md) and
+[`PIPELINE_MODES.md`](../PIPELINE_MODES.md). This file remains the roadmap for
+quality work that is still proposed.
+
 ## Objective
 
 Improve the correctness of published race data by changing how the research

--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -28,7 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared.pipeline_config import PIPELINE_STEP_IDS, REVIEW_PROVIDERS, PipelineRuntimeConfig
+from shared.pipeline_config import DEFAULT_UPDATE_PIPELINE_STEPS, PIPELINE_STEP_IDS, REVIEW_PROVIDERS, PipelineRuntimeConfig
 
 from .ballotpedia import default_ballotpedia_race_url
 from .cost import _cost_ctx, estimate_cost
@@ -651,7 +651,7 @@ async def run_agent(
 
     # Step enablement check - None means all enabled
     _all_steps = set(PIPELINE_STEP_IDS)
-    _enabled = set(enabled_steps) if enabled_steps else _all_steps
+    _enabled = set(enabled_steps) if enabled_steps else set(_all_steps)
 
     def _step_enabled(step: str) -> bool:
         return step in _enabled
@@ -691,6 +691,9 @@ async def run_agent(
     if existing_data is None:
         existing_data = _load_existing(race_id)
     baseline_existing_data = copy.deepcopy(existing_data) if isinstance(existing_data, dict) else None
+    if existing_data and enabled_steps is None:
+        _enabled = set(DEFAULT_UPDATE_PIPELINE_STEPS)
+        log("info", "Using low-cost update steps; issue research and review are opt-in")
 
     if existing_data:
         log("info", f"Update mode for {race_id} (profile={profile}, model={model}, small_model={small_model})")

--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -359,6 +359,8 @@ async def check_profile_links(
 
 def _remove_confirmed_dead_candidate_sources(race_json: Dict[str, Any], link_review: Dict[str, Any]) -> int:
     """Remove candidate URLs that the link validator confirmed as HTTP 404/410."""
+    if not isinstance(link_review, dict):
+        return 0
     removals: Dict[int, set[str]] = {}
     for flag in link_review.get("flags") or []:
         if not isinstance(flag, dict):

--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -357,6 +357,54 @@ async def check_profile_links(
     }
 
 
+def _remove_confirmed_dead_candidate_sources(race_json: Dict[str, Any], link_review: Dict[str, Any]) -> int:
+    """Remove candidate URLs that the link validator confirmed as HTTP 404/410."""
+    removals: Dict[int, set[str]] = {}
+    for flag in link_review.get("flags") or []:
+        if not isinstance(flag, dict):
+            continue
+        concern = str(flag.get("concern") or "")
+        if "HTTP error 404" not in concern and "HTTP error 410" not in concern:
+            continue
+        field_match = re.match(r"candidates\[(\d+)\]", str(flag.get("field") or ""))
+        url_match = re.search(r"Cited source URL \((https?://[^)]+)\)", concern)
+        if field_match and url_match:
+            removals.setdefault(int(field_match.group(1)), set()).add(url_match.group(1))
+
+    removed = 0
+    candidates = race_json.get("candidates") or []
+    for candidate_index, urls in removals.items():
+        if candidate_index >= len(candidates) or not isinstance(candidates[candidate_index], dict):
+            continue
+        candidate = candidates[candidate_index]
+        for key in ("roster_sources", "summary_sources", "donor_sources", "voting_sources", "links"):
+            items = candidate.get(key)
+            if isinstance(items, list):
+                kept = [item for item in items if not (isinstance(item, dict) and str(item.get("url") or "").strip() in urls)]
+                removed += len(items) - len(kept)
+                candidate[key] = kept
+        for key in ("donor_source_url", "voting_source_url"):
+            if str(candidate.get(key) or "").strip() in urls:
+                candidate[key] = None
+                removed += 1
+        for issue in (candidate.get("issues") or {}).values():
+            if not isinstance(issue, dict) or not isinstance(issue.get("sources"), list):
+                continue
+            sources = issue["sources"]
+            kept = [item for item in sources if not (isinstance(item, dict) and str(item.get("url") or "").strip() in urls)]
+            removed += len(sources) - len(kept)
+            issue["sources"] = kept
+
+        pipeline_state = race_json.setdefault("pipeline_state", {})
+        tombstones = pipeline_state.setdefault("removed_source_urls", [])
+        candidate_name = str(candidate.get("name") or "").strip()
+        for url in urls:
+            tombstone = {"candidate_name": candidate_name, "url": url}
+            if tombstone not in tombstones:
+                tombstones.append(tombstone)
+    return removed
+
+
 def _is_documented_absence(stance: str) -> bool:
     normalized = stance.casefold()
     return "no public position found" in normalized or "no publicly stated position" in normalized
@@ -638,6 +686,14 @@ async def run_reviews(
     cached_deterministic = cache.get(packet_key)
     if cached_deterministic is None:
         link_review = await check_profile_links(race_json, on_log=on_log, run_budget=run_budget)
+        removed_dead_sources = _remove_confirmed_dead_candidate_sources(race_json, link_review)
+        if removed_dead_sources:
+            if on_log:
+                on_log(
+                    "warning",
+                    f"Removed {removed_dead_sources} candidate source occurrence(s) confirmed dead by HTTP status.",
+                )
+            link_review = await check_profile_links(race_json, on_log=on_log, run_budget=run_budget)
         quality_review = check_profile_quality(race_json)
         cached_deterministic = {
             "link_review": copy.deepcopy(link_review),

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -131,21 +131,6 @@ class AgentHandler:
 
         logger.info(f"Agent: researching race {race_id} (cheap_mode={cheap_mode})")
 
-        # Resolve enabled steps: explicit list > derive from options > all
-        if enabled_steps_raw:
-            enabled_steps = [s for s in enabled_steps_raw if s in {e.value for e in PipelineStep}]
-        else:
-            enabled_steps = list(ALL_STEPS)
-        enabled_set = set(enabled_steps)
-        all_enabled_steps_raw = options.get("all_enabled_steps")
-        if all_enabled_steps_raw:
-            all_enabled_steps = [s for s in all_enabled_steps_raw if s in {e.value for e in PipelineStep}]
-        elif options.get("is_continuation"):
-            all_enabled_steps = list(ALL_STEPS)
-        else:
-            all_enabled_steps = list(enabled_steps)
-        all_enabled_set = set(all_enabled_steps)
-
         # Pre-load existing data. Continuation runs receive checkpoint data from
         # the Cloud Function payload; that is more precise than drafts/races GCS.
         # It must win over force_fresh, otherwise fresh runs restart from
@@ -159,6 +144,29 @@ class AgentHandler:
             existing_data = await self._load_existing_from_gcs(
                 race_id, baseline_source=options.get("baseline_source", "latest")
             )
+
+        # Resolve enabled steps only after baseline loading so an unspecified
+        # step list can distinguish a genuine update from new research.
+        if enabled_steps_raw:
+            enabled_steps = [s for s in enabled_steps_raw if s in {e.value for e in PipelineStep}]
+        elif existing_data:
+            from shared.pipeline_config import DEFAULT_UPDATE_PIPELINE_STEPS
+
+            enabled_steps = list(DEFAULT_UPDATE_PIPELINE_STEPS)
+            options["enabled_steps"] = enabled_steps
+            logger.info("Agent: using low-cost update steps (issue research and review are opt-in)")
+        else:
+            enabled_steps = list(ALL_STEPS)
+        enabled_set = set(enabled_steps)
+        all_enabled_steps_raw = options.get("all_enabled_steps")
+        if all_enabled_steps_raw:
+            all_enabled_steps = [s for s in all_enabled_steps_raw if s in {e.value for e in PipelineStep}]
+        elif options.get("is_continuation"):
+            all_enabled_steps = list(ALL_STEPS)
+        else:
+            all_enabled_steps = list(enabled_steps)
+        all_enabled_set = set(all_enabled_steps)
+
         configured_baseline_names = options.get("verified_baseline_candidate_names")
         if isinstance(configured_baseline_names, list):
             verified_baseline_candidate_names = {

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -146,6 +146,7 @@ FRONTEND_ONLY_OR_OTHER_BACKEND_TYPES: Dict[str, str] = {
     "RunStatus": "Mirrors pipeline_client/backend/models.py run-status string literals used by RunInfo/RunStep; not part of shared/models.py.",
     "PipelineStepId": "Mirrors shared/pipeline_config.py:PIPELINE_STEP_IDS; checked separately by check_pipeline_step_ids().",
     "PIPELINE_STEPS": "Derived const array; checked separately by check_pipeline_step_ids().",
+    "DEFAULT_UPDATE_PIPELINE_STEP_IDS": "Derived const array mirroring shared/pipeline_config.py:DEFAULT_UPDATE_PIPELINE_STEPS; checked separately by check_pipeline_step_ids().",
     "RunStep": "Mirrors pipeline_client/backend/models.py:RunStep (pipeline run progress), not shared/models.py.",
     "RunInfo": "Mirrors pipeline_client/backend/models.py:RunInfo (pipeline run progress), not shared/models.py.",
     "Artifact": "Mirrors pipeline_client/backend/models.py artifact listing shape; not part of shared/models.py.",
@@ -625,6 +626,23 @@ def check_pipeline_step_ids(ts_source: str) -> List[str]:
         violations.append(
             f"[PIPELINE_STEPS] labels mismatch vs shared.pipeline_config.PIPELINE_STEP_LABELS: ts={ts_labels} python={pipeline_config.PIPELINE_STEP_LABELS}"
         )
+
+    update_opt_in_match = re.search(
+        r"const UPDATE_OPT_IN_STEPS[^=]*=\s*new Set<PipelineStepId>\(\s*\[(.*?)\]\s*\)",
+        ts_source,
+        re.DOTALL,
+    )
+    if not update_opt_in_match:
+        violations.append("[DEFAULT_UPDATE_PIPELINE_STEP_IDS] could not find UPDATE_OPT_IN_STEPS in types.ts")
+    else:
+        ts_opt_in = set(re.findall(r'"([^"]+)"', update_opt_in_match.group(1)))
+        expected_opt_in = set(pipeline_config.PIPELINE_STEP_IDS) - set(pipeline_config.DEFAULT_UPDATE_PIPELINE_STEPS)
+        if ts_opt_in != expected_opt_in:
+            violations.append(
+                "[DEFAULT_UPDATE_PIPELINE_STEP_IDS] opt-in steps mismatch vs "
+                f"shared.pipeline_config.DEFAULT_UPDATE_PIPELINE_STEPS: ts={sorted(ts_opt_in)} "
+                f"expected={sorted(expected_opt_in)}"
+            )
     return violations
 
 

--- a/services/races-api/Dockerfile
+++ b/services/races-api/Dockerfile
@@ -27,8 +27,11 @@ COPY services/races-api/routers ./routers
 COPY shared /app/shared
 COPY pipeline_client/__init__.py /app/pipeline_client/__init__.py
 COPY pipeline_client/logging_utils.py /app/pipeline_client/logging_utils.py
-# data/published is NOT baked into the image — deployed instances read from GCS.
-# For local dev, mount or copy data/published manually.
+COPY pipeline_client/backend/__init__.py /app/pipeline_client/backend/__init__.py
+COPY pipeline_client/backend/pipeline_metrics.py /app/pipeline_client/backend/pipeline_metrics.py
+
+# data/published is not baked into the image; deployed instances read from GCS.
+# For local development, mount or copy data/published manually.
 RUN mkdir -p /app/data/published
 
 RUN useradd --create-home --shell /usr/sbin/nologin app \

--- a/shared/pipeline_config.py
+++ b/shared/pipeline_config.py
@@ -22,6 +22,20 @@ PIPELINE_STEP_ORDER: tuple[str, ...] = (
 )
 PIPELINE_STEP_IDS = frozenset(PIPELINE_STEP_ORDER)
 
+# Existing profiles should get a targeted maintenance pass by default. Issue
+# research and multi-model review remain explicit opt-ins because they dominate
+# update-run cost and are unnecessary when the existing issue record is being
+# preserved.
+DEFAULT_UPDATE_PIPELINE_STEPS: tuple[str, ...] = (
+    "discovery",
+    "images",
+    "finance",
+    "refinement",
+    "polling",
+    "forecast",
+    "voter_resources",
+)
+
 PIPELINE_STEP_LABELS: dict[str, str] = {
     "discovery": "Discovery",
     "images": "Image Resolution",

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -977,7 +977,7 @@ def test_add_poll_allows_source_only_poll_but_rejects_incomplete_matchups():
     )
     missing = handlers["add_poll"](
         {
-            "pollster": "Example Poll",
+            "pollster": "Reliable Research",
             "date": "2026-06-01",
             "matchups": [{"candidates": ["Alice Smith", "Bob Jones"]}],
             "source_url": "https://example.com/poll",
@@ -985,7 +985,7 @@ def test_add_poll_allows_source_only_poll_but_rejects_incomplete_matchups():
     )
     mismatched = handlers["add_poll"](
         {
-            "pollster": "Example Poll",
+            "pollster": "Reliable Research",
             "date": "2026-06-01",
             "matchups": [{"candidates": ["Alice Smith", "Bob Jones"], "percentages": [48]}],
             "source_url": "https://example.com/poll",

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -115,6 +115,37 @@ async def test_v2_handler_passes_enabled_steps():
 
 
 @pytest.mark.asyncio
+async def test_v2_handler_defaults_updates_to_low_cost_non_issue_steps():
+    """An existing baseline gets maintenance steps unless the caller opts in."""
+    handler = AgentHandler()
+    existing = {"id": "test-race", "candidates": [{"name": "Alice", "issues": {}}]}
+
+    with (
+        patch.object(handler, "_load_existing_from_gcs", new_callable=AsyncMock, return_value=existing),
+        patch("pipeline_client.agent.agent.run_agent", new_callable=AsyncMock) as mock_agent,
+        patch.object(handler, "_save_draft", new_callable=AsyncMock) as mock_save_draft,
+    ):
+        mock_agent.return_value = existing
+        mock_save_draft.return_value = Path("/tmp/test-race.json")
+
+        await handler.handle({"race_id": "test-race"}, {"cheap_mode": True})
+
+    enabled_steps = mock_agent.call_args.kwargs["enabled_steps"]
+    assert enabled_steps == [
+        "discovery",
+        "images",
+        "finance",
+        "refinement",
+        "polling",
+        "forecast",
+        "voter_resources",
+    ]
+    assert "issues" not in enabled_steps
+    assert "review" not in enabled_steps
+    assert "iteration" not in enabled_steps
+
+
+@pytest.mark.asyncio
 async def test_v2_handler_uses_run_id_for_firestore_logs_when_pipeline_import_fails():
     """run_id from options should still drive Firestore logging if optional imports fail."""
     handler = AgentHandler()

--- a/tests/test_pipeline_quality_regressions.py
+++ b/tests/test_pipeline_quality_regressions.py
@@ -3,7 +3,11 @@
 from pipeline_client.agent.evidence import merge_source_lists, preserve_baseline_evidence
 from pipeline_client.agent.handlers import _make_editing_handlers
 from pipeline_client.agent.polling_quality import polling_semantic_problem
-from pipeline_client.agent.review import check_profile_quality, compute_validation_grade
+from pipeline_client.agent.review import (
+    _remove_confirmed_dead_candidate_sources,
+    check_profile_quality,
+    compute_validation_grade,
+)
 
 
 def _source(url: str) -> dict:
@@ -178,3 +182,33 @@ def test_quality_check_flags_implausible_house_term_count():
     review = check_profile_quality(race)
 
     assert any(flag["field"] == "forecast.rationale" and flag["severity"] == "error" for flag in review["flags"])
+
+
+def test_confirmed_dead_candidate_source_is_removed_and_tombstoned():
+    dead_url = "https://example.test/dead"
+    race = {
+        "candidates": [
+            {
+                "name": "Alice",
+                "summary_sources": [_source(dead_url)],
+                "donor_sources": [_source(dead_url)],
+                "issues": {},
+            }
+        ]
+    }
+    review = {
+        "flags": [
+            {
+                "field": "candidates[0].summary_sources[0].url",
+                "concern": f"Cited source URL ({dead_url}) returned a dead link: HTTP error 404.",
+                "severity": "warning",
+            }
+        ]
+    }
+
+    removed = _remove_confirmed_dead_candidate_sources(race, review)
+
+    assert removed == 2
+    assert race["candidates"][0]["summary_sources"] == []
+    assert race["candidates"][0]["donor_sources"] == []
+    assert race["pipeline_state"]["removed_source_urls"] == [{"candidate_name": "Alice", "url": dead_url}]

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1,6 +1,7 @@
 """Tests for run_agent orchestration and _load_existing helper."""
 
 import asyncio
+import copy
 import json
 import os
 import re
@@ -19,6 +20,7 @@ from pipeline_client.agent.phases import (
 )
 from pipeline_client.agent.prompts import CANONICAL_ISSUES
 from pipeline_client.backend.handlers.agent import HandoffTriggered
+from shared.pipeline_config import PIPELINE_STEP_IDS
 
 
 @pytest.fixture(autouse=True)
@@ -514,6 +516,34 @@ async def test_discovery_only_update_uses_update_discovery_phases():
         "roster-verify",
         "update-meta",
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_defaults_existing_profile_to_low_cost_update_steps():
+    existing = {
+        "id": "maintenance-2026",
+        "candidates": [{"name": "Alice", "issues": {}}],
+        "updated_utc": "2026-07-20T00:00:00Z",
+    }
+    observed = {}
+
+    async def fake_update(*_args, step_enabled, **_kwargs):
+        for step in PIPELINE_STEP_IDS:
+            observed[step] = step_enabled(step)
+        return copy.deepcopy(existing)
+
+    with (
+        patch("pipeline_client.agent.agent._run_update", side_effect=fake_update),
+        patch("pipeline_client.agent.agent.run_reviews", new_callable=AsyncMock) as mock_reviews,
+    ):
+        await run_agent("maintenance-2026", cheap_mode=True, existing_data=existing)
+
+    assert observed["discovery"] is True
+    assert observed["voter_resources"] is True
+    assert observed["issues"] is False
+    assert observed["review"] is False
+    assert observed["iteration"] is False
+    mock_reviews.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/web/src/lib/components/admin/BatchQueueModal.svelte
+++ b/web/src/lib/components/admin/BatchQueueModal.svelte
@@ -10,7 +10,10 @@
   } from "$lib/config/pipelineOptions";
   import { PipelineApiService } from "$lib/services/pipelineApiService";
   import type { RunOptions } from "$lib/types";
-  import { PIPELINE_STEPS } from "$lib/types";
+  import {
+    DEFAULT_UPDATE_PIPELINE_STEP_IDS,
+    PIPELINE_STEPS,
+  } from "$lib/types";
   import { racesApiBase } from "$lib/config/api";
 
   export let open = false;
@@ -30,7 +33,10 @@
   let targetNoInfo = false;
   let debugMode = false;
   let stepToggles: Record<string, boolean> = Object.fromEntries(
-    PIPELINE_STEPS.map((s) => [s.id, true]),
+    PIPELINE_STEPS.map((s) => [
+      s.id,
+      DEFAULT_UPDATE_PIPELINE_STEP_IDS.includes(s.id),
+    ]),
   );
   let researchModel = "";
 
@@ -238,6 +244,16 @@
                   });
                   stepToggles = stepToggles;
                 }}>All on</button
+              >
+              <button
+                type="button"
+                on:click={() => {
+                  PIPELINE_STEPS.forEach((s) => {
+                    stepToggles[s.id] =
+                      DEFAULT_UPDATE_PIPELINE_STEP_IDS.includes(s.id);
+                  });
+                  stepToggles = stepToggles;
+                }}>Update default</button
               >
               <button
                 type="button"

--- a/web/src/lib/components/admin/BatchQueueModal.svelte
+++ b/web/src/lib/components/admin/BatchQueueModal.svelte
@@ -10,10 +10,7 @@
   } from "$lib/config/pipelineOptions";
   import { PipelineApiService } from "$lib/services/pipelineApiService";
   import type { RunOptions } from "$lib/types";
-  import {
-    DEFAULT_UPDATE_PIPELINE_STEP_IDS,
-    PIPELINE_STEPS,
-  } from "$lib/types";
+  import { DEFAULT_UPDATE_PIPELINE_STEP_IDS, PIPELINE_STEPS } from "$lib/types";
   import { racesApiBase } from "$lib/config/api";
 
   export let open = false;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -400,6 +400,16 @@ export const PIPELINE_STEPS: {
   { id: "iteration", label: "Review Iteration", weight: 8 },
 ];
 
+const UPDATE_OPT_IN_STEPS = new Set<PipelineStepId>([
+  "issues",
+  "review",
+  "iteration",
+]);
+export const DEFAULT_UPDATE_PIPELINE_STEP_IDS: PipelineStepId[] =
+  PIPELINE_STEPS.filter((step) => !UPDATE_OPT_IN_STEPS.has(step.id)).map(
+    (step) => step.id,
+  );
+
 export interface RunOptions {
   save_artifact?: boolean;
   note?: string;


### PR DESCRIPTION
## What changed

- resolves the pulled pipeline-quality work with local evidence-preservation, dead-link cleanup, API image, and regression changes
- makes existing-profile updates default to a low-cost maintenance scope: discovery, images, finance, refinement, polling, forecast, and voter resources
- keeps issue research plus multi-model review/iteration explicit opt-ins for updates
- exposes the same update preset in the admin batch queue UI
- adds direct-agent and worker regression coverage
- adds a canonical pipeline operations runbook and updates mode/quality documentation with post-primary selection, monitoring, publication safety, cost accounting, Firestore bounds, recovery, diagnostics, and optimization opportunities

## Why

Routine update runs were paying for issue research and whole-profile multi-model review even when the baseline issue record was usable. Live post-primary runs also showed metadata discovery spending several iterations proving that a recent baseline had not changed. The new default removes the largest avoidable phases while preserving explicit control and existing evidence.

## User/developer impact

- ordinary updates are cheaper by default
- fresh races with no baseline still run the full pipeline unless steps are explicitly selected
- operators have one canonical runbook for queueing through publication and recovery
- research still writes drafts only; publishing remains a separate authenticated action

## Validation

- `pytest tests/test_run_agent.py tests/test_shared_config.py tests/test_pipeline_options.py -q` — 97 passed
- `pytest tests/test_editing_tools.py tests/test_gcs_publish_gate.py tests/test_pipeline_quality_regressions.py tests/test_handlers.py -q` — 72 passed
- two focused new default tests — 2 passed
- `npm run check` — 0 errors, 0 warnings
- pre-commit isort, black, whitespace, secret, YAML/JSON, conflict, and symlink hooks passed