### PR TITLE
Allow Cloudflare asset propagation

### DIFF
--- a/web/scripts/verify-deployment.mjs
+++ b/web/scripts/verify-deployment.mjs
@@ -1,5 +1,5 @@
 const site = process.env.PUBLIC_SITE_URL ?? "https://smarter.vote";
-const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 6);
+const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 24);
 const delayMs = Number(process.env.DEPLOY_VERIFY_DELAY_MS ?? 5000);
 const pages = ["/", "/elections/", "/support/"];
 const modulePattern =


### PR DESCRIPTION
﻿## What changed

- extend production module verification from 30 seconds to a bounded two-minute propagation window

## Why

The first guarded deployment correctly detected three new Svelte hashes returning HTML immediately after Cloudflare Pages reported success. All three switched to JavaScript shortly after the 30-second window ended, and the full 36-module verification then passed. This keeps the MIME-type safety gate while accommodating observed edge propagation time.

## Validation

- Prettier check passed
- live verifier passed for 3 pages and 36 Svelte modules
- `git diff --check` passed
