### PR TITLE
Finish pipeline metrics and responsive UI fixes

### DIFF
--- a/pipeline_client/backend/pipeline_metrics.py
+++ b/pipeline_client/backend/pipeline_metrics.py
@@ -48,8 +48,11 @@ class PipelineMetricsStore:
     _COLLECTION = "pipeline_metrics"
 
     def __init__(self) -> None:
+        explicit_db_path = os.getenv("PIPELINE_METRICS_DB_PATH")
         self._firestore_project = os.getenv("FIRESTORE_PROJECT")
-        self._db_path = os.getenv("PIPELINE_METRICS_DB_PATH", str(local_paths.metrics_db_path))
+        if not self._firestore_project and not explicit_db_path:
+            self._firestore_project = os.getenv("GOOGLE_CLOUD_PROJECT")
+        self._db_path = explicit_db_path or str(local_paths.metrics_db_path)
         self._client = None
 
         if self._firestore_project:

--- a/pipeline_client/backend/storage_backend.py
+++ b/pipeline_client/backend/storage_backend.py
@@ -108,7 +108,7 @@ class GCPStorageBackend:
 
     def __init__(self, bucket: str, firestore_project: str | None = None) -> None:
         try:
-            from google.cloud import storage
+            storage = __import__("google.cloud.storage", fromlist=["Client"])
         except Exception as e:  # pragma: no cover - import guard
             raise RuntimeError("google-cloud-storage is required for GCP storage") from e
 

--- a/pipeline_client/worker.py
+++ b/pipeline_client/worker.py
@@ -113,8 +113,7 @@ def _get_db() -> Any:
 
 def _get_gcs() -> Any:
     try:
-        from google.cloud import storage  # type: ignore
-
+        storage = __import__("google.cloud.storage", fromlist=["Client"])
         return storage.Client()
     except Exception as exc:  # noqa: BLE001
         logger.warning("GCS client init failed: %s", exc)

--- a/services/races-api/routers/pipeline.py
+++ b/services/races-api/routers/pipeline.py
@@ -148,6 +148,27 @@ def _to_epoch_seconds(value: Any) -> float:
     return 0.0
 
 
+def _has_pipeline_cost_data(raw: Dict[str, Any]) -> bool:
+    """Return whether a heterogeneous run document carries usable cost data."""
+    payload = raw.get("payload") if isinstance(raw.get("payload"), dict) else {}
+    agent_metrics = raw.get("agent_metrics")
+    if not isinstance(agent_metrics, dict):
+        agent_metrics = payload.get("agent_metrics")
+    if not isinstance(agent_metrics, dict):
+        agent_metrics = {}
+    return any(
+        value is not None
+        for value in (
+            raw.get("cost_usd"),
+            raw.get("estimated_usd"),
+            raw.get("llm_cost_usd"),
+            agent_metrics.get("cost_usd"),
+            agent_metrics.get("estimated_usd"),
+            agent_metrics.get("llm_cost_usd"),
+        )
+    )
+
+
 def _compute_metrics_summary(records: list[Dict[str, Any]]) -> Dict[str, Any]:
     total_runs = len(records)
     successful_runs = 0
@@ -420,7 +441,7 @@ async def get_pipeline_metrics_summary(hours: Optional[int] = None) -> Dict[str,
         docs = db.collection("pipeline_runs").limit(5000).stream()
         for doc in docs:
             plain = firestore_helpers._doc_to_plain(doc)
-            if plain is None:
+            if plain is None or not _has_pipeline_cost_data(plain):
                 continue
             record = _normalize_pipeline_run(plain, doc.id)
             run_records[str(record["run_id"])] = record

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -3799,3 +3799,11 @@ def test_get_run_logs_cursor_reads_only_incremental_page():
     log_query.order_by.assert_called_once_with("__name__")
     log_query.start_after.assert_called_once_with({"__name__": "001"})
     log_query.limit.assert_called_once_with(2)
+
+
+def test_pipeline_cost_data_detection_ignores_status_only_runs():
+    from routers.pipeline import _has_pipeline_cost_data
+
+    assert not _has_pipeline_cost_data({"run_id": "status-only", "status": "completed", "started_at": "2026-07-01T00:00:00Z"})
+    assert _has_pipeline_cost_data({"run_id": "priced", "agent_metrics": {"cost_usd": 0.1}})
+    assert _has_pipeline_cost_data({"run_id": "legacy", "payload": {"agent_metrics": {"estimated_usd": 0.2}}})

--- a/web/e2e/frontend-smoke.e2e.ts
+++ b/web/e2e/frontend-smoke.e2e.ts
@@ -9,6 +9,9 @@ test("global navigation and search stay accessible and within the viewport", asy
   const search = page.getByRole("combobox", {
     name: "Search elections and candidates",
   });
+  if ((page.viewportSize()?.width ?? 0) < 640) {
+    await page.getByRole("button", { name: "Open search" }).click();
+  }
   await expect(search).toBeVisible();
   await expect(search).toHaveAttribute("aria-autocomplete", "list");
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -18,6 +18,7 @@
 /* ─── Semantic color tokens ─────────────────────────────────── */
 /* Light mode (default) */
 :root {
+  --site-header-height: 68px;
   --sv-page: 249 250 251; /* gray-50  — page background   */
   --sv-surface: 255 255 255; /* white    — cards & panels     */
   --sv-surface-alt: 243 244 246; /* gray-100 — subtle surfaces    */

--- a/web/src/lib/components/SiteHeader.svelte
+++ b/web/src/lib/components/SiteHeader.svelte
@@ -2,6 +2,7 @@
   import { browser } from "$app/environment";
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
+  import { onMount, tick } from "svelte";
   import type { RaceSummary } from "$lib/types";
   import { getRaceSummaries } from "$lib/api";
   import { candidateSlug } from "$lib/utils/format";
@@ -25,7 +26,24 @@
   let searchLoadError = false;
   let searchLoadPromise: Promise<void> | null = null;
   let mobileNavOpen = false;
+  let mobileSearchOpen = false;
+  let siteHeader: HTMLElement;
   const resultsId = "site-search-results";
+
+  onMount(() => {
+    const updateHeaderHeight = () => {
+      document.documentElement.style.setProperty(
+        "--site-header-height",
+        `${siteHeader.offsetHeight}px`,
+      );
+    };
+
+    updateHeaderHeight();
+    const resizeObserver = new ResizeObserver(updateHeaderHeight);
+    resizeObserver.observe(siteHeader);
+
+    return () => resizeObserver.disconnect();
+  });
 
   async function ensureSearchRaces() {
     if (!browser || searchLoaded || searchLoadPromise) return searchLoadPromise;
@@ -118,12 +136,14 @@
 
   function selectRace(id: string) {
     open = false;
+    mobileSearchOpen = false;
     query = "";
     goto(`/races/${id}`);
   }
 
   function selectCandidate(raceId: string, name: string) {
     open = false;
+    mobileSearchOpen = false;
     query = "";
     goto(`/races/${raceId}/${candidateSlug(name)}`);
   }
@@ -160,14 +180,31 @@
   }
 
   function handleWindowKeydown(event: KeyboardEvent) {
-    if (event.key === "Escape") mobileNavOpen = false;
+    if (event.key === "Escape") {
+      mobileNavOpen = false;
+      mobileSearchOpen = false;
+    }
     if (
       event.key === "/" &&
       !["INPUT", "TEXTAREA"].includes(document.activeElement?.tagName || "")
     ) {
       event.preventDefault();
+      mobileSearchOpen = true;
+      void tick().then(() => {
+        searchInput?.focus();
+        searchInput?.select();
+      });
+    }
+  }
+
+  async function toggleMobileSearch() {
+    mobileSearchOpen = !mobileSearchOpen;
+    mobileNavOpen = false;
+    if (mobileSearchOpen) {
+      await tick();
       searchInput?.focus();
-      searchInput?.select();
+    } else {
+      open = false;
     }
   }
 
@@ -188,17 +225,43 @@
 <svelte:window on:click={handleWindowClick} on:keydown={handleWindowKeydown} />
 
 <header
+  bind:this={siteHeader}
   class="sticky top-0 z-50 bg-surface/90 backdrop-blur-md shadow-sm border-b border-stroke/50"
 >
   <div class="container mx-auto max-w-7xl px-4 py-3">
-    <div class="flex flex-wrap items-center gap-3 lg:flex-nowrap">
+    <div class="flex flex-wrap items-center gap-1 sm:gap-3 lg:flex-nowrap">
       <a
         href="/"
-        class="mr-auto text-xl sm:text-2xl font-bold text-blue-600 hover:text-blue-700 whitespace-nowrap"
+        class="mr-auto text-xl sm:text-2xl font-bold text-primary hover:text-primary/80 whitespace-nowrap"
         aria-label="Smarter.Vote home"
       >
         Smarter.Vote
       </a>
+
+      <button
+        type="button"
+        class="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-muted hover:bg-surface-alt hover:text-content sm:hidden"
+        aria-label={mobileSearchOpen ? "Close search" : "Open search"}
+        aria-controls="site-search"
+        aria-expanded={mobileSearchOpen}
+        on:click={toggleMobileSearch}
+      >
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          class="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          {#if mobileSearchOpen}
+            <path stroke-linecap="round" d="M6 6l12 12M18 6L6 18" />
+          {:else}
+            <circle cx="11" cy="11" r="7" />
+            <path stroke-linecap="round" d="m16 16 4 4" />
+          {/if}
+        </svg>
+      </button>
 
       <button
         type="button"
@@ -208,7 +271,11 @@
           : "Open navigation menu"}
         aria-controls="primary-navigation"
         aria-expanded={mobileNavOpen}
-        on:click={() => (mobileNavOpen = !mobileNavOpen)}
+        on:click={() => {
+          mobileNavOpen = !mobileNavOpen;
+          mobileSearchOpen = false;
+          open = false;
+        }}
       >
         <span aria-hidden="true">{mobileNavOpen ? "×" : "☰"}</span>
       </button>
@@ -241,7 +308,9 @@
       </nav>
 
       <div
-        class="relative order-2 w-full sm:order-none sm:w-64 lg:w-72"
+        class="relative order-2 w-full {mobileSearchOpen
+          ? 'block'
+          : 'hidden'} sm:order-none sm:block sm:w-64 lg:w-72"
         bind:this={searchContainer}
       >
         <label class="sr-only" for="site-search"
@@ -257,7 +326,7 @@
             if (open) void ensureSearchRaces();
           }}
           on:keydown={handleKeydown}
-          class="min-h-11 w-full rounded-full border border-stroke bg-surface-alt py-2 pl-4 pr-9 text-sm text-content focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          class="min-h-11 w-full rounded-full border border-stroke bg-surface-alt py-2 pl-4 pr-12 text-sm text-content focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary"
           placeholder="Search elections or candidates"
           autocomplete="off"
           role="combobox"

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -145,8 +145,7 @@
   <div style="min-width: {(compact ? 170 : 220) + candidates.length * 250}px">
     <div
       class:sticky={!compact}
-      class:top-[57px]={!compact}
-      class:md:top-[65px]={!compact}
+      class:top-[var(--site-header-height)]={!compact}
       class="z-30 w-full border-b border-stroke bg-surface py-4 shadow-sm"
     >
       <div

--- a/web/src/lib/components/forecast/ForecastElectoralMap.svelte
+++ b/web/src/lib/components/forecast/ForecastElectoralMap.svelte
@@ -12,17 +12,28 @@
   export let onStateClick: (state: string) => void;
   export let onClearFilter: () => void;
 
+  $: stateOptions = [...activeStates].sort((a, b) => a.localeCompare(b));
+
   function handleStateClick(event: CustomEvent<string>) {
     onStateClick(event.detail);
+  }
+
+  function handleStateSelect(event: Event) {
+    const state = (event.currentTarget as HTMLSelectElement).value;
+    if (state) {
+      onStateClick(state);
+    } else {
+      onClearFilter();
+    }
   }
 </script>
 
 <!-- Map Canvas Card -->
 <div
-  class="bg-surface/60 border border-stroke rounded-2xl p-6 shadow-sm backdrop-blur-md flex flex-col min-h-[380px] h-full"
+  class="bg-surface/60 border border-stroke rounded-2xl p-4 sm:p-6 shadow-sm backdrop-blur-md flex flex-col min-h-[380px] h-full"
 >
   <div
-    class="flex items-center justify-between border-b border-stroke/40 pb-4 mb-4"
+    class="flex flex-col items-start justify-between gap-2 border-b border-stroke/40 pb-4 mb-4 sm:flex-row sm:items-center"
   >
     <div>
       <h2 class="text-lg font-bold text-content">Electoral Map</h2>
@@ -39,6 +50,28 @@
       </button>
     {/if}
   </div>
+
+  {#if stateOptions.length > 0}
+    <div class="mb-3 sm:hidden">
+      <label
+        for="forecast-state-select"
+        class="mb-1.5 block text-xs font-semibold text-content-muted"
+      >
+        Select a state
+      </label>
+      <select
+        id="forecast-state-select"
+        value={selectedState ?? ""}
+        on:change={handleStateSelect}
+        class="w-full rounded-lg border border-stroke bg-surface px-3 py-2 text-sm text-content focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        <option value="">All active states</option>
+        {#each stateOptions as state}
+          <option value={state}>{state} ({stateRaceCounts[state] ?? 0})</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
 
   <div
     class="relative w-full py-2 flex flex-1 items-center justify-center min-h-[320px]"

--- a/web/src/lib/components/forecast/ForecastElectoralMap.test.ts
+++ b/web/src/lib/components/forecast/ForecastElectoralMap.test.ts
@@ -67,4 +67,24 @@ describe("ForecastElectoralMap", () => {
 
     expect(props.onClearFilter).toHaveBeenCalledTimes(1);
   });
+
+  it("offers active states in a mobile selector and updates the filter", async () => {
+    const props = baseProps();
+    render(ForecastElectoralMap, {
+      activeTab: "house",
+      ...props,
+      activeStates: new Set(["Texas", "Delaware"]),
+      stateRaceCounts: { Texas: 3, Delaware: 1 },
+    });
+
+    const select = screen.getByLabelText("Select a state");
+    expect(screen.getByRole("option", { name: "Delaware (1)" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Texas (3)" })).toBeTruthy();
+
+    await fireEvent.change(select, { target: { value: "Delaware" } });
+    expect(props.onStateClick).toHaveBeenCalledWith("Delaware");
+
+    await fireEvent.change(select, { target: { value: "" } });
+    expect(props.onClearFilter).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
           faint: "rgb(var(--sv-text-faint) / <alpha-value>)",
         },
         primary: {
+          DEFAULT: "rgb(var(--sv-primary) / <alpha-value>)",
           50: "#eff6ff",
           500: "#3b82f6",
           600: "#2563eb",


### PR DESCRIPTION
## What changed
- use Firestore metrics automatically in GCP while preserving explicit local SQLite overrides
- make Google Cloud Storage imports reliable in worker/storage startup paths
- exclude status-only pipeline run documents from cost aggregation
- improve the mobile site header/search and keep comparison sticky offsets synchronized with the real header height
- add a mobile forecast state selector and regression coverage

## Why
These are the remaining validated changes from the pipeline cost audit and responsive UI work. The cost endpoint was mixing heterogeneous status documents into metrics, GCP defaults could fall back to a local metrics database, and mobile navigation/forecast controls needed more usable responsive behavior.

## Validation
- 196 focused Python tests passed
- `npm run check`
- `npm run lint`
- focused ForecastElectoralMap Vitest suite (4 tests)
- pre-commit formatting, secret, conflict, and integrity checks