### PR TITLE
Harden frontend deployment recovery

### DIFF
--- a/.github/workflows/cloudflare-deploy.yaml
+++ b/.github/workflows/cloudflare-deploy.yaml
@@ -213,6 +213,12 @@ jobs:
             curl --fail --silent --show-error --location --max-time 30 "$PUBLIC_SITE_URL$path" > /dev/null
           done
 
+      - name: Verify public JavaScript modules
+        env:
+          PUBLIC_SITE_URL: ${{ vars.PUBLIC_SITE_URL || 'https://smarter.vote' }}
+        run: node scripts/verify-deployment.mjs
+        working-directory: web
+
       - name: Submit sitemap URLs to IndexNow
         if: ${{ env.INDEXNOW_KEY_CONFIGURED == 'true' }}
         run: npm run submit:indexnow

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -8,7 +8,7 @@ Production uses a serialized release chain after `CI - Quality Gates` passes on 
 
 - CI builds and scans immutable `races-api` and `pipeline-worker` container artifacts.
 - `.github/workflows/terraform-deploy.yaml` promotes those exact images, packages the admin-agent Function, syncs secrets, runs Terraform, and verifies `/health` plus `/health/ready`.
-- `.github/workflows/cloudflare-deploy.yaml` starts only after the automatic infrastructure deployment succeeds, pulls published static JSON from GCS, builds the SvelteKit static site, deploys to Cloudflare Pages, verifies public pages, and optionally submits IndexNow URLs.
+- `.github/workflows/cloudflare-deploy.yaml` starts only after the automatic infrastructure deployment succeeds, pulls published static JSON from GCS, builds the SvelteKit static site, deploys to Cloudflare Pages, verifies the public home, elections, and support pages plus their referenced JavaScript module MIME types, and optionally submits IndexNow URLs.
 
 Deployments are serialized per environment. Every manual apply, rollback, or web deploy requires a commit SHA with a successful `main` push CI run. GitHub environments named `dev`, `staging`, `prod`, and `production` provide deployment policy boundaries; `production` is the public Cloudflare site.
 

--- a/web/scripts/verify-deployment.mjs
+++ b/web/scripts/verify-deployment.mjs
@@ -1,0 +1,83 @@
+const site = process.env.PUBLIC_SITE_URL ?? "https://smarter.vote";
+const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 6);
+const delayMs = Number(process.env.DEPLOY_VERIFY_DELAY_MS ?? 5000);
+const pages = ["/", "/elections/", "/support/"];
+const modulePattern =
+  /(?:src|href)=\x22([^\x22]*\/_app\/immutable\/[^\x22]+\.(?:js|wasm))\x22/g;
+
+const wait = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function fetchUncached(url) {
+  return fetch(url, {
+    cache: "no-store",
+    headers: { "Cache-Control": "no-cache" },
+    redirect: "follow",
+    signal: AbortSignal.timeout(30_000),
+  });
+}
+
+async function verify() {
+  const modules = new Set();
+  for (const path of pages) {
+    const url = new URL(path, site);
+    const response = await fetchUncached(url);
+    const type = response.headers.get("content-type") ?? "";
+    if (!response.ok || !type.includes("text/html")) {
+      throw new Error(
+        String(url) + " returned " + response.status + " " + type,
+      );
+    }
+    const html = await response.text();
+    for (const match of html.matchAll(modulePattern)) {
+      modules.add(new URL(match[1], url).href);
+    }
+  }
+  if (modules.size === 0) throw new Error("No Svelte modules found");
+
+  const failures = (
+    await Promise.all(
+      [...modules].map(async (url) => {
+        try {
+          const response = await fetchUncached(url);
+          const type = response.headers.get("content-type") ?? "";
+          const validType =
+            type.includes("javascript") ||
+            type.includes("ecmascript") ||
+            type.includes("application/wasm");
+          return response.ok && validType
+            ? null
+            : url + " returned " + response.status + " " + type;
+        } catch (error) {
+          return url + " failed: " + String(error);
+        }
+      }),
+    )
+  ).filter(Boolean);
+  if (failures.length) {
+    throw new Error("Module verification failed:\n" + failures.join("\n"));
+  }
+  console.log(
+    "Verified " +
+      pages.length +
+      " public pages and " +
+      modules.size +
+      " Svelte modules.",
+  );
+}
+
+let latestError;
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  try {
+    await verify();
+    latestError = undefined;
+    break;
+  } catch (error) {
+    latestError = error;
+    if (attempt < attempts) {
+      console.warn("Verification attempt " + attempt + " failed; retrying.");
+      await wait(delayMs);
+    }
+  }
+}
+if (latestError) throw latestError;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -5,12 +5,44 @@
   import SiteHeader from "$lib/components/SiteHeader.svelte";
   import SiteFooter from "$lib/components/SiteFooter.svelte";
 
+  import { onNavigate } from "$app/navigation";
+  import { updated } from "$app/stores";
+
   let isAuthenticated = false;
   let darkMode = false;
   const cloudflareAnalyticsToken = import.meta.env
     .VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN;
 
-  onMount(async () => {
+  onNavigate((navigation) => {
+    if (navigation.to && $updated) {
+      location.href = navigation.to.url.href;
+    }
+  });
+
+  function handleChunkError(err: unknown) {
+    const msg = String(err).toLowerCase();
+    if (
+      msg.includes("failed to fetch dynamically imported module") ||
+      msg.includes("failed to load module script") ||
+      msg.includes("strict mime type checking") ||
+      msg.includes("importing a module script failed")
+    ) {
+      const lastReload = sessionStorage.getItem("sv_chunk_reload");
+      const now = Date.now();
+      if (!lastReload || now - Number(lastReload) > 10000) {
+        sessionStorage.setItem("sv_chunk_reload", String(now));
+        window.location.reload();
+      }
+    }
+  }
+
+  onMount(() => {
+    const handleErr = (e: ErrorEvent) => handleChunkError(e.error || e.message);
+    const handleRej = (e: PromiseRejectionEvent) => handleChunkError(e.reason);
+
+    window.addEventListener("error", handleErr);
+    window.addEventListener("unhandledrejection", handleRej);
+
     if (cloudflareAnalyticsToken && !$page.url.pathname.startsWith("/admin")) {
       const script = document.createElement("script");
       script.defer = true;
@@ -34,14 +66,21 @@
         : window.matchMedia("(prefers-color-scheme: dark)").matches;
     document.documentElement.classList.toggle("dark", darkMode);
 
-    try {
-      const { getAuth0Client, isAuthSkipped } = await import("$lib/auth");
-      isAuthenticated = isAuthSkipped()
-        ? true
-        : await (await getAuth0Client()).isAuthenticated();
-    } catch {
-      isAuthenticated = false;
-    }
+    void (async () => {
+      try {
+        const { getAuth0Client, isAuthSkipped } = await import("$lib/auth");
+        isAuthenticated = isAuthSkipped()
+          ? true
+          : await (await getAuth0Client()).isAuthenticated();
+      } catch {
+        isAuthenticated = false;
+      }
+    })();
+
+    return () => {
+      window.removeEventListener("error", handleErr);
+      window.removeEventListener("unhandledrejection", handleRej);
+    };
   });
 
   function toggleDark() {

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -24,6 +24,8 @@ const fixedPrerenderEntries = [
   "/partners/",
   "/privacy/",
   "/support/",
+  "/support/cancel/",
+  "/support/success/",
   "/terms/",
 ];
 
@@ -37,6 +39,9 @@ const config = {
       precompress: false,
       strict: true,
     }),
+    version: {
+      pollInterval: 60000,
+    },
     prerender: {
       crawl: !isFastBuild,
       // Production publishes every known race route so Cloudflare can return a


### PR DESCRIPTION
﻿## What changed

- recover once from stale Svelte chunk/module failures and reload when a newer app version is detected
- enable SvelteKit version polling and explicitly prerender support checkout result routes
- verify `/`, `/elections/`, `/support/`, and every referenced immutable JavaScript/Wasm module after Cloudflare deployment
- document the stronger production verification

## Root cause

During a Cloudflare deployment, public HTML referenced hashed Svelte modules that temporarily returned HTML instead of JavaScript. The browser rejected those responses under strict MIME checking, so hydration failed and all support form buttons appeared broken. The existing deploy smoke test only checked that two HTML pages returned HTTP 200 and could not detect invalid module responses.

## Impact

Clients can recover from stale chunk references with a bounded reload, and future deployments fail their production verification if public pages or referenced modules return the wrong MIME type.

## Validation

- `npm ci` in an isolated clean copy
- `npm run check` (0 errors, 0 warnings)
- `npm run lint`
- `npm run build`
- `npm run test:unit -- --run` (50 files, 174 tests passed)
- production verifier: 3 pages and 36 Svelte modules passed
