### PR TITLE
Stop module reload loops

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -9,7 +9,6 @@ Production uses a serialized release chain after `CI - Quality Gates` passes on 
 - CI builds and scans immutable `races-api` and `pipeline-worker` container artifacts.
 - `.github/workflows/terraform-deploy.yaml` promotes those exact images, packages the admin-agent Function, syncs secrets, runs Terraform, and verifies `/health` plus `/health/ready`.
 - `.github/workflows/cloudflare-deploy.yaml` starts only after the automatic infrastructure deployment succeeds, pulls published static JSON from GCS, builds the SvelteKit static site, deploys to Cloudflare Pages, verifies the public home, elections, and support pages plus their referenced JavaScript module MIME types, and optionally submits IndexNow URLs.
-  The live module check allows up to ten minutes for Cloudflare custom-domain activation while continuing to reject HTML fallback responses for immutable modules.
 
 Deployments are serialized per environment. Every manual apply, rollback, or web deploy requires a commit SHA with a successful `main` push CI run. GitHub environments named `dev`, `staging`, `prod`, and `production` provide deployment policy boundaries; `production` is the public Cloudflare site.
 

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -31,67 +31,6 @@
       })();
     </script>
 
-    <!-- Recover even when Cloudflare activates HTML before its modules. -->
-    <script>
-      (function () {
-        let recovering = false;
-        const findUrl = (value) =>
-          String(value || "").match(/https?:\/\/[^\s)]+\.(?:js|wasm)/)?.[0] ||
-          "";
-
-        async function recover(url) {
-          if (recovering) return;
-          recovering = true;
-          if (!url) {
-            const key = "sv_module_fallback_reload";
-            const now = Date.now();
-            const last = Number(sessionStorage.getItem(key) || 0);
-            if (now - last > 60000) {
-              sessionStorage.setItem(key, String(now));
-              setTimeout(() => location.reload(), 5000);
-            }
-            return;
-          }
-          for (let attempt = 0; attempt < 120; attempt += 1) {
-            try {
-              const response = await fetch(url, { cache: "no-store" });
-              const type = response.headers.get("content-type") || "";
-              if (
-                response.ok &&
-                /javascript|ecmascript|application\/wasm/.test(type)
-              ) {
-                location.reload();
-                return;
-              }
-            } catch (error) {
-              // Retry transient edge and network failures.
-            }
-            await new Promise((resolve) => setTimeout(resolve, 5000));
-          }
-          recovering = false;
-        }
-
-        addEventListener(
-          "error",
-          (event) => {
-            const target = event.target;
-            if (target?.tagName === "SCRIPT" && target.type === "module") {
-              void recover(target.src);
-              return;
-            }
-            const message = String(event.error || event.message || "");
-            if (/module|MIME type/i.test(message))
-              void recover(findUrl(message));
-          },
-          true,
-        );
-        addEventListener("unhandledrejection", (event) => {
-          const message = String(event.reason || "");
-          if (/module/i.test(message)) void recover(findUrl(message));
-        });
-      })();
-    </script>
-
     <!-- Global SEO defaults (page-specific tags are set in each page's svelte:head) -->
     <meta name="author" content="Smarter.vote" />
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -5,44 +5,12 @@
   import SiteHeader from "$lib/components/SiteHeader.svelte";
   import SiteFooter from "$lib/components/SiteFooter.svelte";
 
-  import { onNavigate } from "$app/navigation";
-  import { updated } from "$app/stores";
-
   let isAuthenticated = false;
   let darkMode = false;
   const cloudflareAnalyticsToken = import.meta.env
     .VITE_CLOUDFLARE_WEB_ANALYTICS_TOKEN;
 
-  onNavigate((navigation) => {
-    if (navigation.to && $updated) {
-      location.href = navigation.to.url.href;
-    }
-  });
-
-  function handleChunkError(err: unknown) {
-    const msg = String(err).toLowerCase();
-    if (
-      msg.includes("failed to fetch dynamically imported module") ||
-      msg.includes("failed to load module script") ||
-      msg.includes("strict mime type checking") ||
-      msg.includes("importing a module script failed")
-    ) {
-      const lastReload = sessionStorage.getItem("sv_chunk_reload");
-      const now = Date.now();
-      if (!lastReload || now - Number(lastReload) > 10000) {
-        sessionStorage.setItem("sv_chunk_reload", String(now));
-        window.location.reload();
-      }
-    }
-  }
-
   onMount(() => {
-    const handleErr = (e: ErrorEvent) => handleChunkError(e.error || e.message);
-    const handleRej = (e: PromiseRejectionEvent) => handleChunkError(e.reason);
-
-    window.addEventListener("error", handleErr);
-    window.addEventListener("unhandledrejection", handleRej);
-
     if (cloudflareAnalyticsToken && !$page.url.pathname.startsWith("/admin")) {
       const script = document.createElement("script");
       script.defer = true;
@@ -76,11 +44,6 @@
         isAuthenticated = false;
       }
     })();
-
-    return () => {
-      window.removeEventListener("error", handleErr);
-      window.removeEventListener("unhandledrejection", handleRej);
-    };
   });
 
   function toggleDark() {

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -39,9 +39,6 @@ const config = {
       precompress: false,
       strict: true,
     }),
-    version: {
-      pollInterval: 60000,
-    },
     prerender: {
       crawl: !isFastBuild,
       // Production publishes every known race route so Cloudflare can return a


### PR DESCRIPTION
﻿## What changed

- remove the pre-Svelte module polling/reload bootstrap
- remove layout-level module-error reloads
- remove SvelteKit version polling and navigation-triggered hard reloads
- retain explicit support checkout route prerendering and production module MIME verification

## Root cause

Cloudflare custom-domain edges can temporarily serve new HTML before every new immutable module is available. Automatic recovery sampled one edge where the module was ready, reloaded, then hit another edge where it was not. The layered bootstrap and layout recovery amplified the underlying module error into a rapid reload loop on every route.

## Impact

A delayed module may leave a single page load unhydrated until the user refreshes after edge convergence, but the site will no longer enter an uncontrolled reload loop or generate repeated 500/module requests.

## Validation

- `npm run check` (0 errors, 0 warnings)
- `npm run lint`
- `npm run build`
- `npm run test:unit -- --run` (50 files, 174 tests passed)
- rollback production HTML contains no recovery bootstrap or version polling
- rollback module graph returned JavaScript for all 24 referenced modules from DFW
