### PR TITLE
Recover delayed Cloudflare modules

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -9,6 +9,7 @@ Production uses a serialized release chain after `CI - Quality Gates` passes on 
 - CI builds and scans immutable `races-api` and `pipeline-worker` container artifacts.
 - `.github/workflows/terraform-deploy.yaml` promotes those exact images, packages the admin-agent Function, syncs secrets, runs Terraform, and verifies `/health` plus `/health/ready`.
 - `.github/workflows/cloudflare-deploy.yaml` starts only after the automatic infrastructure deployment succeeds, pulls published static JSON from GCS, builds the SvelteKit static site, deploys to Cloudflare Pages, verifies the public home, elections, and support pages plus their referenced JavaScript module MIME types, and optionally submits IndexNow URLs.
+  The live module check allows up to ten minutes for Cloudflare custom-domain activation while continuing to reject HTML fallback responses for immutable modules.
 
 Deployments are serialized per environment. Every manual apply, rollback, or web deploy requires a commit SHA with a successful `main` push CI run. GitHub environments named `dev`, `staging`, `prod`, and `production` provide deployment policy boundaries; `production` is the public Cloudflare site.
 

--- a/web/scripts/verify-deployment.mjs
+++ b/web/scripts/verify-deployment.mjs
@@ -1,5 +1,5 @@
 const site = process.env.PUBLIC_SITE_URL ?? "https://smarter.vote";
-const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 60);
+const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 120);
 const delayMs = Number(process.env.DEPLOY_VERIFY_DELAY_MS ?? 5000);
 const pages = ["/", "/elections/", "/support/"];
 const modulePattern =

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -31,6 +31,67 @@
       })();
     </script>
 
+    <!-- Recover even when Cloudflare activates HTML before its modules. -->
+    <script>
+      (function () {
+        let recovering = false;
+        const findUrl = (value) =>
+          String(value || "").match(/https?:\/\/[^\s)]+\.(?:js|wasm)/)?.[0] ||
+          "";
+
+        async function recover(url) {
+          if (recovering) return;
+          recovering = true;
+          if (!url) {
+            const key = "sv_module_fallback_reload";
+            const now = Date.now();
+            const last = Number(sessionStorage.getItem(key) || 0);
+            if (now - last > 60000) {
+              sessionStorage.setItem(key, String(now));
+              setTimeout(() => location.reload(), 5000);
+            }
+            return;
+          }
+          for (let attempt = 0; attempt < 120; attempt += 1) {
+            try {
+              const response = await fetch(url, { cache: "no-store" });
+              const type = response.headers.get("content-type") || "";
+              if (
+                response.ok &&
+                /javascript|ecmascript|application\/wasm/.test(type)
+              ) {
+                location.reload();
+                return;
+              }
+            } catch (error) {
+              // Retry transient edge and network failures.
+            }
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+          }
+          recovering = false;
+        }
+
+        addEventListener(
+          "error",
+          (event) => {
+            const target = event.target;
+            if (target?.tagName === "SCRIPT" && target.type === "module") {
+              void recover(target.src);
+              return;
+            }
+            const message = String(event.error || event.message || "");
+            if (/module|MIME type/i.test(message))
+              void recover(findUrl(message));
+          },
+          true,
+        );
+        addEventListener("unhandledrejection", (event) => {
+          const message = String(event.reason || "");
+          if (/module/i.test(message)) void recover(findUrl(message));
+        });
+      })();
+    </script>
+
     <!-- Global SEO defaults (page-specific tags are set in each page's svelte:head) -->
     <meta name="author" content="Smarter.vote" />
 


### PR DESCRIPTION
﻿## What changed

- install a pre-Svelte module failure handler in the static HTML bootstrap
- poll a failed JavaScript/Wasm asset until Cloudflare serves the correct module MIME type, then reload once
- bound both client recovery and production verification to ten minutes
- document the custom-domain activation behavior

## Root cause

Cloudflare Pages reports the upload complete and begins serving the new HTML before every new immutable module is available from the custom domain. The observed delay exceeded five minutes on a rapid release. When the root Svelte layout module is one of the delayed files, layout-level recovery cannot execute because hydration never starts.

## Impact

Users no longer need to manually refresh a page whose initial module load raced Cloudflare activation. The static bootstrap polls the exact failed asset and reloads only after it becomes valid JavaScript. The deployment remains gated until all public modules are valid.

## Validation

- `npm run check` (0 errors, 0 warnings)
- `npm run lint`
- `npm run build`
- `npm run test:unit -- --run` (50 files, 174 tests passed)
- live verifier passed for 3 pages and 36 Svelte modules
- `git diff --check`
