### PR TITLE
Fix production module cache poisoning

### DIFF
--- a/.github/workflows/cloudflare-deploy.yaml
+++ b/.github/workflows/cloudflare-deploy.yaml
@@ -178,6 +178,11 @@ jobs:
           if (fs.existsSync("build/200.html")) {
             throw new Error("Unexpected catch-all 200.html would create soft 404s");
           }
+          if (!fs.existsSync("build/404.html")) {
+            throw new Error(
+              "Missing build/404.html would make Cloudflare treat the site as an SPA",
+            );
+          }
           console.log(`Verified ${summaries.length} prerendered race routes.`);
           EOF
         working-directory: web

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -8,7 +8,7 @@ Production uses a serialized release chain after `CI - Quality Gates` passes on 
 
 - CI builds and scans immutable `races-api` and `pipeline-worker` container artifacts.
 - `.github/workflows/terraform-deploy.yaml` promotes those exact images, packages the admin-agent Function, syncs secrets, runs Terraform, and verifies `/health` plus `/health/ready`.
-- `.github/workflows/cloudflare-deploy.yaml` starts only after the automatic infrastructure deployment succeeds, pulls published static JSON from GCS, builds the SvelteKit static site, deploys to Cloudflare Pages, verifies the public home, elections, and support pages plus their referenced JavaScript module MIME types, and optionally submits IndexNow URLs.
+- `.github/workflows/cloudflare-deploy.yaml` starts only after the automatic infrastructure deployment succeeds, pulls published static JSON from GCS, builds the SvelteKit static site with a release-specific asset namespace and a real `404.html`, deploys to Cloudflare Pages, verifies the public home, elections, and support pages plus the complete JavaScript module graph and missing-module 404 behavior, and optionally submits IndexNow URLs.
 
 Deployments are serialized per environment. Every manual apply, rollback, or web deploy requires a commit SHA with a successful `main` push CI run. GitHub environments named `dev`, `staging`, `prod`, and `production` provide deployment policy boundaries; `production` is the public Cloudflare site.
 

--- a/web/scripts/verify-deployment.mjs
+++ b/web/scripts/verify-deployment.mjs
@@ -3,7 +3,9 @@ const attempts = Number(process.env.DEPLOY_VERIFY_ATTEMPTS ?? 120);
 const delayMs = Number(process.env.DEPLOY_VERIFY_DELAY_MS ?? 5000);
 const pages = ["/", "/elections/", "/support/"];
 const modulePattern =
-  /(?:src|href)=\x22([^\x22]*\/_app\/immutable\/[^\x22]+\.(?:js|wasm))\x22/g;
+  /(?:src|href)=\x22([^\x22]*\/_app(?:-[a-f0-9]+)?\/immutable\/[^\x22]+\.(?:js|wasm))\x22/g;
+const nestedModulePattern =
+  /[\x22']((?:\/_app(?:-[a-f0-9]+)?\/immutable\/|\.\.?\/)[^\x22']+\.(?:js|wasm))[\x22']/g;
 
 const wait = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -35,25 +37,59 @@ async function verify() {
   }
   if (modules.size === 0) throw new Error("No Svelte modules found");
 
-  const failures = (
-    await Promise.all(
-      [...modules].map(async (url) => {
-        try {
-          const response = await fetchUncached(url);
-          const type = response.headers.get("content-type") ?? "";
-          const validType =
-            type.includes("javascript") ||
-            type.includes("ecmascript") ||
-            type.includes("application/wasm");
-          return response.ok && validType
-            ? null
-            : url + " returned " + response.status + " " + type;
-        } catch (error) {
-          return url + " failed: " + String(error);
+  const failures = [];
+  const checked = new Set();
+  const pending = [...modules];
+  while (pending.length > 0) {
+    const url = pending.shift();
+    if (checked.has(url)) continue;
+    checked.add(url);
+    try {
+      const response = await fetchUncached(url);
+      const type = response.headers.get("content-type") ?? "";
+      const isWasm = new URL(url).pathname.endsWith(".wasm");
+      const validType = isWasm
+        ? type.includes("application/wasm")
+        : type.includes("javascript") || type.includes("ecmascript");
+      if (!response.ok || !validType) {
+        failures.push(url + " returned " + response.status + " " + type);
+        continue;
+      }
+      if (!isWasm) {
+        const source = await response.text();
+        for (const match of source.matchAll(nestedModulePattern)) {
+          const dependency = new URL(match[1], url).href;
+          if (!checked.has(dependency)) pending.push(dependency);
         }
-      }),
-    )
-  ).filter(Boolean);
+      }
+    } catch (error) {
+      failures.push(url + " failed: " + String(error));
+    }
+    if (checked.size + pending.length > 5000) {
+      failures.push("Module graph exceeded the 5000-module safety limit");
+      break;
+    }
+  }
+
+  const appPath = new URL([...modules][0]).pathname.match(
+    /^(\/_app(?:-[a-f0-9]+)?)\/immutable\//,
+  )?.[1];
+  if (!appPath) throw new Error("Could not determine Svelte app path");
+  const missingUrl = new URL(
+    appPath + "/immutable/entry/__deployment-verifier-missing__.js",
+    site,
+  );
+  const missingResponse = await fetchUncached(missingUrl);
+  if (missingResponse.ok) {
+    failures.push(
+      String(missingUrl) +
+        " unexpectedly returned " +
+        missingResponse.status +
+        " " +
+        (missingResponse.headers.get("content-type") ?? ""),
+    );
+  }
+
   if (failures.length) {
     throw new Error("Module verification failed:\n" + failures.join("\n"));
   }
@@ -61,8 +97,8 @@ async function verify() {
     "Verified " +
       pages.length +
       " public pages and " +
-      modules.size +
-      " Svelte modules.",
+      checked.size +
+      " recursively discovered Svelte modules, plus missing-module 404 behavior.",
   );
 }
 

--- a/web/static/404.html
+++ b/web/static/404.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Page not found | Smarter.Vote</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+      }
+      body {
+        display: grid;
+        min-height: 100vh;
+        margin: 0;
+        place-items: center;
+        background: #f8fafc;
+        color: #172033;
+      }
+      main {
+        max-width: 34rem;
+        padding: 2rem;
+        text-align: center;
+      }
+      a {
+        color: #1d4ed8;
+        font-weight: 700;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #0f172a;
+          color: #e2e8f0;
+        }
+        a {
+          color: #93c5fd;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p>404</p>
+      <h1>Page not found</h1>
+      <p>The page you requested does not exist.</p>
+      <p><a href="/">Return to Smarter.Vote</a></p>
+    </main>
+  </body>
+</html>

--- a/web/static/_headers
+++ b/web/static/_headers
@@ -7,4 +7,7 @@
   X-Frame-Options: DENY
 
 /_app/immutable/*
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=0, must-revalidate
+
+/_app-*/immutable/*
+  Cache-Control: public, max-age=0, must-revalidate

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -10,6 +10,13 @@ const isFastBuild =
   process.argv.includes("--mode=fast");
 
 const prerenderDynamicRoutes = process.env.VITE_PRERENDER_RACES === "true";
+const deploySha = process.env.DEPLOY_SHA?.trim();
+if (deploySha && !/^[0-9a-f]{7,64}$/i.test(deploySha)) {
+  throw new Error("DEPLOY_SHA must be a Git commit SHA");
+}
+const appDir = deploySha
+  ? `_app-${deploySha.slice(0, 12).toLowerCase()}`
+  : "_app";
 const fixedPrerenderEntries = [
   "/",
   "/about/",
@@ -33,6 +40,9 @@ const fixedPrerenderEntries = [
 const config = {
   preprocess: vitePreprocess(),
   kit: {
+    // A release-specific namespace prevents an HTML response cached under an
+    // older module URL from breaking hydration after a deployment.
+    appDir,
     adapter: adapter({
       pages: "build",
       assets: "build",


### PR DESCRIPTION
## Summary
- give each production release a commit-specific Svelte asset namespace
- ship a real static 404 so missing modules cannot become 200 homepage HTML
- make module cache responses revalidate instead of remaining poisoned
- recursively verify the full deployed module graph and missing-module 404 behavior

## Validation
- npm run check (0 errors/warnings)
- npm run lint
- npm run test:unit (174 passed)
- DEPLOY_SHA=7ef8097... npm run build:cloudflare
- generated 404.html and versioned app directory verified
- deployment verifier walked 60 modules against the local production build