### PR TITLE
Allow Cloudflare edge activation

### DIFF
--- a/web/scripts/verify-deployment.mjs
+++ b/web/scripts/verify-deployment.mjs
@@ -1,5 +1,5 @@
 const site = process.env.PUBLIC_SITE_URL ?? "https://smarter.vote";
-const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 24);
+const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 60);
 const delayMs = Number(process.env.DEPLOY_VERIFY_DELAY_MS ?? 5000);
 const pages = ["/", "/elections/", "/support/"];
 const modulePattern =


### PR DESCRIPTION
﻿## What changed

- allow up to five minutes for the custom domain to expose every newly uploaded immutable module

## Why

The guarded production releases observed Cloudflare Pages returning HTML for one new immutable module for roughly 2 minutes 40 seconds after the upload step reported success. The module then became available as JavaScript and the complete 36-module verification passed. A five-minute bounded window covers the measured behavior without weakening the MIME-type gate.

## Validation

- Prettier check passed
- live verifier passed for 3 pages and 36 Svelte modules
- `git diff --check` passed
