### PR TITLE
Improve catalog repair targeting and pipeline controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,15 @@ SKIP_AUTH=true
 # Max execution time before a run is considered timed-out, in seconds (default: 86400 = 24h)
 # WORKER_DEADLINE_SECONDS=86400
 
+# Logical-run and phase ceilings. Cached search/page hits do not consume the
+# external-call ceilings.
+# PIPELINE_MAX_SEARCH_CALLS=240
+# PIPELINE_MAX_TOTAL_TOKENS=2500000
+# PIPELINE_MAX_PHASE_SEARCH_CALLS=120
+# PIPELINE_MAX_PHASE_TOKENS=1250000
+# PIPELINE_MAX_PAGE_FETCHES=300
+# PIPELINE_MAX_FETCHED_CHARS=3000000
+
 # =============================================================================
 # ADVANCED CACHING (optional)
 # =============================================================================

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -147,13 +147,37 @@ changes baseline loading but does not silently change an explicit step list.
 
 Common tools:
 
+- `scan_catalog`: compact prioritized inventory with research tiers, coverage,
+  traffic, freshness, and persisted asset-audit findings
+- `plan_repairs`: non-mutating, independently queueable race/candidate repair
+  groups with calibrated-or-static cost and search ceilings
+- `audit_race_assets`: bounded source/photo URL and image-quality checks;
+  `persist=true` stores the evidence on the catalog record
 - `queue_races`: one or more races with full options
 - `run_race`: one race
 - `list_active_runs`, `get_queue`: queue/worker state
 - `get_run`, `get_run_logs`: status and cursor-based logs
 - `get_race_data(draft=true)`: inspect output
 - `publish_race`, `publish_races`: publish only after approval
+- `get_run_diagnostics`, `summarize_run_costs`: run health and exact cost
 - `get_pipeline_metrics`, `get_pipeline_metrics_summary`: cost reporting
+
+Queue each `repair_groups` item independently. The combined
+`recommended_steps` and `candidate_names` fields are summaries, not a safe
+queue payload when candidates need different work. Estimates use a 25% margin
+over compatible observed per-phase spend, with the static missing-work estimate
+as a floor.
+
+Catalog health records strong contest-matched roster evidence, terminal and
+sourced issue coverage, field-level freshness, finance/voting coverage,
+forecast evidence lineage, and pipeline/validation health. Use
+`audit_race_assets(..., persist=true)` when URL reachability, content type, or
+thumbnail quality matters; presence alone is not treated as verification.
+
+Logical runs enforce both global and phase search/token ceilings. They also cap
+uncached page fetches and fetched characters, and persist per-phase
+token/provider/search/page attribution across continuation handoffs. Defaults
+are documented in `.env.example`.
 
 Example targeted update:
 

--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -674,6 +674,10 @@ async def run_agent(
         "priced_calls": int(prior_agent_metrics.get("priced_calls", 0) or 0),
         "unpriced_calls": int(prior_agent_metrics.get("unpriced_calls", 0) or 0),
         "serper_calls": int(prior_agent_metrics.get("serper_calls", 0) or 0),
+        "searlo_calls": int(prior_agent_metrics.get("searlo_calls", 0) or 0),
+        "search_budget_blocked": int(prior_agent_metrics.get("search_budget_blocked", 0) or 0),
+        "token_budget_nudges": int(prior_agent_metrics.get("token_budget_nudges", 0) or 0),
+        "prior_duration_s": float(prior_agent_metrics.get("duration_s", 0.0) or 0.0),
         "context_requests": int(prior_agent_metrics.get("context_requests", 0) or 0),
         "max_estimated_context_tokens": int(prior_agent_metrics.get("max_estimated_context_tokens", 0) or 0),
         "max_context_window_tokens": int(prior_agent_metrics.get("max_context_window_tokens", 0) or 0),
@@ -685,6 +689,10 @@ async def run_agent(
         "retry_provider_failures": int(prior_agent_metrics.get("retry_provider_failures", 0) or 0),
         "retry_deadline_exits": int(prior_agent_metrics.get("retry_deadline_exits", 0) or 0),
         "model_breakdown": copy.deepcopy(prior_agent_metrics.get("model_breakdown", {})),
+        "phase_breakdown": copy.deepcopy(prior_agent_metrics.get("phase_breakdown", {})),
+        "page_fetches": int(prior_agent_metrics.get("page_fetches", 0) or 0),
+        "fetched_chars": int(prior_agent_metrics.get("fetched_chars", 0) or 0),
+        "page_budget_blocked": int(prior_agent_metrics.get("page_budget_blocked", 0) or 0),
     }
     _ctx_token = _cost_ctx.set(_acc)
 
@@ -963,6 +971,24 @@ async def run_agent(
         _track("skip", "review")
         _track("skip", "iteration")
 
+    # Apply safe mechanical cleanup after all model-authored changes. This pass
+    # also carries explicit polling/market/finance evidence URLs into forecasts
+    # before enforcing the forecast evidence gate.
+    from shared.race_cleanup import cleanup_race_data, validate_forecast_evidence
+
+    cleanup_report = cleanup_race_data(race_json)
+    pipeline_state = race_json.setdefault("pipeline_state", pipeline_state)
+    pipeline_state["deterministic_cleanup"] = cleanup_report
+    if any(cleanup_report.values()):
+        log(
+            "info",
+            "Deterministic cleanup applied "
+            f"({cleanup_report['text_changes']} text, "
+            f"{cleanup_report['source_duplicates_removed']} duplicate sources, "
+            f"{cleanup_report['forecast_sources_added']} forecast sources)",
+        )
+    validate_forecast_evidence(race_json)
+
     # Compute aggregate validation grade from review scores
     grade = compute_validation_grade(race_json.get("reviews", [])) if race_json.get("reviews") else None
     race_json["validation_grade"] = grade
@@ -1001,6 +1027,7 @@ async def run_agent(
 
     # Add Serper costs ($0.001 per call) to both estimated and provider costs
     serper_calls = _acc.get("serper_calls", 0)
+    searlo_calls = _acc.get("searlo_calls", 0)
     serper_cost = serper_calls * 0.001
     estimated_cost += serper_cost
     if provider_cost > 0:
@@ -1019,8 +1046,23 @@ async def run_agent(
         "cost_source": "provider" if has_exact_provider_cost else "estimated",
         "estimated_usd": round(estimated_cost, 6),
         "model_breakdown": breakdown,
-        "duration_s": round(elapsed, 1),
+        "phase_breakdown": _acc.get("phase_breakdown", {}),
+        "duration_s": round(_acc.get("prior_duration_s", 0.0) + elapsed, 1),
+        "segment_duration_s": round(elapsed, 1),
         "serper_calls": serper_calls,
+        "searlo_calls": searlo_calls,
+        "search_calls": serper_calls + searlo_calls,
+        "search_budget_blocked": _acc.get("search_budget_blocked", 0),
+        "token_budget_nudges": _acc.get("token_budget_nudges", 0),
+        "page_fetches": _acc.get("page_fetches", 0),
+        "fetched_chars": _acc.get("fetched_chars", 0),
+        "page_budget_blocked": _acc.get("page_budget_blocked", 0),
+        "max_search_calls": PipelineRuntimeConfig.from_env().max_search_calls,
+        "max_total_tokens": PipelineRuntimeConfig.from_env().max_total_tokens,
+        "max_phase_search_calls": PipelineRuntimeConfig.from_env().max_phase_search_calls,
+        "max_phase_tokens": PipelineRuntimeConfig.from_env().max_phase_tokens,
+        "max_page_fetches": PipelineRuntimeConfig.from_env().max_page_fetches,
+        "max_fetched_chars": PipelineRuntimeConfig.from_env().max_fetched_chars,
         "context_requests": _acc.get("context_requests", 0),
         "max_estimated_context_tokens": _acc.get("max_estimated_context_tokens", 0),
         "max_context_window_tokens": _acc.get("max_context_window_tokens", 0),

--- a/pipeline_client/agent/cost.py
+++ b/pipeline_client/agent/cost.py
@@ -1,7 +1,10 @@
 """Token cost accounting for the agent pipeline."""
 
+import re
 from contextvars import ContextVar
 from typing import Any, Dict, Optional
+
+from shared.pipeline_config import PipelineRuntimeConfig
 
 from .model_registry import MODEL_CATALOG, normalize_model_id
 
@@ -10,9 +13,51 @@ from .model_registry import MODEL_CATALOG, normalize_model_id
 #          "provider_cost_usd": float, "priced_calls": int, "unpriced_calls": int,
 #          "model_breakdown": {model: {"prompt_tokens": int, "completion_tokens": int}}}
 _cost_ctx: ContextVar[Optional[Dict[str, Any]]] = ContextVar("_cost_ctx", default=None)
+_phase_ctx: ContextVar[str] = ContextVar("_phase_ctx", default="unattributed")
 
 _DEFAULT_INPUT_PER_M = 2.50
 _DEFAULT_OUTPUT_PER_M = 10.00
+
+
+def phase_family(phase: str) -> str:
+    """Collapse candidate/issue-specific phase labels into stable metric buckets."""
+    normalized = str(phase or "unattributed").strip().lower().replace("_", "-")
+    normalized = re.sub(r"^update-", "", normalized)
+    if normalized.startswith("issue"):
+        return "issues"
+    for family in (
+        "discovery",
+        "images",
+        "finance",
+        "refinement",
+        "polling",
+        "forecast",
+        "voter-resources",
+        "review",
+        "iteration",
+    ):
+        if normalized.startswith(family):
+            return family.replace("-", "_")
+    return normalized or "unattributed"
+
+
+def set_current_phase(phase: str) -> None:
+    _phase_ctx.set(phase_family(phase))
+
+
+def _phase_entry(acc: Dict[str, Any]) -> Dict[str, Any]:
+    return acc.setdefault("phase_breakdown", {}).setdefault(
+        _phase_ctx.get(),
+        {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "provider_cost_usd": 0.0,
+            "llm_calls": 0,
+            "search_calls": 0,
+            "page_fetches": 0,
+            "fetched_chars": 0,
+        },
+    )
 
 
 def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> float:
@@ -34,13 +79,18 @@ def accumulate(
     acc = _cost_ctx.get()
     if acc is None:
         return
+    phase = _phase_entry(acc)
     acc["prompt_tokens"] += prompt_tokens
     acc["completion_tokens"] += completion_tokens
+    phase["prompt_tokens"] += prompt_tokens
+    phase["completion_tokens"] += completion_tokens
+    phase["llm_calls"] += 1
     if cost_usd is None:
         acc["unpriced_calls"] = acc.get("unpriced_calls", 0) + 1
     else:
         acc["provider_cost_usd"] = acc.get("provider_cost_usd", 0.0) + cost_usd
         acc["priced_calls"] = acc.get("priced_calls", 0) + 1
+        phase["provider_cost_usd"] += cost_usd
     normalized_model = normalize_model_id(model) if model else None
     if normalized_model:
         breakdown = acc.setdefault("model_breakdown", {})
@@ -90,3 +140,67 @@ def record_retry_metric(kind: str) -> None:
         return
     key = f"retry_{kind}"
     acc[key] = acc.get(key, 0) + 1
+
+
+def reserve_search_call(provider: str) -> bool:
+    """Atomically reserve one paid search call within the logical run ceiling."""
+    acc = _cost_ctx.get()
+    if acc is None:
+        return True
+    config = PipelineRuntimeConfig.from_env()
+    used = int(acc.get("serper_calls", 0) or 0) + int(acc.get("searlo_calls", 0) or 0)
+    phase = _phase_entry(acc)
+    if used >= config.max_search_calls or int(phase.get("search_calls", 0)) >= config.max_phase_search_calls:
+        acc["search_budget_blocked"] = int(acc.get("search_budget_blocked", 0) or 0) + 1
+        phase["search_budget_blocked"] = int(phase.get("search_budget_blocked", 0) or 0) + 1
+        return False
+    key = f"{provider}_calls"
+    acc[key] = int(acc.get(key, 0) or 0) + 1
+    phase["search_calls"] += 1
+    return True
+
+
+def reserve_page_fetch() -> bool:
+    """Reserve one uncached page fetch within logical-run and context ceilings."""
+    acc = _cost_ctx.get()
+    if acc is None:
+        return True
+    config = PipelineRuntimeConfig.from_env()
+    phase = _phase_entry(acc)
+    if (
+        int(acc.get("page_fetches", 0) or 0) >= config.max_page_fetches
+        or int(acc.get("fetched_chars", 0) or 0) >= config.max_fetched_chars
+    ):
+        acc["page_budget_blocked"] = int(acc.get("page_budget_blocked", 0) or 0) + 1
+        phase["page_budget_blocked"] = int(phase.get("page_budget_blocked", 0) or 0) + 1
+        return False
+    acc["page_fetches"] = int(acc.get("page_fetches", 0) or 0) + 1
+    phase["page_fetches"] += 1
+    return True
+
+
+def record_fetched_chars(count: int) -> None:
+    acc = _cost_ctx.get()
+    if acc is None:
+        return
+    count = max(0, int(count))
+    acc["fetched_chars"] = int(acc.get("fetched_chars", 0) or 0) + count
+    _phase_entry(acc)["fetched_chars"] += count
+
+
+def total_token_budget_reached() -> bool:
+    """Return whether prior completed model calls reached the logical run ceiling."""
+    acc = _cost_ctx.get()
+    if acc is None:
+        return False
+    used = int(acc.get("prompt_tokens", 0) or 0) + int(acc.get("completion_tokens", 0) or 0)
+    config = PipelineRuntimeConfig.from_env()
+    phase = _phase_entry(acc)
+    phase_used = int(phase.get("prompt_tokens", 0) or 0) + int(phase.get("completion_tokens", 0) or 0)
+    return used >= config.max_total_tokens or phase_used >= config.max_phase_tokens
+
+
+def record_token_budget_nudge() -> None:
+    acc = _cost_ctx.get()
+    if acc is not None:
+        acc["token_budget_nudges"] = int(acc.get("token_budget_nudges", 0) or 0) + 1

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -1028,6 +1028,18 @@ def _make_editing_handlers(
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "model": str(args.get("model") or ""),
             "source_urls": [str(url) for url in args.get("source_urls") or [] if str(url).strip()],
+            "evidence_lineage": [
+                {
+                    "claim": str(item.get("claim") or "").strip(),
+                    "source_url": str(item.get("source_url") or "").strip(),
+                    "kind": str(item.get("kind") or "other"),
+                    "inferred": bool(item.get("inferred", False)),
+                }
+                for item in args.get("evidence_lineage") or []
+                if isinstance(item, dict)
+                and str(item.get("claim") or "").strip()
+                and str(item.get("source_url") or "").strip()
+            ],
         }
         race_json["forecast"] = forecast
         log("info", f"    race.forecast updated ({rating})")

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -11,7 +11,14 @@ from typing import Any, Dict, List, Optional
 from .ballotpedia import lookup_candidate_data as _ballotpedia_lookup
 from .ballotpedia import lookup_election_page as _ballotpedia_election_lookup
 from .context import AgentContext, AgentContextBudget
-from .cost import accumulate, record_context_metrics, record_retry_metric
+from .cost import (
+    accumulate,
+    record_context_metrics,
+    record_retry_metric,
+    record_token_budget_nudge,
+    set_current_phase,
+    total_token_budget_reached,
+)
 from .errors import PermanentProviderError, RetryableProviderError
 from .model_registry import (
     CHEAP_CLAUDE_MODEL,
@@ -441,6 +448,7 @@ async def _agent_loop(
     the loop exits when the LLM stops making tool calls.  Returns ``{}``.
     """
     log = make_logger(on_log)
+    set_current_phase(phase_name)
 
     messages: List[Dict[str, Any]] = [
         {"role": "system", "content": system},
@@ -459,8 +467,23 @@ async def _agent_loop(
     _extra_handlers = extra_tool_handlers or {}
     _json_parse_failures = 0
     _MAX_JSON_RETRIES = 3
+    token_budget_nudged = False
 
     for iteration in range(max_iterations):
+        token_budget_reached = total_token_budget_reached()
+        if token_budget_reached and not token_budget_nudged:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "The logical run token ceiling has been reached. Do not perform more web research. "
+                        "Finalize now from the evidence already collected; do not invent missing facts."
+                    ),
+                }
+            )
+            record_token_budget_nudge()
+            token_budget_nudged = True
+            log("warning", f"  [{phase_name}] token ceiling reached; forcing finalization without search tools")
         active_model = model
         if _json_parse_failures > 0:
             norm_model = normalize_model_id(model)
@@ -476,7 +499,7 @@ async def _agent_loop(
         if tools_mode:
             search_tools = (
                 [SEARCH_TOOL, FETCH_TOOL, BALLOTPEDIA_TOOL, BALLOTPEDIA_ELECTION_TOOL, IMAGE_SEARCH_TOOL]
-                if allow_search_tools and iteration < nudge_at
+                if allow_search_tools and not token_budget_reached and iteration < nudge_at
                 else []
             )
             tools_for_call = search_tools + _extra_tools if (search_tools or _extra_tools) else None
@@ -512,7 +535,7 @@ async def _agent_loop(
 
             base_tools = (
                 [SEARCH_TOOL, FETCH_TOOL, BALLOTPEDIA_TOOL, BALLOTPEDIA_ELECTION_TOOL, IMAGE_SEARCH_TOOL]
-                if allow_search_tools and iteration < nudge_at
+                if allow_search_tools and not token_budget_reached and iteration < nudge_at
                 else []
             )
             tools_for_call = (base_tools + _extra_tools) if (base_tools or _extra_tools) else None

--- a/pipeline_client/agent/phase_state.py
+++ b/pipeline_client/agent/phase_state.py
@@ -30,6 +30,12 @@ def issue_stance_is_complete(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
     stance = str(value.get("stance") or "").strip()
+    # A documented no-position result is a terminal research verdict even
+    # though quality scoring correctly treats it as missing substantive policy
+    # information. Continuations must not spend another pass rediscovering the
+    # same absence.
+    if "no public position found" in stance.lower():
+        return True
     return bool(stance) and not _is_missing_stance_text(stance)
 
 

--- a/pipeline_client/agent/phases/_common.py
+++ b/pipeline_client/agent/phases/_common.py
@@ -66,11 +66,9 @@ def _mark_pipeline_unit_complete(race_json: Dict[str, Any], unit: str) -> None:
 
 
 def _issue_stance_is_complete(value: Any) -> bool:
-    """True if *value* holds a real stance — not empty and not a placeholder.
+    """True for a substantive stance or a terminal no-position verdict.
 
-    A plain non-empty check let literal placeholder text (e.g. "To be determined
-    after review") count as "done", so a fresh issues-step pass would skip it
-    forever as already-complete rather than retry it.
+    Literal placeholders remain incomplete so a continuation retries them.
     """
     return phase_state.issue_stance_is_complete(value)
 

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -437,8 +437,10 @@ Write like a concise, expert election analyst. Avoid repetitive boilerplate open
 Be sure to populate the following structured fields in set_forecast:
 - rationale: A concise nonpartisan explanation (maximum 2 sentences).
 - takeaway: A single concise sentence summarizing the main forecast takeaway (MUST be exactly one sentence under 25 words).
-- key_reasons: A list of the 2-3 most important analytical reasons for the forecast, when available.
-- uncertainty: A single sentence outlining the key caveats or sources of uncertainty, when available."""
+  - key_reasons: A list of the 2-3 most important analytical reasons for the forecast, when available.
+  - evidence_lineage: Map each materially sourced key reason to the exact polling,
+    market, finance, or race-context URL that supports it. Do not invent URLs.
+  - uncertainty: A single sentence outlining the key caveats or sources of uncertainty, when available."""
 
 VOTER_RESOURCES_SYSTEM = f"""\
 You are a nonpartisan election-resource researcher. Your only task is to verify

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -872,6 +872,23 @@ SET_FORECAST_TOOL: Dict = {
                 },
                 "based_on_poll_count": {"type": "integer", "minimum": 0},
                 "source_urls": {"type": "array", "items": {"type": "string"}},
+                "evidence_lineage": {
+                    "type": "array",
+                    "description": "Claim-to-source mappings for material forecast reasons.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "claim": {"type": "string"},
+                            "source_url": {"type": "string"},
+                            "kind": {
+                                "type": "string",
+                                "enum": ["polling", "market", "finance", "race_context", "other"],
+                            },
+                            "inferred": {"type": "boolean"},
+                        },
+                        "required": ["claim", "source_url"],
+                    },
+                },
             },
             "required": [
                 "rating",
@@ -880,6 +897,7 @@ SET_FORECAST_TOOL: Dict = {
                 "based_on_poll_count",
                 "party_probabilities",
                 "source_urls",
+                "evidence_lineage",
             ],
         },
     },

--- a/pipeline_client/agent/web_tools.py
+++ b/pipeline_client/agent/web_tools.py
@@ -15,6 +15,7 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 
+from .cost import record_fetched_chars, reserve_page_fetch, reserve_search_call
 from .run_budget import RunBudget
 
 logger = logging.getLogger("pipeline")
@@ -301,6 +302,8 @@ async def _fetch_page(url: str) -> str:
         if cached:
             logger.debug(f"Page cache HIT: {url[:60]}")
             return cached
+    if not reserve_page_fetch():
+        return "[Page fetch budget reached; use the evidence already collected.]"
 
     client = _get_fetch_client()
     failure_reasons: List[str] = []
@@ -329,6 +332,7 @@ async def _fetch_page(url: str) -> str:
             if _is_unusable_page_text(text):
                 failure_reasons.append("primary_fetch_unusable_content")
                 continue
+            record_fetched_chars(len(text))
 
             # Some anti-bot pages return HTTP 200 with short generic text. For very
             # short pages, opportunistically try the proxy and prefer richer content.
@@ -341,6 +345,7 @@ async def _fetch_page(url: str) -> str:
                     if (not _is_unusable_page_text(proxy_text)) and (len(proxy_text) > len(text) + 200):
                         if len(proxy_text) > _PAGE_MAX_CHARS:
                             proxy_text = proxy_text[:_PAGE_MAX_CHARS] + f"\n\n[...truncated at {_PAGE_MAX_CHARS} chars]"
+                        record_fetched_chars(max(0, len(proxy_text) - len(text)))
                         if cache:
                             cache.set_page(url, proxy_text)
                         return proxy_text
@@ -367,6 +372,7 @@ async def _fetch_page(url: str) -> str:
                 proxy_text = proxy_text[:_PAGE_MAX_CHARS] + f"\n\n[...truncated at {_PAGE_MAX_CHARS} chars]"
             if cache:
                 cache.set_page(url, proxy_text)
+            record_fetched_chars(len(proxy_text))
             return proxy_text
         failure_reasons.append("proxy_unusable_content")
     except Exception as exc:
@@ -378,6 +384,7 @@ async def _fetch_page(url: str) -> str:
     if fallback_text:
         if cache:
             cache.set_page(url, fallback_text)
+        record_fetched_chars(len(fallback_text))
         return fallback_text
 
     return f"[Failed to fetch {url}: {' | '.join(failure_reasons[:3])}]"
@@ -673,14 +680,8 @@ async def _searlo_search(
     operation = "Searlo image search" if images else "Searlo search"
     if run_budget:
         run_budget.require_call_time(2.0, operation=operation)
-    try:
-        from pipeline_client.agent.cost import _cost_ctx
-
-        acc = _cost_ctx.get()
-        if acc is not None:
-            acc["searlo_calls"] = acc.get("searlo_calls", 0) + 1
-    except Exception:
-        pass
+    if not reserve_search_call("searlo"):
+        return [{"error": "Run search budget reached; finish from cached evidence."}]
 
     timeout = run_budget.bounded_timeout(10.0, minimum_seconds=2.0, operation=operation) if run_budget else 10.0
     endpoint = "images" if images else "web"
@@ -760,14 +761,8 @@ async def _serper_search(
     for attempt in range(max(1, max_attempts)):
         if run_budget:
             run_budget.require_call_time(2.0, operation="Serper search")
-        try:
-            from pipeline_client.agent.cost import _cost_ctx
-
-            acc = _cost_ctx.get()
-            if acc is not None:
-                acc["serper_calls"] = acc.get("serper_calls", 0) + 1
-        except Exception:
-            pass
+        if not reserve_search_call("serper"):
+            return [{"error": "Run search budget reached; finish from cached evidence."}]
 
         request_timeout = (
             run_budget.bounded_timeout(10.0, minimum_seconds=2.0, operation="Serper search") if run_budget else 10.0
@@ -883,14 +878,8 @@ async def _serper_image_search(
     for attempt in range(max(1, max_attempts)):
         if run_budget:
             run_budget.require_call_time(2.0, operation="Serper image search")
-        try:
-            from pipeline_client.agent.cost import _cost_ctx
-
-            acc = _cost_ctx.get()
-            if acc is not None:
-                acc["serper_calls"] = acc.get("serper_calls", 0) + 1
-        except Exception:
-            pass
+        if not reserve_search_call("serper"):
+            return [{"error": "Run search budget reached; finish from cached evidence."}]
 
         request_timeout = (
             run_budget.bounded_timeout(10.0, minimum_seconds=2.0, operation="Serper image search") if run_budget else 10.0

--- a/pipeline_client/backend/firestore_logger.py
+++ b/pipeline_client/backend/firestore_logger.py
@@ -225,6 +225,9 @@ class FirestoreLogger:
             }
             if duration_ms is not None:
                 update["duration_ms"] = duration_ms
+                from google.cloud.firestore_v1 import Increment  # type: ignore
+
+                update["logical_duration_ms"] = Increment(duration_ms)
             if run_health is not None:
                 update["run_health"] = run_health
             if self.truncated_log_count or self.dropped_log_count or self.coalesced_progress_count:
@@ -257,6 +260,9 @@ class FirestoreLogger:
             }
             if duration_ms is not None:
                 update["duration_ms"] = duration_ms
+                from google.cloud.firestore_v1 import Increment  # type: ignore
+
+                update["logical_duration_ms"] = Increment(duration_ms)
             if run_health is not None:
                 update["run_health"] = run_health
             if self.truncated_log_count or self.dropped_log_count or self.coalesced_progress_count:
@@ -269,7 +275,7 @@ class FirestoreLogger:
         except Exception as exc:
             logger.debug("FirestoreLogger.mark_failed failed: %s", exc)
 
-    def mark_handoff(self, continuation_item_id: str) -> None:
+    def mark_handoff(self, continuation_item_id: str, *, duration_ms: int | None = None) -> None:
         """Record an invocation handoff while keeping the logical run active."""
         self.flush()
         db = _get_db()
@@ -278,14 +284,14 @@ class FirestoreLogger:
         try:
             from google.cloud.firestore_v1 import Increment  # type: ignore
 
-            db.collection(FIRESTORE_RUNS_COLLECTION).document(self.run_id).set(
-                {
-                    "status": "running",
-                    "continuation_item_id": continuation_item_id,
-                    "continuation_count": Increment(1),
-                    "handoff_at": datetime.now(timezone.utc).isoformat(),
-                },
-                merge=True,
-            )
+            update = {
+                "status": "running",
+                "continuation_item_id": continuation_item_id,
+                "continuation_count": Increment(1),
+                "handoff_at": datetime.now(timezone.utc).isoformat(),
+            }
+            if duration_ms is not None:
+                update["logical_duration_ms"] = Increment(duration_ms)
+            db.collection(FIRESTORE_RUNS_COLLECTION).document(self.run_id).set(update, merge=True)
         except Exception as exc:
             logger.debug("FirestoreLogger.mark_handoff failed: %s", exc)

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -603,6 +603,11 @@ class AgentHandler:
                         "priced_calls": cost_snapshot.get("priced_calls", 0),
                         "unpriced_calls": cost_snapshot.get("unpriced_calls", 0),
                         "serper_calls": cost_snapshot.get("serper_calls", 0),
+                        "searlo_calls": cost_snapshot.get("searlo_calls", 0),
+                        "search_budget_blocked": cost_snapshot.get("search_budget_blocked", 0),
+                        "token_budget_nudges": cost_snapshot.get("token_budget_nudges", 0),
+                        "duration_s": float((options.get("prior_agent_metrics") or {}).get("duration_s", 0.0) or 0.0)
+                        + (time.perf_counter() - t0),
                         "context_requests": cost_snapshot.get("context_requests", 0),
                         "max_estimated_context_tokens": cost_snapshot.get("max_estimated_context_tokens", 0),
                         "max_context_window_tokens": cost_snapshot.get("max_context_window_tokens", 0),
@@ -614,6 +619,10 @@ class AgentHandler:
                         "retry_provider_failures": cost_snapshot.get("retry_provider_failures", 0),
                         "retry_deadline_exits": cost_snapshot.get("retry_deadline_exits", 0),
                         "model_breakdown": cost_snapshot.get("model_breakdown", {}),
+                        "phase_breakdown": cost_snapshot.get("phase_breakdown", {}),
+                        "page_fetches": cost_snapshot.get("page_fetches", 0),
+                        "fetched_chars": cost_snapshot.get("fetched_chars", 0),
+                        "page_budget_blocked": cost_snapshot.get("page_budget_blocked", 0),
                     }
                 db.collection("pipeline_queue").document(item_id).set(
                     {
@@ -637,7 +646,7 @@ class AgentHandler:
 
             # Keep one logical run active across physical function invocations.
             if _fs_logger:
-                _fs_logger.mark_handoff(item_id)
+                _fs_logger.mark_handoff(item_id, duration_ms=int((time.perf_counter() - t0) * 1000))
 
             raise HandoffTriggered(item_id, remaining, continuation_run_id)
 

--- a/pipeline_client/backend/pipeline_metrics.py
+++ b/pipeline_client/backend/pipeline_metrics.py
@@ -105,10 +105,19 @@ class PipelineMetricsStore:
                     cost_usd          REAL,
                     cost_source       TEXT NOT NULL DEFAULT 'estimated',
                     model_breakdown   TEXT NOT NULL DEFAULT '{}',
+                    phase_breakdown   TEXT NOT NULL DEFAULT '{}',
                     duration_s        REAL NOT NULL DEFAULT 0,
                     candidate_count   INTEGER NOT NULL DEFAULT 0,
                     cheap_mode        INTEGER NOT NULL DEFAULT 0,
-                    serper_calls      INTEGER NOT NULL DEFAULT 0
+                    serper_calls      INTEGER NOT NULL DEFAULT 0,
+                    searlo_calls      INTEGER NOT NULL DEFAULT 0,
+                    search_calls      INTEGER NOT NULL DEFAULT 0,
+                    search_budget_blocked INTEGER NOT NULL DEFAULT 0,
+                    token_budget_nudges INTEGER NOT NULL DEFAULT 0,
+                    segment_duration_s REAL NOT NULL DEFAULT 0
+                    ,page_fetches INTEGER NOT NULL DEFAULT 0
+                    ,fetched_chars INTEGER NOT NULL DEFAULT 0
+                    ,page_budget_blocked INTEGER NOT NULL DEFAULT 0
                 )
                 """
             )
@@ -123,6 +132,15 @@ class PipelineMetricsStore:
                 "search_cost_usd REAL NOT NULL DEFAULT 0",
                 "cost_source TEXT NOT NULL DEFAULT 'estimated'",
                 "serper_calls INTEGER NOT NULL DEFAULT 0",
+                "searlo_calls INTEGER NOT NULL DEFAULT 0",
+                "search_calls INTEGER NOT NULL DEFAULT 0",
+                "search_budget_blocked INTEGER NOT NULL DEFAULT 0",
+                "token_budget_nudges INTEGER NOT NULL DEFAULT 0",
+                "segment_duration_s REAL NOT NULL DEFAULT 0",
+                "phase_breakdown TEXT NOT NULL DEFAULT '{}'",
+                "page_fetches INTEGER NOT NULL DEFAULT 0",
+                "fetched_chars INTEGER NOT NULL DEFAULT 0",
+                "page_budget_blocked INTEGER NOT NULL DEFAULT 0",
             ]:
                 try:
                     conn.execute(f"ALTER TABLE pipeline_metrics ADD COLUMN {col_def}")
@@ -165,10 +183,19 @@ class PipelineMetricsStore:
             "cost_usd": agent_metrics.get("cost_usd"),
             "cost_source": agent_metrics.get("cost_source", "estimated"),
             "model_breakdown": agent_metrics.get("model_breakdown", {}),
+            "phase_breakdown": agent_metrics.get("phase_breakdown", {}),
+            "page_fetches": agent_metrics.get("page_fetches", 0),
+            "fetched_chars": agent_metrics.get("fetched_chars", 0),
+            "page_budget_blocked": agent_metrics.get("page_budget_blocked", 0),
             "duration_s": agent_metrics.get("duration_s", 0.0),
             "candidate_count": candidate_count,
             "cheap_mode": cheap_mode,
             "serper_calls": serper_calls,
+            "searlo_calls": agent_metrics.get("searlo_calls", 0),
+            "search_calls": agent_metrics.get("search_calls", serper_calls),
+            "search_budget_blocked": agent_metrics.get("search_budget_blocked", 0),
+            "token_budget_nudges": agent_metrics.get("token_budget_nudges", 0),
+            "segment_duration_s": agent_metrics.get("segment_duration_s", 0.0),
         }
 
         if self._client is not None:
@@ -194,9 +221,11 @@ class PipelineMetricsStore:
                         (run_id, race_id, timestamp, status, model,
                          prompt_tokens, completion_tokens, total_tokens,
                          estimated_usd, llm_cost_usd, search_cost_usd,
-                         cost_usd, cost_source, model_breakdown, duration_s,
-                         candidate_count, cheap_mode, serper_calls)
-                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                         cost_usd, cost_source, model_breakdown, phase_breakdown, duration_s,
+                         candidate_count, cheap_mode, serper_calls, searlo_calls,
+                         search_calls, search_budget_blocked, token_budget_nudges,
+                         segment_duration_s, page_fetches, fetched_chars, page_budget_blocked)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                     """,
                     (
                         record["run_id"],
@@ -213,10 +242,19 @@ class PipelineMetricsStore:
                         record["cost_usd"],
                         record["cost_source"],
                         json.dumps(record["model_breakdown"]),
+                        json.dumps(record["phase_breakdown"]),
                         record["duration_s"],
                         record.get("candidate_count", 0),
                         int(record.get("cheap_mode", True)),
                         record.get("serper_calls", 0),
+                        record.get("searlo_calls", 0),
+                        record.get("search_calls", 0),
+                        record.get("search_budget_blocked", 0),
+                        record.get("token_budget_nudges", 0),
+                        record.get("segment_duration_s", 0.0),
+                        record.get("page_fetches", 0),
+                        record.get("fetched_chars", 0),
+                        record.get("page_budget_blocked", 0),
                     ),
                 )
                 conn.commit()
@@ -256,8 +294,10 @@ class PipelineMetricsStore:
                     SELECT run_id, race_id, timestamp, status, model,
                            prompt_tokens, completion_tokens, total_tokens,
                            estimated_usd, llm_cost_usd, search_cost_usd,
-                           cost_usd, cost_source, model_breakdown, duration_s,
-                           candidate_count, cheap_mode, serper_calls
+                           cost_usd, cost_source, model_breakdown, phase_breakdown, duration_s,
+                           candidate_count, cheap_mode, serper_calls, searlo_calls,
+                           search_calls, search_budget_blocked, token_budget_nudges,
+                           segment_duration_s, page_fetches, fetched_chars, page_budget_blocked
                     FROM pipeline_metrics
                     ORDER BY timestamp DESC
                     LIMIT ?
@@ -282,10 +322,19 @@ class PipelineMetricsStore:
                     cost_usd,
                     cost_source,
                     model_breakdown_json,
+                    phase_breakdown_json,
                     duration_s,
                     candidate_count,
                     cheap_mode_int,
                     serper_calls,
+                    searlo_calls,
+                    search_calls,
+                    search_budget_blocked,
+                    token_budget_nudges,
+                    segment_duration_s,
+                    page_fetches,
+                    fetched_chars,
+                    page_budget_blocked,
                 ) = row
                 rows_list.append(
                     {
@@ -303,10 +352,19 @@ class PipelineMetricsStore:
                         "cost_usd": cost_usd,
                         "cost_source": cost_source,
                         "model_breakdown": json.loads(model_breakdown_json or "{}"),
+                        "phase_breakdown": json.loads(phase_breakdown_json or "{}"),
                         "duration_s": duration_s,
                         "candidate_count": candidate_count or 0,
                         "cheap_mode": bool(cheap_mode_int),
                         "serper_calls": serper_calls or 0,
+                        "searlo_calls": searlo_calls or 0,
+                        "search_calls": search_calls or 0,
+                        "search_budget_blocked": search_budget_blocked or 0,
+                        "token_budget_nudges": token_budget_nudges or 0,
+                        "segment_duration_s": segment_duration_s or 0.0,
+                        "page_fetches": page_fetches or 0,
+                        "fetched_chars": fetched_chars or 0,
+                        "page_budget_blocked": page_budget_blocked or 0,
                     }
                 )
             return rows_list

--- a/pipeline_client/backend/queue_processor.py
+++ b/pipeline_client/backend/queue_processor.py
@@ -392,6 +392,10 @@ async def process_claimed_item(
                 "cost_source": "provider" if has_exact_cost else "estimated",
                 "estimated_usd": estimated_usd + search_cost_usd,
                 "model_breakdown": breakdown,
+                "phase_breakdown": acc.get("phase_breakdown", {}),
+                "page_fetches": int(acc.get("page_fetches", 0) or 0),
+                "fetched_chars": int(acc.get("fetched_chars", 0) or 0),
+                "page_budget_blocked": int(acc.get("page_budget_blocked", 0) or 0),
                 "duration_s": round(_time.perf_counter() - started_at, 1),
                 "serper_calls": int(acc.get("serper_calls", 0) or 0),
             }

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -108,6 +108,7 @@ CHECKED_MODELS: Dict[str, Type[BaseModel]] = {
     "AgentReview": shared_models.AgentReview,
     "ValidationGrade": shared_models.ValidationGrade,
     "ForecastMarketSignal": shared_models.ForecastMarketSignal,
+    "ForecastEvidence": shared_models.ForecastEvidence,
     "RaceForecast": shared_models.RaceForecast,
     "Candidate": shared_models.Candidate,
     "PollMatchup": shared_models.PollMatchup,

--- a/services/races-api/request_models.py
+++ b/services/races-api/request_models.py
@@ -4,7 +4,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from shared.pipeline_options import PipelineRunOptions
 
@@ -28,6 +28,28 @@ class RaceQueueRequest(BaseModel):
 
 class BatchPublishRequest(BaseModel):
     race_ids: List[str]
+
+
+class RepairPlanRequest(BaseModel):
+    race_ids: List[str]
+
+    @field_validator("race_ids")
+    @classmethod
+    def validate_race_ids(cls, value: List[str]) -> List[str]:
+        normalized = list(dict.fromkeys(str(race_id).strip() for race_id in value if str(race_id).strip()))
+        if not normalized:
+            raise ValueError("race_ids cannot be empty")
+        if len(normalized) > 200:
+            raise ValueError("race_ids cannot contain more than 200 races")
+        for race_id in normalized:
+            if not _RACE_ID_RE.match(race_id):
+                raise ValueError(f"invalid race_id: {race_id}")
+        return normalized
+
+
+class AssetAuditRequest(RepairPlanRequest):
+    persist: bool = False
+    max_urls_per_race: int = Field(default=100, ge=1, le=300)
 
 
 class AdminChatMessage(BaseModel):

--- a/services/races-api/routers/pipeline.py
+++ b/services/races-api/routers/pipeline.py
@@ -77,6 +77,7 @@ def _normalize_pipeline_run(raw: Dict[str, Any], fallback_run_id: str) -> Dict[s
     prompt_tokens = _as_int(raw.get("prompt_tokens"), _as_int(agent_metrics.get("prompt_tokens"), 0))
     completion_tokens = _as_int(raw.get("completion_tokens"), _as_int(agent_metrics.get("completion_tokens"), 0))
     serper_calls = _as_int(raw.get("serper_calls"), _as_int(agent_metrics.get("serper_calls"), 0))
+    searlo_calls = _as_int(raw.get("searlo_calls"), _as_int(agent_metrics.get("searlo_calls"), 0))
 
     estimated_usd = _as_float(
         raw.get("estimated_usd"),
@@ -102,7 +103,9 @@ def _normalize_pipeline_run(raw: Dict[str, Any], fallback_run_id: str) -> Dict[s
     if candidate_count <= 0 and isinstance(payload.get("candidates"), list):
         candidate_count = len(payload.get("candidates") or [])
 
-    duration_s = _as_float(raw.get("duration_s"), 0.0)
+    duration_s = _as_float(raw.get("logical_duration_ms"), 0.0) / 1000.0
+    if duration_s <= 0:
+        duration_s = _as_float(raw.get("duration_s"), 0.0)
     if duration_s <= 0:
         duration_ms = _as_float(raw.get("duration_ms"), 0.0)
         if duration_ms > 0:
@@ -124,9 +127,26 @@ def _normalize_pipeline_run(raw: Dict[str, Any], fallback_run_id: str) -> Dict[s
         "cost_source": cost_source,
         "model_breakdown": model_breakdown,
         "duration_s": duration_s,
+        "segment_duration_s": _as_float(
+            raw.get("segment_duration_s"),
+            _as_float(agent_metrics.get("segment_duration_s"), 0.0),
+        ),
+        "continuation_count": _as_int(raw.get("continuation_count"), 0),
         "candidate_count": candidate_count,
         "cheap_mode": cheap_mode,
         "serper_calls": serper_calls,
+        "searlo_calls": searlo_calls,
+        "search_calls": _as_int(
+            raw.get("search_calls"), _as_int(agent_metrics.get("search_calls"), serper_calls + searlo_calls)
+        ),
+        "search_budget_blocked": _as_int(
+            raw.get("search_budget_blocked"),
+            _as_int(agent_metrics.get("search_budget_blocked"), 0),
+        ),
+        "token_budget_nudges": _as_int(
+            raw.get("token_budget_nudges"),
+            _as_int(agent_metrics.get("token_budget_nudges"), 0),
+        ),
         "model_profile": options.get("model_profile"),
     }
 
@@ -391,6 +411,9 @@ async def get_pipeline_metrics(limit: int = 50) -> Dict[str, Any]:
             merged["serper_calls"] = run_record["serper_calls"]
         if run_record.get("duration_s") and not merged.get("duration_s"):
             merged["duration_s"] = run_record["duration_s"]
+        for field in ("continuation_count", "search_budget_blocked", "token_budget_nudges"):
+            if run_record.get(field) and not merged.get(field):
+                merged[field] = run_record[field]
         records.append(merged)
         seen.add(run_id)
 

--- a/services/races-api/routers/races_admin/drafts.py
+++ b/services/races-api/routers/races_admin/drafts.py
@@ -45,6 +45,7 @@ async def delete_draft_race(race_id: str) -> Dict[str, Any]:
         "draft_updated_utc": None,
         "draft_candidate_count": None,
         "draft_quality_grade": None,
+        "draft_catalog_health": None,
     }
     if has_published:
         published_data = gcs_helpers._gcs_get_race_json(race_id, "races")
@@ -72,6 +73,7 @@ async def publish_race(request: Request, race_id: str) -> Dict[str, Any]:
             "draft_updated_utc": None,
             "draft_candidate_count": None,
             "draft_quality_grade": None,
+            "draft_catalog_health": None,
         },
     )
     _clear_public_race_cache(request)
@@ -93,6 +95,7 @@ async def unpublish_race(request: Request, race_id: str) -> Dict[str, Any]:
         "published_updated_utc": None,
         "published_candidate_count": None,
         "published_quality_grade": None,
+        "published_catalog_health": None,
         "draft_updated_at": datetime.now(timezone.utc).isoformat() if has_draft else None,
     }
     if has_draft:
@@ -128,6 +131,7 @@ async def batch_publish_races(request: Request, payload: BatchPublishRequest) ->
                     "draft_updated_utc": None,
                     "draft_candidate_count": None,
                     "draft_quality_grade": None,
+                    "draft_catalog_health": None,
                 },
             )
             published.append(race_id)

--- a/services/races-api/routers/races_admin/helpers.py
+++ b/services/races-api/routers/races_admin/helpers.py
@@ -108,6 +108,7 @@ def _catalog_update_from_storage(race_id: str) -> Dict[str, Any] | None:
                 "published_updated_utc": None,
                 "published_candidate_count": None,
                 "published_quality_grade": None,
+                "published_catalog_health": None,
             }
         )
 
@@ -120,6 +121,7 @@ def _catalog_update_from_storage(race_id: str) -> Dict[str, Any] | None:
                 "draft_updated_utc": None,
                 "draft_candidate_count": None,
                 "draft_quality_grade": None,
+                "draft_catalog_health": None,
             }
         )
 
@@ -347,12 +349,14 @@ def _apply_catalog_view(race: Dict[str, Any]) -> Dict[str, Any]:
 
     if published_exists:
         race["quality_grade"] = race.get("published_quality_grade")
+        race["catalog_health"] = race.get("published_catalog_health") or race.get("catalog_health")
         if race.get("published_candidate_count") is not None:
             race["candidate_count"] = race.get("published_candidate_count")
         if published_updated:
             race["public_updated_utc"] = published_updated
     elif draft_exists:
         race["quality_grade"] = race.get("draft_quality_grade")
+        race["catalog_health"] = race.get("draft_catalog_health") or race.get("catalog_health")
         if race.get("draft_candidate_count") is not None:
             race["candidate_count"] = race.get("draft_candidate_count")
 

--- a/services/races-api/routers/races_admin/race_runs.py
+++ b/services/races-api/routers/races_admin/race_runs.py
@@ -13,9 +13,10 @@ router = APIRouter()
 
 @router.get("/api/races/{race_id}/runs", dependencies=[Depends(verify_token)])
 async def list_race_runs(race_id: str, limit: int = 20) -> Dict[str, Any]:
-    """List runs for a specific race from Firestore."""
+    """List archived and canonical runs for a specific race from Firestore."""
     validate_race_id(race_id)
     db = firestore_helpers._get_fs()
+    limit = max(1, min(limit, 100))
     sub_docs = (
         db.collection("races")
         .document(race_id)
@@ -24,13 +25,26 @@ async def list_race_runs(race_id: str, limit: int = 20) -> Dict[str, Any]:
         .limit(limit)
         .stream()
     )
-    runs = [firestore_helpers._doc_to_plain(d) for d in sub_docs]
-    active_docs = db.collection("pipeline_runs").where("race_id", "==", race_id).stream()
-    for d in active_docs:
+    runs_by_id: Dict[str, Dict[str, Any]] = {}
+    for d in sub_docs:
         data = firestore_helpers._doc_to_plain(d)
-        if data and data.get("status") in ("pending", "running"):
-            runs.insert(0, data)
-    runs = [r for r in runs if r is not None]
+        if data:
+            runs_by_id[str(data.get("run_id") or getattr(d, "id", ""))] = data
+
+    canonical_docs = db.collection("pipeline_runs").where("race_id", "==", race_id).stream()
+    for d in canonical_docs:
+        data = firestore_helpers._doc_to_plain(d)
+        if data:
+            runs_by_id[str(data.get("run_id") or getattr(d, "id", ""))] = data
+
+    runs = list(runs_by_id.values())
+    runs.sort(
+        key=lambda run: (
+            run.get("status") in ("pending", "running"),
+            str(run.get("started_at") or run.get("created_at") or ""),
+        ),
+        reverse=True,
+    )
     return {"runs": runs[:limit], "count": len(runs[:limit])}
 
 

--- a/services/races-api/routers/races_admin/records.py
+++ b/services/races-api/routers/races_admin/records.py
@@ -1,17 +1,26 @@
 """Race record (Firestore metadata) CRUD, status reconciliation, and run trigger endpoints."""
 
+import asyncio
+import ipaddress
 import logging
 import os
+import re
+import socket
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Dict
+from urllib.parse import urlparse
 
 import firestore_helpers
 import gcs_helpers
+import httpx
 from auth import verify_token
 from cloud_run_jobs import dispatch_pipeline_job
 from fastapi import APIRouter, Depends, HTTPException, Request
-from request_models import RunOptions, validate_race_id
+from request_models import AssetAuditRequest, RepairPlanRequest, RunOptions, validate_race_id
 from routers.utils import _queue_ttl_at
+
+from shared.repair_planner import build_repair_plan, summarize_repair_plans
 
 from .helpers import (
     _apply_catalog_view,
@@ -115,6 +124,148 @@ async def recheck_all_race_statuses() -> Dict[str, Any]:
         races.append({"race_id": race_id, **update})
         updated += 1
     return {"message": f"Rechecked {len(races)} races", "checked": len(races), "updated": updated, "races": races}
+
+
+@router.post("/api/races/repair-plan", dependencies=[Depends(verify_token)])
+async def plan_race_repairs(request: RepairPlanRequest) -> Dict[str, Any]:
+    """Build bounded repair plans from the latest draft-or-published RaceJSON."""
+    db = firestore_helpers._get_fs()
+    plans = []
+    missing_race_ids = []
+    for race_id in request.race_ids:
+        catalog_doc = db.collection("races").document(race_id).get()
+        catalog = firestore_helpers._doc_to_plain(catalog_doc) or {}
+        _apply_catalog_view(catalog)
+        race_data = gcs_helpers._gcs_get_race_json(race_id, "drafts")
+        if not isinstance(race_data, dict):
+            race_data = gcs_helpers._gcs_get_race_json(race_id, "races")
+        if not isinstance(race_data, dict):
+            missing_race_ids.append(race_id)
+            continue
+        plans.append(build_repair_plan(race_id, race_data, freshness=catalog.get("freshness")))
+    return {**summarize_repair_plans(plans), "missing_race_ids": missing_race_ids}
+
+
+def _asset_urls(race_data: Dict[str, Any]) -> list[tuple[str, str]]:
+    assets: list[tuple[str, str]] = []
+    for candidate in race_data.get("candidates") or []:
+        if not isinstance(candidate, dict):
+            continue
+        if candidate.get("image_url"):
+            assets.append(("image", str(candidate["image_url"])))
+        for key in ("roster_sources", "donor_sources", "voting_sources", "summary_sources"):
+            for source in candidate.get(key) or []:
+                if isinstance(source, dict) and source.get("url"):
+                    assets.append((key, str(source["url"])))
+        for issue in (candidate.get("issues") or {}).values():
+            if isinstance(issue, dict):
+                for source in issue.get("sources") or []:
+                    if isinstance(source, dict) and source.get("url"):
+                        assets.append(("issue_source", str(source["url"])))
+    forecast = race_data.get("forecast") or {}
+    for url in forecast.get("source_urls") or []:
+        assets.append(("forecast_source", str(url)))
+    return list(dict.fromkeys(assets))
+
+
+def _safe_public_asset_url(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    host = parsed.hostname.casefold()
+    if host in {"localhost", "metadata.google.internal"} or host.endswith((".local", ".internal")):
+        return False
+    try:
+        return ipaddress.ip_address(host).is_global
+    except ValueError:
+        return True
+
+
+async def _host_resolves_public(url: str) -> bool:
+    host = urlparse(url).hostname
+    if not host:
+        return False
+    try:
+        addresses = await asyncio.get_running_loop().getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except OSError:
+        return False
+    resolved = {entry[4][0] for entry in addresses}
+    return bool(resolved) and all(ipaddress.ip_address(address).is_global for address in resolved)
+
+
+async def _probe_asset(client: httpx.AsyncClient, kind: str, url: str) -> Dict[str, Any]:
+    if not _safe_public_asset_url(url) or not await _host_resolves_public(url):
+        return {"kind": kind, "url": url, "status": "blocked", "reachable": False}
+    try:
+        response = await client.head(url, follow_redirects=False)
+        content_type = response.headers.get("content-type", "").split(";")[0].lower()
+        reachable = response.status_code < 400 or response.status_code in {401, 403, 405}
+        image_valid = (
+            None
+            if kind != "image" or response.status_code in {401, 403, 405} or not content_type
+            else content_type.startswith("image/")
+        )
+        content_length = int(response.headers.get("content-length") or 0) or None
+        thumbnail_match = re.search(r"(?:^|[-_/])(\d{2,4})x(\d{2,4})(?:[-_.?/]|$)", url, re.IGNORECASE)
+        suspicious_thumbnail = bool(
+            thumbnail_match and min(int(thumbnail_match.group(1)), int(thumbnail_match.group(2))) < 150
+        )
+        image_quality = None
+        if kind == "image" and image_valid is False:
+            image_quality = "invalid_content_type"
+        elif kind == "image" and (suspicious_thumbnail or (content_length is not None and content_length < 10_000)):
+            image_quality = "suspicious_small"
+        elif kind == "image" and image_valid is True:
+            image_quality = "content_type_valid"
+        return {
+            "kind": kind,
+            "url": url,
+            "status": "reachable" if reachable else "broken",
+            "reachable": reachable,
+            "http_status": response.status_code,
+            "content_type": content_type or None,
+            "content_length": content_length,
+            "image_content_type_valid": image_valid,
+            "image_quality": image_quality,
+            "redirect_location": response.headers.get("location"),
+        }
+    except (httpx.HTTPError, ValueError) as exc:
+        return {"kind": kind, "url": url, "status": "error", "reachable": False, "error": str(exc)[:300]}
+
+
+@router.post("/api/races/asset-audit", dependencies=[Depends(verify_token)])
+async def audit_race_assets(request: AssetAuditRequest) -> Dict[str, Any]:
+    """Probe bounded race assets without downloading their bodies; optionally persist results."""
+    db = firestore_helpers._get_fs()
+    audited_at = datetime.now(timezone.utc).isoformat()
+    results = []
+    async with httpx.AsyncClient(timeout=10.0, headers={"User-Agent": "SmarterVote asset auditor/1.0"}) as client:
+        for race_id in request.race_ids:
+            race_data = gcs_helpers._gcs_get_race_json(race_id, "drafts")
+            if not isinstance(race_data, dict):
+                race_data = gcs_helpers._gcs_get_race_json(race_id, "races")
+            if not isinstance(race_data, dict):
+                results.append({"race_id": race_id, "missing": True})
+                continue
+            assets = _asset_urls(race_data)[: request.max_urls_per_race]
+            probes = await asyncio.gather(*(_probe_asset(client, kind, url) for kind, url in assets))
+            result = {
+                "race_id": race_id,
+                "audited_at": audited_at,
+                "asset_count": len(probes),
+                "reachable_count": sum(bool(probe.get("reachable")) for probe in probes),
+                "broken_count": sum(not bool(probe.get("reachable")) for probe in probes),
+                "invalid_image_count": sum(probe.get("image_content_type_valid") is False for probe in probes),
+                "suspicious_image_count": sum(probe.get("image_quality") == "suspicious_small" for probe in probes),
+                "assets": probes,
+            }
+            results.append(result)
+            if request.persist:
+                db.collection("races").document(race_id).set(
+                    {"asset_audit": result, "asset_audited_at": audited_at},
+                    merge=True,
+                )
+    return {"results": results, "persisted": request.persist}
 
 
 @router.get("/api/races/{race_id}", dependencies=[Depends(verify_token)])

--- a/shared/models.py
+++ b/shared/models.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 
+from shared.run_health import StepFailure
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
@@ -256,6 +258,15 @@ class ForecastMarketSignal(BaseModel):
     confidence: ConfidenceLevel = ConfidenceLevel.UNKNOWN
 
 
+class ForecastEvidence(BaseModel):
+    """Lineage from one forecast claim to the source that supports it."""
+
+    claim: str
+    source_url: str
+    kind: Literal["polling", "market", "finance", "race_context", "other"] = "other"
+    inferred: bool = False
+
+
 class RaceForecast(BaseModel):
     """Informational AI forecast for a race."""
 
@@ -274,6 +285,7 @@ class RaceForecast(BaseModel):
     generated_at: datetime
     model: str
     source_urls: List[str] = Field(default_factory=list)
+    evidence_lineage: Optional[List[ForecastEvidence]] = None
     market_signals: List[ForecastMarketSignal] = Field(default_factory=list)
 
     @field_validator("party_probabilities")
@@ -435,6 +447,9 @@ class PipelineState(BaseModel):
     remaining_candidates: List[str] = Field(default_factory=list)
     remaining_steps: List[str] = Field(default_factory=list)
     completed_units: List[str] = Field(default_factory=list)
+    issue_attempts: Dict[str, int] = Field(default_factory=dict)
+    step_failures: List[StepFailure] = Field(default_factory=list)
+    deterministic_cleanup: Dict[str, int] = Field(default_factory=dict)
     race_identity: Optional[RaceIdentityBrief] = None
 
 

--- a/shared/pipeline_config.py
+++ b/shared/pipeline_config.py
@@ -96,6 +96,12 @@ class PipelineRuntimeConfig:
     iteration_min_iterations: int = 14
     quality_critical_issue_stances: int = CANONICAL_ISSUE_COUNT // 2
     quality_warning_issue_stances: int = (CANONICAL_ISSUE_COUNT * 2) // 3
+    max_search_calls: int = 240
+    max_total_tokens: int = 2_500_000
+    max_phase_search_calls: int = 120
+    max_phase_tokens: int = 1_250_000
+    max_page_fetches: int = 300
+    max_fetched_chars: int = 3_000_000
 
     @classmethod
     def from_env(cls) -> "PipelineRuntimeConfig":
@@ -113,6 +119,12 @@ class PipelineRuntimeConfig:
             iteration_min_iterations=_env_int("PIPELINE_ITERATION_MIN_ITERATIONS", 14, 1, None),
             quality_critical_issue_stances=critical,
             quality_warning_issue_stances=warning,
+            max_search_calls=_env_int("PIPELINE_MAX_SEARCH_CALLS", 240, 1, 5000),
+            max_total_tokens=_env_int("PIPELINE_MAX_TOTAL_TOKENS", 2_500_000, 10_000, 50_000_000),
+            max_phase_search_calls=_env_int("PIPELINE_MAX_PHASE_SEARCH_CALLS", 120, 1, 5000),
+            max_phase_tokens=_env_int("PIPELINE_MAX_PHASE_TOKENS", 1_250_000, 10_000, 50_000_000),
+            max_page_fetches=_env_int("PIPELINE_MAX_PAGE_FETCHES", 300, 1, 5000),
+            max_fetched_chars=_env_int("PIPELINE_MAX_FETCHED_CHARS", 3_000_000, 10_000, 100_000_000),
         )
 
 

--- a/shared/race_catalog.py
+++ b/shared/race_catalog.py
@@ -3,7 +3,26 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
-from shared.pipeline_config import FreshnessConfig
+from shared.models import CanonicalIssue
+from shared.pipeline_config import CANONICAL_ISSUE_COUNT, FreshnessConfig
+from shared.race_cleanup import forecast_evidence_gaps
+
+_PLACEHOLDER_STANCES = {
+    "",
+    "draft",
+    "fixme",
+    "missing",
+    "n/a",
+    "none",
+    "pending",
+    "placeholder",
+    "tbd",
+    "to be determined",
+    "todo",
+    "unknown",
+    "wip",
+}
+_CANONICAL_ISSUES = {issue.value for issue in CanonicalIssue}
 
 
 def _coerce_datetime(value: Any) -> datetime | None:
@@ -38,12 +57,236 @@ def compute_freshness(updated_utc: Any) -> str | None:
     return "old"
 
 
+def _latest_date(values: List[Any]) -> datetime | None:
+    parsed = [date for date in (_coerce_datetime(value) for value in values) if date is not None]
+    return max(parsed) if parsed else None
+
+
+def _section_freshness(race_data: Dict[str, Any], candidates: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return independent freshness signals instead of treating a race as one timestamp."""
+    section_dates: Dict[str, List[Any]] = {
+        "roster": [],
+        "issues": [],
+        "finance": [],
+        "polling": [],
+        "forecast": [],
+        "voter_resources": [],
+    }
+    for candidate in candidates:
+        for source in candidate.get("roster_sources") or []:
+            if isinstance(source, dict):
+                section_dates["roster"].append(source.get("last_accessed") or source.get("published_at"))
+        for issue in (candidate.get("issues") or {}).values():
+            if not isinstance(issue, dict):
+                continue
+            for source in issue.get("sources") or []:
+                if isinstance(source, dict):
+                    section_dates["issues"].append(source.get("last_accessed") or source.get("published_at"))
+        for key in ("donor_sources", "voting_sources"):
+            for source in candidate.get(key) or []:
+                if isinstance(source, dict):
+                    section_dates["finance"].append(source.get("last_accessed") or source.get("published_at"))
+    for poll in race_data.get("polling") or []:
+        if isinstance(poll, dict):
+            section_dates["polling"].append(
+                poll.get("last_accessed") or poll.get("end_date") or poll.get("date") or poll.get("published_at")
+            )
+    forecast = race_data.get("forecast")
+    if isinstance(forecast, dict):
+        section_dates["forecast"].append(forecast.get("generated_at"))
+    fallback = race_data.get("updated_utc") or race_data.get("generated_at")
+    if any(race_data.get(key) for key in ("register_to_vote_url", "find_polling_place_url", "absentee_ballot_url")):
+        section_dates["voter_resources"].append(fallback)
+
+    result: Dict[str, Any] = {}
+    for section, values in section_dates.items():
+        latest = _latest_date(values)
+        result[section] = {
+            "updated_at": latest.isoformat() if latest else None,
+            "status": compute_freshness(latest),
+        }
+    return result
+
+
 def extract_quality_grade(race_data: Dict[str, Any]) -> str | None:
     validation_grade = race_data.get("validation_grade")
     if not isinstance(validation_grade, dict):
         return None
     grade = validation_grade.get("grade")
     return str(grade) if grade else None
+
+
+def _is_missing_image(value: Any) -> bool:
+    url = str(value or "").strip().lower()
+    return not url or "submitphoto-150px" in url
+
+
+def _issue_verdict(value: Any) -> tuple[bool, bool, bool]:
+    """Return (terminal, substantive, sourced) for one issue record."""
+    if not isinstance(value, dict):
+        return False, False, False
+    stance = str(value.get("stance") or "").strip()
+    normalized = stance.strip(".").casefold()
+    placeholder_prefix = any(
+        normalized == marker or normalized.startswith(f"{marker} ") for marker in _PLACEHOLDER_STANCES if marker
+    )
+    if not stance or normalized in _PLACEHOLDER_STANCES or (len(normalized) <= 60 and placeholder_prefix):
+        return False, False, False
+    no_position = "no public position found" in normalized or "no publicly stated position" in normalized
+    sources = value.get("sources")
+    sourced = isinstance(sources, list) and any(
+        isinstance(source, dict) and str(source.get("url") or "").strip() for source in sources
+    )
+    return True, not no_position, sourced
+
+
+def _strong_roster_source(source: Any, race_id: Any) -> bool:
+    if not isinstance(source, dict) or not source.get("url"):
+        return False
+    try:
+        tier = int(source.get("evidence_tier") or 99)
+    except (TypeError, ValueError):
+        return False
+    return (
+        tier <= 2
+        and source.get("retrieval_status", "content") == "content"
+        and (not source.get("race_id") or source.get("race_id") == race_id)
+    )
+
+
+def build_catalog_health(race_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Materialize compact coverage facts used for catalog targeting and repair plans."""
+    candidates = [candidate for candidate in race_data.get("candidates", []) if isinstance(candidate, dict)]
+    candidate_count = len(candidates)
+    issue_slots = candidate_count * CANONICAL_ISSUE_COUNT
+    terminal_issues = 0
+    substantive_issues = 0
+    sourced_issues = 0
+    sourced_substantive_issues = 0
+    missing_images = 0
+    roster_verified_candidates = 0
+    roster_strong_evidence_candidates = 0
+    finance_complete_candidates = 0
+    incumbent_count = 0
+    voting_complete_incumbents = 0
+
+    for candidate in candidates:
+        missing_images += int(_is_missing_image(candidate.get("image_url")))
+        roster_sources = candidate.get("roster_sources")
+        roster_verified_candidates += int(isinstance(roster_sources, list) and bool(roster_sources))
+        strong_roster_source = any(
+            _strong_roster_source(source, race_data.get("race_id")) for source in (roster_sources or [])
+        )
+        roster_strong_evidence_candidates += int(strong_roster_source)
+        issues = candidate.get("issues") if isinstance(candidate.get("issues"), dict) else {}
+        for issue_name, issue in issues.items():
+            if str(issue_name) not in _CANONICAL_ISSUES:
+                continue
+            terminal, substantive, sourced = _issue_verdict(issue)
+            terminal_issues += int(terminal)
+            substantive_issues += int(substantive)
+            sourced_issues += int(sourced)
+            sourced_substantive_issues += int(substantive and sourced)
+
+        donor_sources = candidate.get("donor_sources")
+        has_finance_source = bool(candidate.get("donor_source_url")) or (
+            isinstance(donor_sources, list) and bool(donor_sources)
+        )
+        finance_complete_candidates += int(bool(candidate.get("donor_summary")) and has_finance_source)
+
+        if candidate.get("incumbent"):
+            incumbent_count += 1
+            voting_sources = candidate.get("voting_sources")
+            has_voting_source = bool(candidate.get("voting_source_url")) or (
+                isinstance(voting_sources, list) and bool(voting_sources)
+            )
+            voting_complete_incumbents += int(bool(candidate.get("voting_summary")) and has_voting_source)
+
+    grade_data = race_data.get("validation_grade")
+    grade_data = grade_data if isinstance(grade_data, dict) else {}
+    grade = str(grade_data.get("grade") or "").upper() or None
+    if grade in {"A", "B"} and grade_data.get("passed") is True:
+        research_tier = "validated"
+    elif grade in {"A", "B", "C", "D", "F"}:
+        research_tier = "graded_low"
+    elif candidate_count == 0:
+        research_tier = "empty"
+    elif terminal_issues == 0:
+        research_tier = "discovery_only"
+    elif terminal_issues < issue_slots:
+        research_tier = "partial_research"
+    else:
+        research_tier = "full_unreviewed"
+
+    forecast = race_data.get("forecast") if isinstance(race_data.get("forecast"), dict) else {}
+    forecast_sources = forecast.get("source_urls") if isinstance(forecast.get("source_urls"), list) else []
+    forecast_lineage = forecast.get("evidence_lineage") if isinstance(forecast.get("evidence_lineage"), list) else []
+    forecast_gaps = forecast_evidence_gaps(race_data)
+    forecast_evidence_complete = bool(forecast) and bool(forecast_sources) and not forecast_gaps
+    forecast_lineage_complete = bool(forecast_lineage) and all(
+        isinstance(item, dict)
+        and bool(item.get("claim"))
+        and bool(item.get("source_url"))
+        and item.get("source_url") in forecast_sources
+        for item in forecast_lineage
+    )
+    pipeline_state = race_data.get("pipeline_state") if isinstance(race_data.get("pipeline_state"), dict) else {}
+    run_health = race_data.get("run_health") if isinstance(race_data.get("run_health"), dict) else {}
+    section_freshness = _section_freshness(race_data, candidates)
+    stale_sections = [section for section, value in section_freshness.items() if value.get("status") in {"stale", "old"}]
+
+    gaps: List[str] = []
+    if candidate_count == 0:
+        gaps.append("missing_roster")
+    if missing_images:
+        gaps.append("missing_images")
+    if terminal_issues < issue_slots:
+        gaps.append("missing_issue_research")
+    if substantive_issues and sourced_substantive_issues < substantive_issues:
+        gaps.append("unsourced_issue_stances")
+    if finance_complete_candidates < candidate_count:
+        gaps.append("incomplete_finance")
+    if voting_complete_incumbents < incumbent_count:
+        gaps.append("incomplete_voting_record")
+    if not forecast:
+        gaps.append("missing_forecast")
+    elif not forecast_evidence_complete:
+        gaps.append("forecast_missing_sources")
+    if not grade:
+        gaps.append("unreviewed")
+    elif grade_data.get("passed") is not True:
+        gaps.append("validation_failed")
+
+    return {
+        "research_tier": research_tier,
+        "candidate_count": candidate_count,
+        "missing_image_count": missing_images,
+        "roster_verified_candidates": roster_verified_candidates,
+        "roster_strong_evidence_candidates": roster_strong_evidence_candidates,
+        "issue_slot_count": issue_slots,
+        "terminal_issue_count": terminal_issues,
+        "substantive_issue_count": substantive_issues,
+        "sourced_issue_count": sourced_issues,
+        "sourced_substantive_issue_count": sourced_substantive_issues,
+        "no_position_issue_count": max(0, terminal_issues - substantive_issues),
+        "missing_issue_count": max(0, issue_slots - terminal_issues),
+        "finance_complete_candidates": finance_complete_candidates,
+        "incumbent_count": incumbent_count,
+        "voting_complete_incumbents": voting_complete_incumbents,
+        "forecast_present": bool(forecast),
+        "forecast_source_count": len(forecast_sources),
+        "forecast_evidence_complete": forecast_evidence_complete,
+        "forecast_lineage_complete": forecast_lineage_complete,
+        "forecast_lineage_count": len(forecast_lineage),
+        "forecast_evidence_gaps": forecast_gaps,
+        "validation_grade": grade,
+        "validation_passed": grade_data.get("passed") is True,
+        "pipeline_complete": pipeline_state.get("complete") is True,
+        "run_health_status": run_health.get("status") or run_health.get("verdict"),
+        "section_freshness": section_freshness,
+        "stale_sections": stale_sections,
+        "gaps": gaps,
+    }
 
 
 def build_candidate_summaries(race_data: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -114,6 +357,7 @@ def build_race_summary_fields(race_id: str, race_data: Dict[str, Any]) -> Dict[s
         "freshness": compute_freshness(updated_utc),
         "agent_metrics": build_agent_metrics_summary(race_data),
         "forecast": build_forecast_summary(race_data),
+        "catalog_health": build_catalog_health(race_data),
     }
 
 
@@ -124,4 +368,5 @@ def build_versioned_catalog_fields(prefix: str, race_data: Dict[str, Any]) -> Di
         f"{prefix}_updated_utc": updated_utc,
         f"{prefix}_candidate_count": len(candidates),
         f"{prefix}_quality_grade": extract_quality_grade(race_data),
+        f"{prefix}_catalog_health": build_catalog_health(race_data),
     }

--- a/shared/race_cleanup.py
+++ b/shared/race_cleanup.py
@@ -1,0 +1,234 @@
+"""Deterministic, non-LLM cleanup and evidence checks for RaceJSON."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List
+
+from shared.run_health import RunFailureReason, record_step_failure
+
+_TEXT_REPLACEMENTS = {
+    " after advanced ": " after advancing ",
+}
+
+
+def _clean_text(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    cleaned = re.sub(r"[ \t]+", " ", value).strip()
+    padded = f" {cleaned} "
+    for old, new in _TEXT_REPLACEMENTS.items():
+        padded = padded.replace(old, new)
+    return padded.strip()
+
+
+def _dedupe_urls(values: Iterable[Any]) -> List[str]:
+    urls: List[str] = []
+    seen: set[str] = set()
+    for value in values:
+        url = str(value or "").strip()
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        urls.append(url)
+    return urls
+
+
+def _dedupe_sources(values: Any) -> Any:
+    if not isinstance(values, list):
+        return values
+    result = []
+    seen_urls: set[str] = set()
+    for source in values:
+        if not isinstance(source, dict):
+            continue
+        url = str(source.get("url") or "").strip()
+        if url and url in seen_urls:
+            continue
+        if url:
+            seen_urls.add(url)
+        result.append(source)
+    return result
+
+
+def _forecast_evidence_urls(race_data: Dict[str, Any]) -> List[str]:
+    urls: List[Any] = []
+    for poll in race_data.get("polling", []):
+        if isinstance(poll, dict):
+            urls.append(poll.get("source_url"))
+    forecast = race_data.get("forecast")
+    if isinstance(forecast, dict):
+        for signal in forecast.get("market_signals", []):
+            if isinstance(signal, dict):
+                urls.append(signal.get("url"))
+    for candidate in race_data.get("candidates", []):
+        if not isinstance(candidate, dict):
+            continue
+        urls.append(candidate.get("donor_source_url"))
+        for source in candidate.get("donor_sources", []):
+            if isinstance(source, dict):
+                urls.append(source.get("url"))
+    return _dedupe_urls(urls)
+
+
+def cleanup_race_data(race_data: Dict[str, Any]) -> Dict[str, int]:
+    """Apply safe text/source normalization and return mutation counts."""
+    text_changes = 0
+    source_duplicates_removed = 0
+    forecast_sources_added = 0
+
+    for field in ("title", "description", "polling_note"):
+        before = race_data.get(field)
+        after = _clean_text(before)
+        if after != before:
+            race_data[field] = after
+            text_changes += 1
+
+    for candidate in race_data.get("candidates", []):
+        if not isinstance(candidate, dict):
+            continue
+        for field in ("name", "summary", "donor_summary", "voting_summary"):
+            before = candidate.get(field)
+            after = _clean_text(before)
+            if after != before:
+                candidate[field] = after
+                text_changes += 1
+        for field in ("summary_sources", "donor_sources", "voting_sources", "roster_sources"):
+            before = candidate.get(field)
+            after = _dedupe_sources(before)
+            if isinstance(before, list) and isinstance(after, list):
+                source_duplicates_removed += len(before) - len(after)
+                candidate[field] = after
+        links = candidate.get("links")
+        if isinstance(links, list):
+            before_count = len(links)
+            candidate["links"] = _dedupe_sources(links)
+            source_duplicates_removed += before_count - len(candidate["links"])
+        issues = candidate.get("issues")
+        if isinstance(issues, dict):
+            for issue in issues.values():
+                if not isinstance(issue, dict):
+                    continue
+                before = issue.get("stance")
+                after = _clean_text(before)
+                if after != before:
+                    issue["stance"] = after
+                    text_changes += 1
+                sources = issue.get("sources")
+                deduped = _dedupe_sources(sources)
+                if isinstance(sources, list) and isinstance(deduped, list):
+                    source_duplicates_removed += len(sources) - len(deduped)
+                    issue["sources"] = deduped
+
+    forecast = race_data.get("forecast")
+    if isinstance(forecast, dict):
+        for field in ("rationale", "takeaway", "uncertainty"):
+            before = forecast.get(field)
+            after = _clean_text(before)
+            if after != before:
+                forecast[field] = after
+                text_changes += 1
+        reasons = forecast.get("key_reasons")
+        if isinstance(reasons, list):
+            cleaned_reasons = [_clean_text(reason) for reason in reasons if _clean_text(reason)]
+            if cleaned_reasons != reasons:
+                forecast["key_reasons"] = cleaned_reasons
+                text_changes += 1
+        existing_urls = _dedupe_urls(forecast.get("source_urls") or [])
+        inferred_urls = _forecast_evidence_urls(race_data)
+        merged_urls = _dedupe_urls([*existing_urls, *inferred_urls])
+        source_duplicates_removed += max(0, len(forecast.get("source_urls") or []) - len(existing_urls))
+        forecast_sources_added = len(merged_urls) - len(existing_urls)
+        forecast["source_urls"] = merged_urls
+        existing_lineage = [
+            item
+            for item in forecast.get("evidence_lineage") or []
+            if isinstance(item, dict) and item.get("claim") and item.get("source_url")
+        ]
+        lineage_urls = {str(item["source_url"]) for item in existing_lineage}
+        poll_urls = {
+            str(poll.get("source_url"))
+            for poll in race_data.get("polling", [])
+            if isinstance(poll, dict) and poll.get("source_url")
+        }
+        market_urls = {
+            str(signal.get("url"))
+            for signal in forecast.get("market_signals", [])
+            if isinstance(signal, dict) and signal.get("url")
+        }
+        for url in inferred_urls:
+            if url in lineage_urls:
+                continue
+            kind = "polling" if url in poll_urls else "market" if url in market_urls else "finance"
+            existing_lineage.append(
+                {
+                    "claim": f"{kind.replace('_', ' ').title()} input used by the forecast",
+                    "source_url": url,
+                    "kind": kind,
+                    "inferred": True,
+                }
+            )
+        forecast["evidence_lineage"] = existing_lineage
+
+    return {
+        "text_changes": text_changes,
+        "source_duplicates_removed": source_duplicates_removed,
+        "forecast_sources_added": forecast_sources_added,
+    }
+
+
+def forecast_evidence_gaps(race_data: Dict[str, Any]) -> List[str]:
+    """Return deterministic claim/source mismatches for a narrative forecast."""
+    forecast = race_data.get("forecast")
+    if not isinstance(forecast, dict):
+        return []
+    claims = (
+        " ".join(
+            [
+                str(forecast.get("rationale") or ""),
+                str(forecast.get("takeaway") or ""),
+                " ".join(str(reason) for reason in forecast.get("key_reasons") or []),
+            ]
+        )
+        .strip()
+        .casefold()
+    )
+    urls = _dedupe_urls(forecast.get("source_urls") or [])
+    lowered_urls = " ".join(url.casefold() for url in urls)
+    gaps: List[str] = []
+    if claims and not urls:
+        gaps.append("missing_explicit_sources")
+    claim_domains = {
+        "cook": "cookpolitical.com",
+        "inside elections": "insideelections.com",
+        "swing state project": "swingstateproject.com",
+    }
+    for marker, domain in claim_domains.items():
+        if marker in claims and domain not in lowered_urls:
+            gaps.append(f"missing_{marker.replace(' ', '_')}_source")
+    if "poll" in claims and int(forecast.get("based_on_poll_count") or 0) > 0:
+        polling_urls = {
+            str(poll.get("source_url") or "").strip()
+            for poll in race_data.get("polling", [])
+            if isinstance(poll, dict) and poll.get("source_url")
+        }
+        if not polling_urls.intersection(urls):
+            gaps.append("missing_poll_source")
+    return gaps
+
+
+def validate_forecast_evidence(race_data: Dict[str, Any]) -> bool:
+    """Register a degraded run-health finding for deterministic evidence gaps."""
+    forecast = race_data.get("forecast")
+    if not isinstance(forecast, dict):
+        return True
+    gaps = forecast_evidence_gaps(race_data)
+    if gaps:
+        record_step_failure(
+            race_data,
+            "forecast",
+            RunFailureReason.STEP_NO_DATA,
+            "Forecast evidence gaps: " + ", ".join(gaps),
+        )
+        return False
+    return True

--- a/shared/repair_planner.py
+++ b/shared/repair_planner.py
@@ -1,0 +1,280 @@
+"""Deterministic race repair planning and conservative cost ceilings."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from shared.models import CanonicalIssue
+from shared.pipeline_config import PIPELINE_STEP_ORDER, PipelineRuntimeConfig
+from shared.race_catalog import _coerce_datetime, _is_missing_image, _issue_verdict, build_catalog_health, compute_freshness
+
+_FIXED_STEP_COST_USD = {
+    "discovery": 0.10,
+    "polling": 0.08,
+    "forecast": 0.07,
+    "voter_resources": 0.03,
+    "review": 0.18,
+    "iteration": 0.25,
+}
+_PER_CANDIDATE_COST_USD = {
+    "images": 0.04,
+    "finance": 0.08,
+    "refinement": 0.06,
+}
+_PER_ISSUE_COST_USD = 0.05
+_CANONICAL_ISSUES = {issue.value for issue in CanonicalIssue}
+
+
+def _ordered_steps(steps: set[str]) -> List[str]:
+    return [step for step in PIPELINE_STEP_ORDER if step in steps]
+
+
+def _sources_are_stale(sources: List[Any]) -> bool:
+    dates = [
+        date
+        for date in (
+            _coerce_datetime(source.get("last_accessed") or source.get("published_at"))
+            for source in sources
+            if isinstance(source, dict)
+        )
+        if date is not None
+    ]
+    return bool(dates) and compute_freshness(max(dates)) in {"stale", "old"}
+
+
+def _estimate_group(
+    steps: set[str],
+    *,
+    candidate_count: int = 0,
+    missing_issue_count: int = 0,
+    phase_breakdown: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    ordered = _ordered_steps(steps)
+    static_cost = sum(_FIXED_STEP_COST_USD.get(step, 0.0) for step in ordered)
+    static_cost += sum(_PER_CANDIDATE_COST_USD.get(step, 0.0) * candidate_count for step in ordered)
+    if "issues" in steps:
+        static_cost += _PER_ISSUE_COST_USD * missing_issue_count
+    calibrated_cost = 0.0
+    calibration_samples = 0
+    for step in ordered:
+        phase = (phase_breakdown or {}).get(step)
+        if not isinstance(phase, dict):
+            continue
+        observed = float(phase.get("provider_cost_usd") or 0) + int(phase.get("search_calls") or 0) * 0.001
+        if observed > 0:
+            calibrated_cost += observed * 1.25
+            calibration_samples += 1
+    search_demand = (
+        (12 if "discovery" in steps else 0)
+        + (4 * candidate_count if "images" in steps else 0)
+        + (10 * missing_issue_count if "issues" in steps else 0)
+        + (10 * candidate_count if "finance" in steps else 0)
+        + (6 * candidate_count if "refinement" in steps else 0)
+        + (12 if "polling" in steps else 0)
+        + (8 if "forecast" in steps else 0)
+    )
+    ceiling = PipelineRuntimeConfig.from_env().max_search_calls
+    return {
+        "enabled_steps": ordered,
+        "estimated_max_cost_usd": round(max(static_cost, calibrated_cost, 0.01 if ordered else 0.0), 2),
+        "estimated_max_search_calls": min(search_demand, ceiling),
+        "estimated_search_demand": search_demand,
+        "estimate_kind": "observed_plus_25pct_or_static_ceiling" if calibration_samples else "static_ceiling",
+        "calibration_samples": calibration_samples,
+    }
+
+
+def build_repair_plan(race_id: str, race_data: Dict[str, Any], *, freshness: str | None = None) -> Dict[str, Any]:
+    """Return a bounded, non-mutating repair proposal for one RaceJSON document."""
+    health = build_catalog_health(race_data)
+    candidates = [candidate for candidate in race_data.get("candidates", []) if isinstance(candidate, dict)]
+    steps: set[str] = set()
+    reasons: List[str] = []
+    target_names: List[str] = []
+    candidate_groups: List[Dict[str, Any]] = []
+    race_steps: set[str] = set()
+    race_reasons: List[str] = []
+
+    if health["candidate_count"] == 0:
+        race_steps.add("discovery")
+        reasons.append("Roster is empty.")
+        race_reasons.append("Roster is empty.")
+    elif health["roster_verified_candidates"] < health["candidate_count"]:
+        race_steps.add("discovery")
+        reasons.append("One or more candidates lack roster evidence.")
+        race_reasons.append("One or more candidates lack roster evidence.")
+
+    for candidate in candidates:
+        candidate_steps: set[str] = set()
+        candidate_reasons: List[str] = []
+        if _is_missing_image(candidate.get("image_url")):
+            steps.add("images")
+            candidate_steps.add("images")
+            candidate_reasons.append("Candidate photo is missing.")
+        issues = candidate.get("issues") if isinstance(candidate.get("issues"), dict) else {}
+        terminal_issues = sum(
+            _issue_verdict(issue)[0] for issue_name, issue in issues.items() if str(issue_name) in _CANONICAL_ISSUES
+        )
+        candidate_missing_issues = max(0, len(_CANONICAL_ISSUES) - terminal_issues)
+        if candidate_missing_issues:
+            steps.add("issues")
+            candidate_steps.add("issues")
+            candidate_reasons.append(f"{candidate_missing_issues} issue slot(s) lack a terminal verdict.")
+        donor_sources = candidate.get("donor_sources")
+        if not candidate.get("donor_summary") or not (
+            candidate.get("donor_source_url") or (isinstance(donor_sources, list) and donor_sources)
+        ):
+            steps.add("finance")
+            candidate_steps.add("finance")
+            candidate_reasons.append("Finance summary or citation is incomplete.")
+        if candidate.get("incumbent"):
+            voting_sources = candidate.get("voting_sources")
+            if not candidate.get("voting_summary") or not (
+                candidate.get("voting_source_url") or (isinstance(voting_sources, list) and voting_sources)
+            ):
+                steps.add("finance")
+                candidate_steps.add("finance")
+                candidate_reasons.append("Incumbent voting summary or citation is incomplete.")
+        unsourced = sum(
+            int(_issue_verdict(issue)[1] and not _issue_verdict(issue)[2])
+            for issue_name, issue in issues.items()
+            if str(issue_name) in _CANONICAL_ISSUES
+        )
+        if unsourced:
+            steps.add("refinement")
+            candidate_steps.add("refinement")
+            candidate_reasons.append(f"{unsourced} substantive stance(s) lack sources.")
+        issue_sources = [
+            source for issue in issues.values() if isinstance(issue, dict) for source in issue.get("sources") or []
+        ]
+        if _sources_are_stale(issue_sources):
+            steps.add("refinement")
+            candidate_steps.add("refinement")
+            candidate_reasons.append("Issue evidence is stale.")
+        finance_sources = [source for key in ("donor_sources", "voting_sources") for source in candidate.get(key) or []]
+        if _sources_are_stale(finance_sources):
+            steps.add("finance")
+            candidate_steps.add("finance")
+            candidate_reasons.append("Finance or voting evidence is stale.")
+        candidate_name = str(candidate.get("name") or "").strip()
+        if candidate_steps and candidate_name:
+            target_names.append(candidate_name)
+            estimate = _estimate_group(
+                candidate_steps,
+                candidate_count=1,
+                missing_issue_count=candidate_missing_issues,
+                phase_breakdown=(race_data.get("agent_metrics") or {}).get("phase_breakdown"),
+            )
+            candidate_groups.append(
+                {
+                    **estimate,
+                    "candidate_names": [candidate_name],
+                    "reasons": candidate_reasons,
+                }
+            )
+
+    if health["missing_image_count"]:
+        reasons.append(f"{health['missing_image_count']} candidate photo(s) are missing.")
+    if health["missing_issue_count"]:
+        reasons.append(f"{health['missing_issue_count']} issue slot(s) lack a terminal research verdict.")
+    if health["finance_complete_candidates"] < health["candidate_count"]:
+        reasons.append("Candidate finance summaries or citations are incomplete.")
+    if health["voting_complete_incumbents"] < health["incumbent_count"]:
+        reasons.append("An incumbent voting summary or citation is incomplete.")
+    if health["substantive_issue_count"] > health["sourced_substantive_issue_count"]:
+        reasons.append("One or more substantive issue stances lack sources.")
+    if not health["forecast_present"] or not health["forecast_evidence_complete"]:
+        steps.add("forecast")
+        race_steps.add("forecast")
+        reasons.append("The forecast is missing or lacks explicit source URLs.")
+        race_reasons.append("The forecast is missing or lacks explicit source URLs.")
+
+    freshness = str(freshness or "").lower()
+    if freshness in {"stale", "old"}:
+        steps.update({"polling", "forecast", "voter_resources"})
+        race_steps.update({"polling", "forecast", "voter_resources"})
+        reasons.append(f"Race data is {freshness}.")
+        race_reasons.append(f"Race data is {freshness}.")
+    stale_sections = set(health.get("stale_sections") or [])
+    section_steps = {
+        "roster": "discovery",
+        "polling": "polling",
+        "forecast": "forecast",
+        "voter_resources": "voter_resources",
+    }
+    for section, step in section_steps.items():
+        if section in stale_sections:
+            steps.add(step)
+            race_steps.add(step)
+            reason = f"{section.replace('_', ' ').title()} evidence is stale."
+            reasons.append(reason)
+            race_reasons.append(reason)
+
+    if health["research_tier"] in {"full_unreviewed", "graded_low"}:
+        steps.add("review")
+        race_steps.add("review")
+        reasons.append("Research needs a current validation review.")
+        race_reasons.append("Research needs a current validation review.")
+    if health["research_tier"] == "graded_low":
+        steps.add("iteration")
+        race_steps.add("iteration")
+        reasons.append("The previous validation grade did not pass.")
+        race_reasons.append("The previous validation grade did not pass.")
+
+    steps.update(race_steps)
+    ordered_steps = _ordered_steps(steps)
+    target_names = list(dict.fromkeys(target_names))
+    repair_groups = candidate_groups
+    if race_steps:
+        repair_groups.insert(
+            0,
+            {
+                **_estimate_group(
+                    race_steps,
+                    phase_breakdown=(race_data.get("agent_metrics") or {}).get("phase_breakdown"),
+                ),
+                "candidate_names": None,
+                "reasons": race_reasons,
+            },
+        )
+    estimated_cost = sum(float(group["estimated_max_cost_usd"]) for group in repair_groups)
+    estimated_search_demand = sum(int(group["estimated_search_demand"]) for group in repair_groups)
+    search_ceiling = PipelineRuntimeConfig.from_env().max_search_calls
+    estimated_search_calls = sum(int(group["estimated_max_search_calls"]) for group in repair_groups)
+    budget_warnings = []
+    if estimated_search_demand > search_ceiling:
+        budget_warnings.append(
+            f"Estimated search demand ({estimated_search_demand}) exceeds the logical-run ceiling "
+            f"({search_ceiling}); split the repair by candidate or step."
+        )
+
+    return {
+        "race_id": race_id,
+        "needs_repair": bool(ordered_steps),
+        "research_tier": health["research_tier"],
+        "health": health,
+        "recommended_steps": ordered_steps,
+        "candidate_names": target_names or None,
+        "repair_groups": repair_groups,
+        "queueable_repair_groups_only": True,
+        "reasons": reasons,
+        "estimated_max_cost_usd": round(max(estimated_cost, 0.01 if ordered_steps else 0.0), 2),
+        "estimated_max_search_calls": estimated_search_calls,
+        "estimated_search_demand": estimated_search_demand,
+        "budget_warnings": budget_warnings,
+        "estimate_kind": (
+            "observed_plus_25pct_or_static_ceiling"
+            if any(group["calibration_samples"] for group in repair_groups)
+            else "static_ceiling"
+        ),
+    }
+
+
+def summarize_repair_plans(plans: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "plans": plans,
+        "race_count": len(plans),
+        "repair_count": sum(bool(plan.get("needs_repair")) for plan in plans),
+        "estimated_max_cost_usd": round(sum(float(plan.get("estimated_max_cost_usd") or 0) for plan in plans), 2),
+        "estimated_max_search_calls": sum(int(plan.get("estimated_max_search_calls") or 0) for plan in plans),
+    }

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import re
 from typing import Any, Dict, List, Literal, Tuple
+from urllib.parse import unquote
 
 from mcp.server.fastmcp import FastMCP
 
@@ -61,6 +64,263 @@ async def get_published_race(race_id: str) -> Dict[str, Any]:
 async def list_admin_races() -> Dict[str, Any]:
     """List admin race records, including status and storage metadata."""
     return await _client().get("/api/races")
+
+
+def _missing_image_count(race: Dict[str, Any]) -> int:
+    candidates = race.get("candidates") if isinstance(race.get("candidates"), list) else []
+    return sum(
+        1
+        for candidate in candidates
+        if isinstance(candidate, dict)
+        and (not candidate.get("image_url") or "submitphoto-150px" in str(candidate.get("image_url") or "").lower())
+    )
+
+
+def _catalog_research_tier(race: Dict[str, Any]) -> str:
+    health = race.get("catalog_health")
+    if isinstance(health, dict) and health.get("research_tier"):
+        return str(health["research_tier"])
+    grade = str(race.get("quality_grade") or "").upper()
+    if grade in {"A", "B"}:
+        return "validated"
+    if grade in {"C", "D", "F"}:
+        return "graded_low"
+    return "discovery_only"
+
+
+async def _optional_api_get(path: str, *, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Return an optional analytics payload without making catalog scans brittle."""
+    try:
+        response = await _client().get(path, params=params)
+        return response if isinstance(response, dict) else {}
+    except Exception:
+        return {}
+
+
+def _race_pageviews(traffic: Dict[str, Any]) -> Dict[str, int]:
+    totals: Dict[str, int] = {}
+    for page in traffic.get("top_pages", []):
+        if not isinstance(page, dict):
+            continue
+        match = re.match(r"^/races/([^/?#]+)", str(page.get("name") or ""))
+        if not match:
+            continue
+        race_id = unquote(match.group(1))
+        try:
+            pageviews = max(0, int(page.get("pageviews") or 0))
+        except (TypeError, ValueError):
+            pageviews = 0
+        totals[race_id] = totals.get(race_id, 0) + pageviews
+    return totals
+
+
+@mcp.tool(structured_output=False)
+async def scan_catalog(
+    state: str | None = None,
+    office: str | None = None,
+    publication: Literal["all", "published", "unpublished"] = "all",
+    research_tier: Literal[
+        "all",
+        "validated",
+        "graded_low",
+        "discovery_only",
+        "partial_research",
+        "full_unreviewed",
+        "empty",
+    ] = "all",
+    missing_images_only: bool = False,
+    competitive_only: bool = False,
+    traffic_hours: int = 720,
+    limit: int = 50,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """Return a compact, ranked catalog-health scan without full RaceJSON payloads.
+
+    This is the preferred inventory tool for deciding which races merit repair.
+    It derives explicit research tiers, image gaps, competitiveness, freshness,
+    and a deterministic priority score from the admin catalog.
+    """
+    traffic_hours = max(1, min(traffic_hours, 720))
+    response, traffic, api_analytics = await asyncio.gather(
+        list_admin_races(),
+        _optional_api_get("/analytics/traffic", params={"hours": traffic_hours}),
+        _optional_api_get("/analytics/races", params={"hours": traffic_hours}),
+    )
+    races = response.get("races", []) if isinstance(response, dict) else []
+    pageviews_by_race = _race_pageviews(traffic)
+    requests_by_race = {
+        str(item.get("race_id")): int(item.get("requests_24h") or 0)
+        for item in api_analytics.get("races", [])
+        if isinstance(item, dict) and item.get("race_id")
+    }
+    rows: List[Dict[str, Any]] = []
+    competitive_ratings = {"tossup", "tilt_d", "tilt_r", "lean_d", "lean_r"}
+    state_query = str(state or "").strip().lower()
+    office_query = str(office or "").strip().lower()
+
+    for race in races:
+        if not isinstance(race, dict):
+            continue
+        published = bool(race.get("published_exists"))
+        tier = _catalog_research_tier(race)
+        health = race.get("catalog_health") if isinstance(race.get("catalog_health"), dict) else {}
+        candidates = race.get("candidates") if isinstance(race.get("candidates"), list) else []
+        candidate_count = int(health.get("candidate_count") or race.get("candidate_count") or len(candidates))
+        missing_images = int(
+            health.get("missing_image_count") if health.get("missing_image_count") is not None else _missing_image_count(race)
+        )
+        forecast = race.get("forecast") if isinstance(race.get("forecast"), dict) else {}
+        rating = str(forecast.get("rating") or "").lower()
+        competitive = rating in competitive_ratings
+        state_haystack = " ".join(
+            [
+                str(race.get("state") or ""),
+                str(race.get("jurisdiction") or ""),
+                str(race.get("race_id") or race.get("id") or ""),
+            ]
+        ).lower()
+        office_haystack = " ".join(
+            [
+                str(race.get("office") or ""),
+                str(race.get("title") or ""),
+                str(race.get("race_id") or race.get("id") or ""),
+            ]
+        ).lower()
+
+        if state_query and state_query not in state_haystack:
+            continue
+        if office_query and office_query not in office_haystack:
+            continue
+        if publication == "published" and not published:
+            continue
+        if publication == "unpublished" and published:
+            continue
+        if research_tier != "all" and tier != research_tier:
+            continue
+        if missing_images_only and missing_images == 0:
+            continue
+        if competitive_only and not competitive:
+            continue
+
+        priority_score = 0
+        reasons: List[str] = []
+        if tier == "discovery_only":
+            priority_score += 4
+            reasons.append("discovery_only")
+        elif tier == "partial_research":
+            priority_score += 5
+            reasons.append("partial_research")
+        elif tier == "full_unreviewed":
+            priority_score += 3
+            reasons.append("needs_review")
+        elif tier == "empty":
+            priority_score += 6
+            reasons.append("missing_roster")
+        elif tier == "graded_low":
+            priority_score += 3
+            reasons.append("low_grade")
+        if competitive:
+            priority_score += 3
+            reasons.append("competitive")
+        if missing_images:
+            priority_score += min(3, missing_images)
+            reasons.append("missing_images")
+        if not forecast:
+            priority_score += 3
+            reasons.append("missing_forecast")
+        freshness = str(race.get("freshness") or "").lower()
+        if freshness == "old":
+            priority_score += 3
+            reasons.append("old")
+        elif freshness == "stale":
+            priority_score += 2
+            reasons.append("stale")
+        asset_audit = race.get("asset_audit") if isinstance(race.get("asset_audit"), dict) else {}
+        if int(asset_audit.get("broken_count") or 0):
+            priority_score += min(3, int(asset_audit["broken_count"]))
+            reasons.append("broken_assets")
+        if int(asset_audit.get("invalid_image_count") or 0) or int(asset_audit.get("suspicious_image_count") or 0):
+            priority_score += 2
+            reasons.append("image_quality")
+
+        race_id = str(race.get("race_id") or race.get("id") or "")
+        pageviews = pageviews_by_race.get(race_id, 0)
+        api_requests = requests_by_race.get(race_id, 0)
+        demand = max(pageviews, api_requests)
+        if demand >= 1000:
+            priority_score += 5
+        elif demand >= 100:
+            priority_score += 4
+        elif demand >= 10:
+            priority_score += 3
+        elif demand:
+            priority_score += 2
+        if demand:
+            reasons.append("user_demand")
+
+        rows.append(
+            {
+                "race_id": race_id,
+                "title": race.get("title"),
+                "state": race.get("state"),
+                "office": race.get("office"),
+                "status": race.get("status"),
+                "published": published,
+                "research_tier": tier,
+                "quality_grade": race.get("quality_grade"),
+                "catalog_health": health or None,
+                "freshness": race.get("freshness"),
+                "candidate_count": candidate_count,
+                "missing_image_count": missing_images,
+                "asset_audited_at": race.get("asset_audited_at"),
+                "broken_asset_count": asset_audit.get("broken_count"),
+                "invalid_image_count": asset_audit.get("invalid_image_count"),
+                "suspicious_image_count": asset_audit.get("suspicious_image_count"),
+                "forecast_rating": rating or None,
+                "competitive": competitive,
+                "pageviews": pageviews,
+                "api_requests": api_requests,
+                "traffic_hours": traffic_hours,
+                "updated_utc": race.get("updated_utc"),
+                "last_run_status": race.get("last_run_status"),
+                "has_unpublished_changes": bool(race.get("has_unpublished_changes")),
+                "estimated_previous_run_usd": (race.get("agent_metrics") or {}).get("estimated_usd"),
+                "priority_score": priority_score,
+                "priority_reasons": reasons,
+            }
+        )
+
+    rows.sort(
+        key=lambda row: (
+            -int(row["priority_score"]),
+            -int(row["pageviews"]),
+            -int(row["api_requests"]),
+            str(row["race_id"] or ""),
+        )
+    )
+    offset = max(0, offset)
+    limit = max(1, min(limit, 200))
+    page = rows[offset : offset + limit]
+    return {
+        "rows": page,
+        "matched": len(rows),
+        "offset": offset,
+        "limit": limit,
+        "has_more": offset + len(page) < len(rows),
+        "summary": {
+            "validated": sum(row["research_tier"] == "validated" for row in rows),
+            "graded_low": sum(row["research_tier"] == "graded_low" for row in rows),
+            "discovery_only": sum(row["research_tier"] == "discovery_only" for row in rows),
+            "partial_research": sum(row["research_tier"] == "partial_research" for row in rows),
+            "full_unreviewed": sum(row["research_tier"] == "full_unreviewed" for row in rows),
+            "empty": sum(row["research_tier"] == "empty" for row in rows),
+            "competitive": sum(bool(row["competitive"]) for row in rows),
+            "with_missing_images": sum(int(row["missing_image_count"]) > 0 for row in rows),
+            "traffic_hours": traffic_hours,
+            "traffic_configured": bool(traffic.get("configured")),
+            "traffic_error": traffic.get("error"),
+        },
+    }
 
 
 @mcp.tool(structured_output=False)
@@ -163,6 +423,112 @@ async def audit_draft_vs_published(race_ids: List[str]) -> Dict[str, Any]:
 
 
 @mcp.tool(structured_output=False)
+async def plan_repairs(race_ids: List[str]) -> Dict[str, Any]:
+    """Return deterministic repair groups and cost ceilings without queueing work.
+
+    Queue each repair_groups item independently. The combined recommended_steps
+    and candidate_names fields are summaries and are not a safe queue payload.
+    """
+    return await _client().post("/api/races/repair-plan", json={"race_ids": race_ids})
+
+
+@mcp.tool(structured_output=False)
+async def audit_race_assets(
+    race_ids: List[str],
+    persist: bool = False,
+    max_urls_per_race: int = 100,
+) -> Dict[str, Any]:
+    """Probe source/photo reachability and image content types for selected races."""
+    return await _client().post(
+        "/api/races/asset-audit",
+        json={
+            "race_ids": race_ids,
+            "persist": persist,
+            "max_urls_per_race": max_urls_per_race,
+        },
+    )
+
+
+def _contains_placeholder(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().upper() in {"DRAFT", "TODO", "TBD", "PLACEHOLDER"}
+    if isinstance(value, list):
+        return any(_contains_placeholder(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_placeholder(item) for item in value.values())
+    return False
+
+
+@mcp.tool(structured_output=False)
+async def assess_publish_readiness(race_ids: List[str]) -> Dict[str, Any]:
+    """Build a conservative batch publish plan without changing production data.
+
+    Checks draft presence, candidate roster, explicit validation pass, run health,
+    pipeline completion, literal placeholder content, and draft-vs-published roster
+    changes. A race is ``ready`` only when it has no blockers. Warnings still require
+    human review but do not claim the API would reject publication.
+    """
+    client = _client()
+    rows: List[Dict[str, Any]] = []
+    for race_id in race_ids:
+        try:
+            draft = await client.get(f"/api/races/{race_id}/data", params={"draft": True})
+        except Exception:
+            draft = None
+        try:
+            published = await client.get(f"/races/{race_id}")
+        except Exception:
+            published = None
+
+        blockers: List[str] = []
+        warnings: List[str] = []
+        names = _candidate_names(draft)
+        if not isinstance(draft, dict):
+            blockers.append("draft_missing")
+        else:
+            if not names:
+                blockers.append("candidate_roster_empty")
+            validation = draft.get("validation_grade") if isinstance(draft.get("validation_grade"), dict) else {}
+            if validation.get("passed") is not True:
+                blockers.append("validation_not_passed")
+            health = draft.get("run_health") if isinstance(draft.get("run_health"), dict) else {}
+            verdict = str(health.get("status") or health.get("verdict") or "unknown")
+            if verdict == "failed":
+                blockers.append("run_health_failed")
+            elif verdict in {"degraded", "unknown"}:
+                warnings.append(f"run_health_{verdict}")
+            pipeline_state = draft.get("pipeline_state") if isinstance(draft.get("pipeline_state"), dict) else {}
+            if not pipeline_state.get("complete"):
+                warnings.append("pipeline_not_complete")
+            if _contains_placeholder(draft):
+                blockers.append("literal_placeholder_content")
+
+        published_names = _candidate_names(published)
+        if published is None:
+            warnings.append("first_publication")
+        elif sorted(names) != sorted(published_names):
+            warnings.append("candidate_roster_changes")
+        rows.append(
+            {
+                "race_id": race_id,
+                "ready": not blockers,
+                "blockers": blockers,
+                "warnings": warnings,
+                "draft_candidates": names,
+                "published_candidates": published_names,
+                "published_exists": published is not None,
+            }
+        )
+    return {
+        "rows": rows,
+        "ready_race_ids": [row["race_id"] for row in rows if row["ready"]],
+        "blocked_race_ids": [row["race_id"] for row in rows if not row["ready"]],
+        "all_ready": all(row["ready"] for row in rows),
+        "race_count": len(rows),
+    }
+
+
+@mcp.tool(structured_output=False)
 async def queue_races(
     race_ids: List[str],
     cheap_mode: bool | None = True,
@@ -180,6 +546,7 @@ async def queue_races(
     max_candidates: int | None = None,
     candidate_names: List[str] | None = None,
     target_no_info: bool | None = None,
+    debug_mode: bool | None = None,
     note: str | None = None,
     goal: str | None = None,
     runner: str | None = "local",
@@ -211,6 +578,7 @@ async def queue_races(
         max_candidates=max_candidates,
         candidate_names=candidate_names,
         target_no_info=target_no_info,
+        debug_mode=debug_mode,
         note=note,
         goal=goal,
         runner=runner,
@@ -225,6 +593,7 @@ async def run_race(
     force_fresh: bool | None = None,
     baseline_source: Literal["latest", "published"] | None = None,
     enabled_steps: List[str] | None = None,
+    debug_mode: bool | None = None,
     note: str | None = None,
     goal: str | None = None,
     runner: str | None = "local",
@@ -243,6 +612,7 @@ async def run_race(
         force_fresh=force_fresh,
         baseline_source=baseline_source,
         enabled_steps=enabled_steps,
+        debug_mode=debug_mode,
         note=note,
         goal=goal,
         runner=runner,
@@ -252,14 +622,33 @@ async def run_race(
 
 @mcp.tool(structured_output=False)
 async def publish_race(race_id: str) -> Dict[str, Any]:
-    """Publish a draft race."""
-    return await _client().post(f"/api/races/{race_id}/publish")
+    """Publish one draft only after the conservative readiness check passes."""
+    readiness = await assess_publish_readiness([race_id])
+    if not readiness.get("all_ready"):
+        return {
+            "published": [],
+            "errors": [{"race_id": race_id, "error": "Publish-readiness blockers remain"}],
+            "readiness": readiness,
+        }
+    result = await _client().post(f"/api/races/{race_id}/publish")
+    return {**result, "readiness": readiness}
 
 
 @mcp.tool(structured_output=False)
 async def publish_races(race_ids: List[str]) -> Dict[str, Any]:
-    """Publish multiple draft races in bulk."""
-    return await _client().post("/api/races/publish", json={"race_ids": race_ids})
+    """Publish a batch only when every requested draft passes readiness checks."""
+    readiness = await assess_publish_readiness(race_ids)
+    if not readiness.get("all_ready"):
+        return {
+            "published": [],
+            "errors": [
+                {"race_id": race_id, "error": "Publish-readiness blockers remain"}
+                for race_id in readiness.get("blocked_race_ids") or []
+            ],
+            "readiness": readiness,
+        }
+    result = await _client().post("/api/races/publish", json={"race_ids": race_ids})
+    return {**result, "readiness": readiness}
 
 
 @mcp.tool(structured_output=False)
@@ -370,7 +759,7 @@ def _normalize_state(query: str) -> Tuple[str, str]:
 
 
 @mcp.tool(structured_output=False)
-async def list_races_by_state(state: str) -> List[Dict[str, Any]]:
+async def list_races_by_state(state: str, office: str | None = None) -> List[Dict[str, Any]]:
     """List admin races that belong to a given US state.
 
     Accepts state abbreviation (e.g. 'ND') or full name (e.g. 'North Dakota').
@@ -384,7 +773,17 @@ async def list_races_by_state(state: str) -> List[Dict[str, Any]]:
         race_id = str(race.get("race_id") or race.get("id") or "")
         race_state = str(race.get("state") or "")
         jurisdiction = str(race.get("jurisdiction") or "")
-        if race_id.startswith(prefix) or race_state.upper() == abbr or full_name.lower() in jurisdiction.lower():
+        state_matches = race_id.startswith(prefix) or race_state.upper() == abbr or full_name.lower() in jurisdiction.lower()
+        office_query = str(office or "").strip().lower()
+        office_haystack = " ".join(
+            [
+                race_id,
+                str(race.get("office") or ""),
+                str(race.get("title") or ""),
+                str(race.get("race_type") or ""),
+            ]
+        ).lower()
+        if state_matches and (not office_query or office_query in office_haystack):
             filtered.append(race)
     return filtered
 
@@ -449,9 +848,59 @@ async def get_run(run_id: str) -> Dict[str, Any]:
 
 
 @mcp.tool(structured_output=False)
-async def get_run_logs(run_id: str, since: int = 0) -> Dict[str, Any]:
-    """Fetch run logs, optionally after an existing log count."""
-    return await _client().get(f"/runs/{run_id}/logs", params={"since": since})
+async def get_run_logs(
+    run_id: str,
+    cursor: str | None = None,
+    limit: int = 1000,
+    since: int | None = None,
+) -> Dict[str, Any]:
+    """Fetch a bounded page of logs using the prior response's opaque cursor.
+
+    ``since`` remains available for legacy callers, but cursor polling avoids
+    repeatedly reading and billing the complete Firestore log collection.
+    """
+    params: Dict[str, Any] = {"limit": max(1, min(limit, 5000))}
+    if cursor is not None:
+        params["cursor"] = cursor
+    elif since is not None:
+        params["since"] = max(0, since)
+    return await _client().get(f"/runs/{run_id}/logs", params=params)
+
+
+@mcp.tool(structured_output=False)
+async def get_run_diagnostics(run_id: str) -> Dict[str, Any]:
+    """Return normalized diagnostics and health evidence for one pipeline run."""
+    return await _client().get(f"/runs/{run_id}/diagnostics")
+
+
+@mcp.tool(structured_output=False)
+async def list_race_runs(race_id: str) -> Dict[str, Any]:
+    """List stored run history for one race."""
+    return await _client().get(f"/api/races/{race_id}/runs")
+
+
+@mcp.tool(structured_output=False)
+async def get_race_run(race_id: str, run_id: str) -> Dict[str, Any]:
+    """Return one race-scoped run record."""
+    return await _client().get(f"/api/races/{race_id}/runs/{run_id}")
+
+
+@mcp.tool(structured_output=False)
+async def list_race_versions(race_id: str) -> Dict[str, Any]:
+    """List restorable historical RaceJSON versions for one race."""
+    return await _client().get(f"/api/races/{race_id}/versions")
+
+
+@mcp.tool(structured_output=False)
+async def get_race_version(race_id: str, filename: str) -> Dict[str, Any]:
+    """Read one historical RaceJSON version without restoring it."""
+    return await _client().get(f"/api/races/{race_id}/versions/{filename}")
+
+
+@mcp.tool(structured_output=False)
+async def restore_race_version(race_id: str, filename: str) -> Dict[str, Any]:
+    """Restore one historical version as the current draft. This mutates draft state."""
+    return await _client().post(f"/api/races/{race_id}/versions/{filename}/restore")
 
 
 @mcp.tool(structured_output=False)
@@ -473,14 +922,18 @@ async def get_pipeline_metrics_summary() -> Dict[str, Any]:
 
 
 @mcp.tool(structured_output=False)
+async def get_gcp_pipeline_costs(days: int = 30) -> Dict[str, Any]:
+    """Return infrastructure-side GCP pipeline costs for the requested lookback."""
+    return await _client().get("/pipeline/gcp-costs", params={"days": days})
+
+
+@mcp.tool(structured_output=False)
 async def summarize_run_costs(run_ids: List[str]) -> Dict[str, Any]:
     """Aggregate cost, token, and status data across many pipeline run IDs in one call.
 
-    Fetches each run via get_run (raw Firestore pipeline_runs doc) and normalizes its
-    cost/token/model-breakdown fields, which may live at the top level or nested under
-    payload.agent_metrics depending on how/when the run was recorded. Returns one row per
-    run plus rolled-up status counts, the list of failed/active run IDs, and totals across
-    the whole batch.
+    Prefers normalized provider-backed pipeline metric records, then falls back
+    to raw run fields or nested payload.agent_metrics estimates. Returns one row
+    per run plus rolled-up status counts, failed/active IDs, and batch totals.
 
     Useful for auditing a batch of pipeline runs (e.g. tracking progress and spend across a
     multi-race repair effort) without manually calling get_run once per run and hand-
@@ -493,6 +946,17 @@ async def summarize_run_costs(run_ids: List[str]) -> Dict[str, Any]:
     total_cost = 0.0
     total_prompt_tokens = 0
     total_completion_tokens = 0
+    metric_records: Dict[str, Dict[str, Any]] = {}
+    try:
+        metrics_response = await client.get("/pipeline/metrics", params={"limit": 500})
+        if isinstance(metrics_response, dict):
+            metric_records = {
+                str(record.get("run_id")): record
+                for record in metrics_response.get("records", [])
+                if isinstance(record, dict) and record.get("run_id")
+            }
+    except Exception:
+        metric_records = {}
 
     for run_id in run_ids:
         try:
@@ -505,21 +969,33 @@ async def summarize_run_costs(run_ids: List[str]) -> Dict[str, Any]:
             status_counts["missing"] = status_counts.get("missing", 0) + 1
             continue
 
+        metric = metric_records.get(run_id, {})
         payload = raw.get("payload") if isinstance(raw.get("payload"), dict) else {}
-        agent_metrics = payload.get("agent_metrics") if isinstance(payload.get("agent_metrics"), dict) else {}
+        agent_metrics = raw.get("agent_metrics") if isinstance(raw.get("agent_metrics"), dict) else {}
+        if not agent_metrics and isinstance(payload.get("agent_metrics"), dict):
+            agent_metrics = payload["agent_metrics"]
 
         status = raw.get("status") or "unknown"
-        race_id = raw.get("race_id") or payload.get("race_id") or ""
+        race_id = raw.get("race_id") or payload.get("race_id") or metric.get("race_id") or ""
 
-        model_breakdown = raw.get("model_breakdown")
+        model_breakdown = metric.get("model_breakdown")
+        if not isinstance(model_breakdown, dict):
+            model_breakdown = raw.get("model_breakdown")
         if not isinstance(model_breakdown, dict):
             model_breakdown = agent_metrics.get("model_breakdown")
         if not isinstance(model_breakdown, dict):
             model_breakdown = {}
 
-        cost_raw = raw.get("estimated_usd")
+        exact_cost = metric.get("cost_usd")
+        if exact_cost is None:
+            exact_cost = raw.get("cost_usd")
+        if exact_cost is None:
+            exact_cost = agent_metrics.get("cost_usd")
+        cost_raw = exact_cost
         if cost_raw is None:
-            cost_raw = raw.get("cost_usd")
+            cost_raw = metric.get("estimated_usd")
+        if cost_raw is None:
+            cost_raw = raw.get("estimated_usd")
         if cost_raw is None:
             cost_raw = agent_metrics.get("estimated_usd")
         try:
@@ -527,30 +1003,75 @@ async def summarize_run_costs(run_ids: List[str]) -> Dict[str, Any]:
         except (TypeError, ValueError):
             cost = 0.0
 
-        prompt_tokens = 0
-        completion_tokens = 0
-        for model_stats in model_breakdown.values():
-            if not isinstance(model_stats, dict):
-                continue
-            try:
-                prompt_tokens += int(model_stats.get("prompt_tokens") or 0)
-            except (TypeError, ValueError):
-                pass
-            try:
-                completion_tokens += int(model_stats.get("completion_tokens") or 0)
-            except (TypeError, ValueError):
-                pass
+        prompt_raw = metric.get("prompt_tokens")
+        if prompt_raw is None:
+            prompt_raw = raw.get("prompt_tokens")
+        if prompt_raw is None:
+            prompt_raw = agent_metrics.get("prompt_tokens")
+        completion_raw = metric.get("completion_tokens")
+        if completion_raw is None:
+            completion_raw = raw.get("completion_tokens")
+        if completion_raw is None:
+            completion_raw = agent_metrics.get("completion_tokens")
+        try:
+            prompt_tokens = int(prompt_raw) if prompt_raw is not None else 0
+        except (TypeError, ValueError):
+            prompt_tokens = 0
+        try:
+            completion_tokens = int(completion_raw) if completion_raw is not None else 0
+        except (TypeError, ValueError):
+            completion_tokens = 0
+        if prompt_raw is None or completion_raw is None:
+            model_prompt_tokens = 0
+            model_completion_tokens = 0
+            for model_stats in model_breakdown.values():
+                if not isinstance(model_stats, dict):
+                    continue
+                try:
+                    model_prompt_tokens += int(model_stats.get("prompt_tokens") or 0)
+                except (TypeError, ValueError):
+                    pass
+                try:
+                    model_completion_tokens += int(model_stats.get("completion_tokens") or 0)
+                except (TypeError, ValueError):
+                    pass
+            if prompt_raw is None:
+                prompt_tokens = model_prompt_tokens
+            if completion_raw is None:
+                completion_tokens = model_completion_tokens
+
+        cost_source = metric.get("cost_source") or raw.get("cost_source") or agent_metrics.get("cost_source")
+        if not cost_source:
+            cost_source = "provider" if exact_cost is not None else "estimated"
 
         rows.append(
             {
                 "run_id": run_id,
                 "race_id": race_id,
                 "status": status,
-                "cost": round(cost, 6),
+                "cost": cost,
                 "has_cost": cost > 0,
+                "cost_source": cost_source,
                 "model_breakdown": model_breakdown,
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
+                "duration_s": metric.get("duration_s") or raw.get("duration_s") or agent_metrics.get("duration_s"),
+                "continuation_count": raw.get("continuation_count") or 0,
+                "search_calls": metric.get("search_calls")
+                or raw.get("search_calls")
+                or agent_metrics.get("search_calls")
+                or metric.get("serper_calls")
+                or raw.get("serper_calls")
+                or agent_metrics.get("serper_calls")
+                or 0,
+                "search_budget_blocked": metric.get("search_budget_blocked")
+                or raw.get("search_budget_blocked")
+                or agent_metrics.get("search_budget_blocked")
+                or 0,
+                "token_budget_nudges": metric.get("token_budget_nudges")
+                or raw.get("token_budget_nudges")
+                or agent_metrics.get("token_budget_nudges")
+                or 0,
             }
         )
         status_counts[status] = status_counts.get(status, 0) + 1
@@ -567,7 +1088,7 @@ async def summarize_run_costs(run_ids: List[str]) -> Dict[str, Any]:
         "failed_run_ids": failed_run_ids,
         "active_run_ids": active_run_ids,
         "totals": {
-            "cost": round(total_cost, 6),
+            "cost": total_cost,
             "prompt_tokens": total_prompt_tokens,
             "completion_tokens": total_completion_tokens,
             "run_count": len(run_ids),

--- a/tests/test_agent_cost.py
+++ b/tests/test_agent_cost.py
@@ -2,7 +2,18 @@
 
 import pytest
 
-from pipeline_client.agent.cost import _cost_ctx, accumulate, estimate_cost, record_context_metrics, record_retry_metric
+from pipeline_client.agent.cost import (
+    _cost_ctx,
+    accumulate,
+    estimate_cost,
+    record_context_metrics,
+    record_fetched_chars,
+    record_retry_metric,
+    reserve_page_fetch,
+    reserve_search_call,
+    set_current_phase,
+    total_token_budget_reached,
+)
 
 
 @pytest.fixture
@@ -137,3 +148,50 @@ def test_record_retry_metric_increments_named_counter(cost_accumulator):
 
     assert cost_accumulator["retry_rate_limits"] == 2
     assert cost_accumulator["retry_provider_failures"] == 1
+
+
+def test_search_budget_reservation_blocks_calls_after_logical_run_ceiling(cost_accumulator, monkeypatch):
+    monkeypatch.setenv("PIPELINE_MAX_SEARCH_CALLS", "2")
+
+    assert reserve_search_call("serper") is True
+    assert reserve_search_call("searlo") is True
+    assert reserve_search_call("serper") is False
+    assert cost_accumulator["serper_calls"] == 1
+    assert cost_accumulator["searlo_calls"] == 1
+    assert cost_accumulator["search_budget_blocked"] == 1
+
+
+def test_total_token_budget_uses_prior_logical_run_tokens(cost_accumulator, monkeypatch):
+    monkeypatch.setenv("PIPELINE_MAX_TOTAL_TOKENS", "10000")
+    cost_accumulator["prompt_tokens"] = 9000
+    cost_accumulator["completion_tokens"] = 1000
+
+    assert total_token_budget_reached() is True
+
+
+def test_phase_breakdown_attributes_tokens_cost_search_and_pages(cost_accumulator):
+    set_current_phase("update-forecast")
+    accumulate(100, 20, model="gpt-4o", cost_usd=0.03)
+    assert reserve_search_call("serper") is True
+    assert reserve_page_fetch() is True
+    record_fetched_chars(250)
+
+    phase = cost_accumulator["phase_breakdown"]["forecast"]
+    assert phase["prompt_tokens"] == 100
+    assert phase["completion_tokens"] == 20
+    assert phase["provider_cost_usd"] == pytest.approx(0.03)
+    assert phase["search_calls"] == 1
+    assert phase["page_fetches"] == 1
+    assert phase["fetched_chars"] == 250
+
+
+def test_phase_search_and_page_budgets_are_enforced(cost_accumulator, monkeypatch):
+    monkeypatch.setenv("PIPELINE_MAX_PHASE_SEARCH_CALLS", "1")
+    monkeypatch.setenv("PIPELINE_MAX_PAGE_FETCHES", "1")
+    set_current_phase("images-Alice")
+
+    assert reserve_search_call("serper") is True
+    assert reserve_search_call("serper") is False
+    assert reserve_page_fetch() is True
+    assert reserve_page_fetch() is False
+    assert cost_accumulator["page_budget_blocked"] == 1

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -9,7 +9,7 @@ The handoff logic lives inside `AgentHandler.handle()` as a nested closure
 
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -259,7 +259,7 @@ async def test_handoff_raised_during_step_progress_when_deadline_exceeded():
     assert continuation_doc["existing_data_gcs_path"] == "gs://test-bucket/checkpoints/run-progress-handoff-test.json"
     assert continuation_doc["run_id"] == "run-progress-handoff-test"
     assert exc_info.value.continuation_run_id == "run-progress-handoff-test"
-    mock_fs_logger_cls.return_value.mark_handoff.assert_called_with(continuation_doc["id"])
+    mock_fs_logger_cls.return_value.mark_handoff.assert_called_with(continuation_doc["id"], duration_ms=ANY)
 
 
 @pytest.mark.asyncio
@@ -310,7 +310,7 @@ async def test_handoff_raised_during_log_callback_when_deadline_exceeded():
     assert continuation_doc["existing_data_gcs_path"] == "gs://test-bucket/checkpoints/run-log-handoff-test.json"
     assert continuation_doc["run_id"] == "run-log-handoff-test"
     assert exc_info.value.continuation_run_id == "run-log-handoff-test"
-    mock_fs_logger_cls.return_value.mark_handoff.assert_called_with(continuation_doc["id"])
+    mock_fs_logger_cls.return_value.mark_handoff.assert_called_with(continuation_doc["id"], duration_ms=ANY)
 
 
 @pytest.mark.asyncio
@@ -365,7 +365,7 @@ async def test_handoff_writes_continuation_run_and_checkpoint_path():
     assert continuation_doc["options"]["force_fresh"] is False
     assert "existing_data_gcs_path" not in continuation_doc["options"]
     assert exc_info.value.continuation_run_id == "run-handoff-test"
-    mock_fs_logger_cls.return_value.mark_handoff.assert_called_with(continuation_doc["id"])
+    mock_fs_logger_cls.return_value.mark_handoff.assert_called_with(continuation_doc["id"], duration_ms=ANY)
     mock_blob.upload_from_string.assert_called_once()
 
 

--- a/tests/test_firestore_logger.py
+++ b/tests/test_firestore_logger.py
@@ -157,7 +157,7 @@ def test_mark_failed_persists_run_health_when_provided(mock_db):
 def test_mark_handoff_keeps_logical_run_active(mock_db):
     """mark_handoff() records an invocation transition without ending the run."""
     logger = FirestoreLogger("run-006")
-    logger.mark_handoff("queue-007")
+    logger.mark_handoff("queue-007", duration_ms=2500)
 
     run_ref = mock_db.collection.return_value.document.return_value
     run_ref.set.assert_called_once()
@@ -165,6 +165,7 @@ def test_mark_handoff_keeps_logical_run_active(mock_db):
     assert data["status"] == "running"
     assert data["continuation_item_id"] == "queue-007"
     assert data["continuation_count"] is not None
+    assert data["logical_duration_ms"] is not None
 
 
 def test_get_db_falls_back_to_default_project_client():

--- a/tests/test_models_review.py
+++ b/tests/test_models_review.py
@@ -331,6 +331,23 @@ def test_semantic_review_packet_includes_every_modeled_profile_field():
     assert packet["candidates"][0] == candidate
 
 
+def test_pipeline_state_preserves_durable_retry_failure_and_cleanup_fields():
+    from shared.models import PipelineState
+
+    state = PipelineState.model_validate(
+        {
+            "complete": False,
+            "issue_attempts": {"issues:Alice:Economy": 2},
+            "step_failures": [{"step": "forecast", "reason": "step_no_data", "detail": "missing source"}],
+            "deterministic_cleanup": {"text_changes": 1},
+        }
+    ).model_dump(mode="json")
+
+    assert state["issue_attempts"] == {"issues:Alice:Economy": 2}
+    assert state["step_failures"][0]["step"] == "forecast"
+    assert state["deterministic_cleanup"] == {"text_changes": 1}
+
+
 def test_review_change_manifest_reports_changed_paths_without_reducing_packet():
     from pipeline_client.agent.review import build_review_change_manifest
 

--- a/tests/test_phase_state.py
+++ b/tests/test_phase_state.py
@@ -29,6 +29,14 @@ def test_issue_attempts_normalizes_values():
     assert race["pipeline_state"]["issue_attempts"] == attempts
 
 
+def test_issue_stance_completion_distinguishes_terminal_no_position_from_placeholders():
+    assert phase_state.issue_stance_is_complete({"stance": "Supports expanded coverage."})
+    assert phase_state.issue_stance_is_complete({"stance": "No public position found after repeated research attempts."})
+    assert not phase_state.issue_stance_is_complete({"stance": ""})
+    assert not phase_state.issue_stance_is_complete({"stance": "DRAFT"})
+    assert not phase_state.issue_stance_is_complete({"stance": "To be determined after review"})
+
+
 def test_build_handoff_context_includes_recent_work_and_cached_queries():
     context = phase_state.build_handoff_context(
         [{"issue": "Healthcare", "stance": "Supports expanded coverage", "confidence": "high"}],

--- a/tests/test_pipeline_metrics.py
+++ b/tests/test_pipeline_metrics.py
@@ -40,7 +40,16 @@ async def test_pipeline_metrics_persists_and_summarizes_provider_cost(monkeypatc
             "cost_usd": 0.01234567,
             "cost_source": "provider",
             "model_breakdown": {},
+            "phase_breakdown": {"forecast": {"provider_cost_usd": 0.01}},
+            "page_fetches": 3,
+            "fetched_chars": 1200,
+            "page_budget_blocked": 1,
             "duration_s": 1.5,
+            "segment_duration_s": 0.5,
+            "searlo_calls": 2,
+            "search_calls": 3,
+            "search_budget_blocked": 1,
+            "token_budget_nudges": 1,
         },
         candidate_count=2,
         cheap_mode=True,
@@ -53,6 +62,15 @@ async def test_pipeline_metrics_persists_and_summarizes_provider_cost(monkeypatc
     assert records[0]["llm_cost_usd"] == pytest.approx(0.01134567)
     assert records[0]["search_cost_usd"] == pytest.approx(0.001)
     assert records[0]["cost_source"] == "provider"
+    assert records[0]["segment_duration_s"] == pytest.approx(0.5)
+    assert records[0]["searlo_calls"] == 2
+    assert records[0]["search_calls"] == 3
+    assert records[0]["search_budget_blocked"] == 1
+    assert records[0]["token_budget_nudges"] == 1
+    assert records[0]["phase_breakdown"]["forecast"]["provider_cost_usd"] == pytest.approx(0.01)
+    assert records[0]["page_fetches"] == 3
+    assert records[0]["fetched_chars"] == 1200
+    assert records[0]["page_budget_blocked"] == 1
     assert summary["total_usd"] == pytest.approx(0.0123)
     assert summary["avg_cheap_usd"] == pytest.approx(0.0123)
 

--- a/tests/test_race_catalog.py
+++ b/tests/test_race_catalog.py
@@ -2,10 +2,12 @@
 
 from datetime import datetime, timedelta, timezone
 
+from shared.models import CanonicalIssue
 from shared.race_catalog import (
     _coerce_datetime,
     build_agent_metrics_summary,
     build_candidate_summaries,
+    build_catalog_health,
     build_forecast_summary,
     build_race_summary_fields,
     build_versioned_catalog_fields,
@@ -137,6 +139,81 @@ def test_build_forecast_summary_defaults_missing_list_fields_to_empty():
     assert summary["based_on_poll_count"] == 0
 
 
+def test_build_catalog_health_distinguishes_discovery_partial_and_terminal_results():
+    discovery = build_catalog_health({"candidates": [{"name": "A", "issues": {}}]})
+    assert discovery["research_tier"] == "discovery_only"
+    assert discovery["missing_issue_count"] == 12
+    assert "missing_issue_research" in discovery["gaps"]
+
+    issues = {
+        issue.value: {
+            "stance": (
+                "No public position found after repeated research attempts." if index == 0 else "Supports this policy."
+            ),
+            "sources": [] if index == 0 else [{"url": "https://example.com"}],
+        }
+        for index, issue in enumerate(CanonicalIssue)
+    }
+    complete = build_catalog_health(
+        {
+            "candidates": [
+                {
+                    "name": "A",
+                    "image_url": "https://example.com/a.jpg",
+                    "roster_sources": [{"url": "https://elections.example.gov"}],
+                    "issues": issues,
+                    "donor_summary": "No federal filings yet.",
+                    "donor_source_url": "https://fec.gov",
+                }
+            ],
+            "forecast": {"rating": "tossup", "source_urls": ["https://cookpolitical.com"]},
+        }
+    )
+    assert complete["research_tier"] == "full_unreviewed"
+    assert complete["terminal_issue_count"] == 12
+    assert complete["substantive_issue_count"] == 11
+    assert complete["no_position_issue_count"] == 1
+    assert complete["sourced_issue_count"] == 11
+    assert complete["forecast_evidence_complete"] is True
+
+
+def test_build_catalog_health_marks_passing_grade_as_validated():
+    health = build_catalog_health(
+        {
+            "candidates": [{"name": "A"}],
+            "validation_grade": {"grade": "A", "passed": True},
+        }
+    )
+    assert health["research_tier"] == "validated"
+    assert health["validation_passed"] is True
+
+
+def test_catalog_health_tracks_strong_roster_evidence_and_section_freshness():
+    health = build_catalog_health(
+        {
+            "race_id": "tx-house-01-2026",
+            "candidates": [
+                {
+                    "name": "A",
+                    "roster_sources": [
+                        {
+                            "url": "https://elections.example.gov/contest",
+                            "race_id": "tx-house-01-2026",
+                            "evidence_tier": 1,
+                            "retrieval_status": "content",
+                            "last_accessed": "2026-07-28T00:00:00Z",
+                        }
+                    ],
+                    "issues": {},
+                }
+            ],
+        }
+    )
+
+    assert health["roster_strong_evidence_candidates"] == 1
+    assert health["section_freshness"]["roster"]["status"] == "recent"
+
+
 def test_build_race_summary_fields_uses_race_data_id_over_race_id_argument():
     race_data = {
         "id": "actual-id",
@@ -152,6 +229,7 @@ def test_build_race_summary_fields_uses_race_data_id_over_race_id_argument():
     assert fields["candidate_count"] == 1
     assert fields["quality_grade"] == "B"
     assert fields["freshness"] == "recent"
+    assert fields["catalog_health"]["research_tier"] == "graded_low"
 
 
 def test_build_race_summary_fields_falls_back_to_argument_race_id():
@@ -176,4 +254,5 @@ def test_build_versioned_catalog_fields_prefixes_keys():
         "draft_updated_utc": "2026-01-01T00:00:00Z",
         "draft_candidate_count": 2,
         "draft_quality_grade": "A",
+        "draft_catalog_health": build_catalog_health(race_data),
     }

--- a/tests/test_race_cleanup.py
+++ b/tests/test_race_cleanup.py
@@ -1,0 +1,80 @@
+from shared.race_cleanup import cleanup_race_data, validate_forecast_evidence
+
+
+def test_cleanup_fixes_known_text_artifact_deduplicates_sources_and_seeds_forecast_evidence():
+    race = {
+        "description": "Candidate advanced after advanced from the primary.  Updated.",
+        "polling": [{"source_url": "https://poll.example.com"}],
+        "candidates": [
+            {
+                "name": "Alice",
+                "donor_summary": "Reported receipts.",
+                "donor_source_url": "https://fec.gov/alice",
+                "issues": {
+                    "Economy": {
+                        "stance": "Supports growth.  ",
+                        "sources": [
+                            {"url": "https://example.com/policy"},
+                            {"url": "https://example.com/policy"},
+                        ],
+                    }
+                },
+            }
+        ],
+        "forecast": {
+            "rationale": "Polling and fundraising support the rating.  ",
+            "source_urls": [],
+            "key_reasons": [" Recent polling.  "],
+            "market_signals": [],
+        },
+    }
+
+    report = cleanup_race_data(race)
+
+    assert race["description"] == "Candidate advanced after advancing from the primary. Updated."
+    assert len(race["candidates"][0]["issues"]["Economy"]["sources"]) == 1
+    assert race["forecast"]["source_urls"] == ["https://poll.example.com", "https://fec.gov/alice"]
+    assert report["text_changes"] >= 3
+    assert report["source_duplicates_removed"] == 1
+    assert report["forecast_sources_added"] == 2
+    assert {item["kind"] for item in race["forecast"]["evidence_lineage"]} == {"polling", "finance"}
+    assert all(item["inferred"] is True for item in race["forecast"]["evidence_lineage"])
+    assert validate_forecast_evidence(race) is True
+
+
+def test_forecast_evidence_gate_records_degraded_step_failure():
+    race = {
+        "pipeline_state": {},
+        "forecast": {
+            "rationale": "Candidate is favored by race ratings.",
+            "source_urls": [],
+        },
+    }
+
+    assert validate_forecast_evidence(race) is False
+    assert race["pipeline_state"]["step_failures"] == [
+        {
+            "step": "forecast",
+            "reason": "step_no_data",
+            "detail": "Forecast evidence gaps: missing_explicit_sources",
+        }
+    ]
+
+
+def test_forecast_evidence_gate_requires_named_rating_source():
+    race = {
+        "pipeline_state": {},
+        "forecast": {
+            "rationale": "Cook Political Report rates this race Lean Republican.",
+            "source_urls": ["https://www.fec.gov/data/candidate/H0CA00001/"],
+        },
+    }
+
+    assert validate_forecast_evidence(race) is False
+    assert "missing_cook_source" in race["pipeline_state"]["step_failures"][0]["detail"]
+
+
+def test_forecast_without_narrative_claims_does_not_require_sources():
+    race = {"forecast": {"rating": "tossup", "source_urls": []}}
+
+    assert validate_forecast_evidence(race) is True

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -58,6 +58,9 @@ def test_pipeline_metrics_prefers_exact_provider_cost():
             "search_cost_usd": 0.001,
             "cost_usd": 0.01234567,
             "cost_source": "provider",
+            "duration_ms": 7000,
+            "logical_duration_ms": 29000,
+            "continuation_count": 2,
             "candidate_count": 2,
             "cheap_mode": True,
         },
@@ -68,6 +71,8 @@ def test_pipeline_metrics_prefers_exact_provider_cost():
     assert record["llm_cost_usd"] == pytest.approx(0.01134567)
     assert record["search_cost_usd"] == pytest.approx(0.001)
     assert record["cost_source"] == "provider"
+    assert record["duration_s"] == 29
+    assert record["continuation_count"] == 2
     assert _compute_metrics_summary([record])["total_usd"] == pytest.approx(0.0123)
 
 
@@ -1549,6 +1554,20 @@ def test_run_options_normalize_and_validate_pipeline_controls():
         RunOptions(review_providers=[])
 
 
+def test_repair_plan_request_deduplicates_and_bounds_races():
+    from pydantic import ValidationError
+    from request_models import RepairPlanRequest
+
+    request = RepairPlanRequest(race_ids=["ca-house-01-2026", "ca-house-01-2026"])
+    assert request.race_ids == ["ca-house-01-2026"]
+
+    with pytest.raises(ValidationError):
+        RepairPlanRequest(race_ids=[])
+
+    with pytest.raises(ValidationError):
+        RepairPlanRequest(race_ids=["INVALID RACE"])
+
+
 # ---------------------------------------------------------------------------
 # /api/races/queue — invalid race_id rejected
 # ---------------------------------------------------------------------------
@@ -1729,6 +1748,73 @@ def test_list_races_normalizes_empty_status_when_catalog_shows_draft():
     assert race["status"] == "draft"
     assert race["draft_exists"] is True
     assert race["published_exists"] is False
+
+
+def test_repair_plan_endpoint_uses_latest_race_data_without_queueing():
+    os.environ["SKIP_AUTH"] = "true"
+    os.environ["ADMIN_API_KEY"] = "test-key"
+
+    import main as app_module
+
+    race_doc = _make_existing_doc(
+        {
+            "race_id": "ca-house-05-2026",
+            "status": "published",
+            "published_at": "2026-07-01T00:00:00Z",
+            "published_updated_utc": "2026-07-01T00:00:00Z",
+            "freshness": "stale",
+        }
+    )
+    races_collection = MagicMock()
+    races_collection.document.return_value.get.return_value = race_doc
+    db = _build_empty_firestore_mock()
+    db.collection.side_effect = lambda name: races_collection if name == "races" else MagicMock()
+    race_data = {
+        "id": "ca-house-05-2026",
+        "candidates": [{"name": "Alice", "issues": {}, "image_url": None}],
+    }
+
+    def get_race_json(_race_id, folder):
+        return None if folder == "drafts" else race_data
+
+    from fastapi.testclient import TestClient
+
+    with (
+        patch("firestore_helpers._get_fs", return_value=db),
+        patch("gcs_helpers._gcs_get_race_json", side_effect=get_race_json),
+    ):
+        response = TestClient(app_module.app).post(
+            "/api/races/repair-plan",
+            json={"race_ids": ["ca-house-05-2026"]},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["race_count"] == 1
+    assert body["repair_count"] == 1
+    assert body["plans"][0]["race_id"] == "ca-house-05-2026"
+    assert body["plans"][0]["estimate_kind"] == "static_ceiling"
+
+
+@pytest.mark.asyncio
+async def test_asset_probe_blocks_private_targets_and_validates_image_content_type():
+    from routers.races_admin.records import _probe_asset, _safe_public_asset_url
+
+    assert _safe_public_asset_url("http://127.0.0.1/private") is False
+    assert _safe_public_asset_url("http://metadata.google.internal/") is False
+
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"content-type": "image/jpeg", "content-length": "1234"}
+    client = MagicMock()
+    client.head = AsyncMock(return_value=response)
+
+    with patch("routers.races_admin.records._host_resolves_public", AsyncMock(return_value=True)):
+        result = await _probe_asset(client, "image", "https://example.com/photo.jpg")
+
+    assert result["reachable"] is True
+    assert result["image_content_type_valid"] is True
+    assert result["content_length"] == 1234
 
 
 def test_list_races_exposes_public_and_draft_quality_separately():
@@ -3530,6 +3616,48 @@ def test_list_race_runs_merges_archived_and_active_runs():
     run_ids = [r["run_id"] for r in body["runs"]]
     assert run_ids[0] == "run-active"
     assert "run-old" in run_ids
+
+
+def test_list_race_runs_includes_completed_canonical_runs():
+    """Recent completed runs remain visible even before or without archival."""
+    os.environ["SKIP_AUTH"] = "true"
+    os.environ["ADMIN_API_KEY"] = "test-key"
+
+    import main as app_module
+    from fastapi.testclient import TestClient
+
+    firestore_helpers._fs_db = None
+
+    runs_subcoll = MagicMock()
+    runs_subcoll.order_by.return_value = runs_subcoll
+    runs_subcoll.limit.return_value = runs_subcoll
+    runs_subcoll.stream.return_value = iter([])
+
+    race_ref = MagicMock()
+    race_ref.collection.return_value = runs_subcoll
+    races_coll = MagicMock()
+    races_coll.document.return_value = race_ref
+
+    completed_doc = _make_existing_doc(
+        {
+            "run_id": "run-completed",
+            "race_id": "ca-house-05-2026",
+            "status": "completed",
+            "started_at": "2026-07-30T00:00:00Z",
+        }
+    )
+    pipeline_runs_coll = MagicMock()
+    pipeline_runs_coll.where.return_value = pipeline_runs_coll
+    pipeline_runs_coll.stream.return_value = iter([completed_doc])
+
+    db = _build_empty_firestore_mock()
+    db.collection.side_effect = lambda name: races_coll if name == "races" else pipeline_runs_coll
+
+    with patch("firestore_helpers._get_fs", return_value=db):
+        response = TestClient(app_module.app).get("/api/races/ca-house-05-2026/runs")
+
+    assert response.status_code == 200
+    assert response.json()["runs"][0]["run_id"] == "run-completed"
 
 
 def test_get_race_run_returns_pipeline_run_doc():

--- a/tests/test_repair_planner.py
+++ b/tests/test_repair_planner.py
@@ -1,0 +1,90 @@
+from shared.models import CanonicalIssue
+from shared.repair_planner import build_repair_plan, summarize_repair_plans
+
+
+def test_discovery_race_plan_targets_missing_research_with_conservative_ceiling():
+    race = {
+        "candidates": [
+            {"name": "Alice", "image_url": None, "issues": {}},
+            {"name": "Bob", "image_url": "https://example.com/bob.jpg", "issues": {}},
+        ],
+        "forecast": None,
+    }
+
+    plan = build_repair_plan("ca-house-01-2026", race)
+
+    assert plan["needs_repair"] is True
+    assert plan["research_tier"] == "discovery_only"
+    assert plan["recommended_steps"] == ["discovery", "images", "issues", "finance", "forecast"]
+    assert plan["candidate_names"] == ["Alice", "Bob"]
+    assert plan["estimated_max_cost_usd"] > 1
+    assert plan["estimated_max_search_calls"] >= 240
+    assert plan["estimate_kind"] == "static_ceiling"
+    assert plan["repair_groups"][0]["candidate_names"] is None
+    assert {tuple(group["candidate_names"] or []) for group in plan["repair_groups"][1:]} == {
+        ("Alice",),
+        ("Bob",),
+    }
+
+
+def test_validated_complete_race_needs_no_repair():
+    issues = {
+        issue.value: {
+            "stance": "Supports a documented policy.",
+            "sources": [{"url": f"https://example.com/{index}"}],
+        }
+        for index, issue in enumerate(CanonicalIssue)
+    }
+    race = {
+        "candidates": [
+            {
+                "name": "Alice",
+                "image_url": "https://example.com/alice.jpg",
+                "roster_sources": [{"url": "https://elections.example.gov"}],
+                "issues": issues,
+                "donor_summary": "Reported receipts.",
+                "donor_source_url": "https://fec.gov",
+            }
+        ],
+        "forecast": {"rating": "safe_d", "source_urls": ["https://example.com/forecast"]},
+        "validation_grade": {"grade": "A", "passed": True},
+    }
+
+    plan = build_repair_plan("ca-house-02-2026", race)
+
+    assert plan["needs_repair"] is False
+    assert plan["recommended_steps"] == []
+    assert plan["candidate_names"] is None
+    assert plan["estimated_max_cost_usd"] == 0
+
+
+def test_low_grade_plan_requires_review_and_iteration():
+    race = {
+        "candidates": [{"name": "Alice", "roster_sources": [{"url": "https://example.gov"}]}],
+        "validation_grade": {"grade": "C", "passed": False},
+    }
+
+    plan = build_repair_plan("ca-house-03-2026", race)
+
+    assert "review" in plan["recommended_steps"]
+    assert "iteration" in plan["recommended_steps"]
+
+
+def test_summarize_repair_plans_rolls_up_ceilings():
+    summary = summarize_repair_plans(
+        [
+            {"needs_repair": True, "estimated_max_cost_usd": 1.25, "estimated_max_search_calls": 20},
+            {"needs_repair": False, "estimated_max_cost_usd": 0, "estimated_max_search_calls": 0},
+        ]
+    )
+
+    assert summary == {
+        "plans": [
+            {"needs_repair": True, "estimated_max_cost_usd": 1.25, "estimated_max_search_calls": 20},
+            {"needs_repair": False, "estimated_max_cost_usd": 0, "estimated_max_search_calls": 0},
+        ],
+        "race_count": 2,
+        "repair_count": 1,
+        "estimated_max_cost_usd": 1.25,
+        "estimated_max_search_calls": 20,
+    }

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1645,6 +1645,45 @@ async def test_run_agent_continuation_skips_completed_issue_stances():
 
 
 @pytest.mark.asyncio
+async def test_run_agent_continuation_skips_terminal_no_position_results():
+    """A reasoned no-position verdict is complete even though it is a quality gap."""
+    existing = {
+        "id": "test-2024",
+        "candidates": [
+            {
+                "name": "Alice",
+                "party": "D",
+                "issues": {
+                    CANONICAL_ISSUES[0]: {
+                        "issue": CANONICAL_ISSUES[0],
+                        "stance": "No public position found after repeated research attempts.",
+                        "confidence": "low",
+                        "sources": [],
+                    }
+                },
+            }
+        ],
+        "pipeline_state": {
+            "completed_units": [f"issues:Alice:{CANONICAL_ISSUES[0]}"],
+        },
+        "updated_utc": "2024-01-01T00:00:00Z",
+    }
+
+    with patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = {}
+        result = await run_agent(
+            "test-2024",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["issues"],
+            resume_partial=True,
+        )
+
+    assert mock_loop.call_count == len(CANONICAL_ISSUES) - 1
+    assert f"issues:Alice:{CANONICAL_ISSUES[0]}" in result["pipeline_state"]["completed_units"]
+
+
+@pytest.mark.asyncio
 async def test_run_agent_continuation_retries_blank_issue_stances():
     existing = {
         "id": "test-2024",

--- a/tests/test_shared_config.py
+++ b/tests/test_shared_config.py
@@ -49,6 +49,16 @@ def test_runtime_config_bounds_review_cycles_and_issue_concurrency(monkeypatch):
     assert config.issue_concurrency == 8
 
 
+def test_runtime_config_bounds_search_and_token_ceilings(monkeypatch):
+    monkeypatch.setenv("PIPELINE_MAX_SEARCH_CALLS", "99999")
+    monkeypatch.setenv("PIPELINE_MAX_TOTAL_TOKENS", "999999999")
+
+    config = PipelineRuntimeConfig.from_env()
+
+    assert config.max_search_calls == 5000
+    assert config.max_total_tokens == 50_000_000
+
+
 def test_review_providers_cannot_be_empty():
     try:
         normalize_review_providers([])

--- a/tests/test_smartervote_mcp_client.py
+++ b/tests/test_smartervote_mcp_client.py
@@ -1,5 +1,6 @@
 import os
 from importlib.util import find_spec
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -24,11 +25,15 @@ async def test_smartervote_mcp_exposes_lean_tool_surface():
         "list_race_summaries",
         "get_published_race",
         "list_admin_races",
+        "scan_catalog",
         "get_race_record",
         "list_draft_races",
         "list_pipeline_steps",
         "get_race_data",
         "audit_draft_vs_published",
+        "plan_repairs",
+        "audit_race_assets",
+        "assess_publish_readiness",
         "queue_races",
         "run_race",
         "publish_race",
@@ -47,9 +52,16 @@ async def test_smartervote_mcp_exposes_lean_tool_surface():
         "list_active_runs",
         "get_run",
         "get_run_logs",
+        "get_run_diagnostics",
+        "list_race_runs",
+        "get_race_run",
+        "list_race_versions",
+        "get_race_version",
+        "restore_race_version",
         "cancel_or_delete_run",
         "get_pipeline_metrics",
         "get_pipeline_metrics_summary",
+        "get_gcp_pipeline_costs",
         "summarize_run_costs",
         "clear_races_api_cache",
         "get_analytics_overview",
@@ -173,6 +185,222 @@ async def test_audit_draft_vs_published_reports_roster_and_grade_diffs(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_scan_catalog_returns_compact_ranked_health_rows(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    monkeypatch.setattr(
+        server,
+        "list_admin_races",
+        AsyncMock(
+            return_value={
+                "races": [
+                    {
+                        "race_id": "ca-house-05-2026",
+                        "state": "California",
+                        "office": "U.S. House",
+                        "published_exists": True,
+                        "quality_grade": None,
+                        "freshness": "stale",
+                        "candidates": [{"name": "One", "image_url": None}, {"name": "Two", "image_url": "https://ok"}],
+                        "forecast": {"rating": "lean_r"},
+                    },
+                    {
+                        "race_id": "ca-house-06-2026",
+                        "state": "California",
+                        "office": "U.S. House",
+                        "published_exists": True,
+                        "quality_grade": "A",
+                        "freshness": "recent",
+                        "candidates": [{"name": "Three", "image_url": "https://ok"}],
+                        "forecast": {"rating": "safe_d"},
+                    },
+                ]
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        server,
+        "_client",
+        lambda: _StubRacesClient(
+            {
+                "/analytics/traffic": {
+                    "configured": True,
+                    "top_pages": [
+                        {"name": "/races/ca-house-05-2026", "pageviews": 1000},
+                        {"name": "/races/ca-house-05-2026/candidates/one", "pageviews": 240},
+                    ],
+                },
+                "/analytics/races": {
+                    "races": [{"race_id": "ca-house-05-2026", "requests_24h": 17}],
+                },
+            }
+        ),
+    )
+
+    result = await server.scan_catalog(
+        state="California",
+        office="House",
+        publication="published",
+        research_tier="discovery_only",
+        missing_images_only=True,
+        competitive_only=True,
+    )
+
+    assert result["matched"] == 1
+    assert result["has_more"] is False
+    assert result["rows"][0]["race_id"] == "ca-house-05-2026"
+    assert result["rows"][0]["research_tier"] == "discovery_only"
+    assert result["rows"][0]["missing_image_count"] == 1
+    assert result["rows"][0]["pageviews"] == 1240
+    assert result["rows"][0]["api_requests"] == 17
+    assert result["rows"][0]["priority_reasons"] == [
+        "discovery_only",
+        "competitive",
+        "missing_images",
+        "stale",
+        "user_demand",
+    ]
+    assert result["summary"]["traffic_configured"] is True
+
+
+@pytest.mark.asyncio
+async def test_plan_repairs_forwards_bounded_read_only_request(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    client = type("Client", (), {"post": AsyncMock(return_value={"plans": []})})()
+    monkeypatch.setattr(server, "_client", lambda: client)
+
+    result = await server.plan_repairs(["ca-house-05-2026"])
+
+    assert result == {"plans": []}
+    client.post.assert_awaited_once_with(
+        "/api/races/repair-plan",
+        json={"race_ids": ["ca-house-05-2026"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_audit_race_assets_forwards_persistence_controls(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    client = type("Client", (), {"post": AsyncMock(return_value={"results": []})})()
+    monkeypatch.setattr(server, "_client", lambda: client)
+
+    await server.audit_race_assets(["ca-house-05-2026"], persist=True, max_urls_per_race=25)
+
+    client.post.assert_awaited_once_with(
+        "/api/races/asset-audit",
+        json={"race_ids": ["ca-house-05-2026"], "persist": True, "max_urls_per_race": 25},
+    )
+
+
+@pytest.mark.asyncio
+async def test_assess_publish_readiness_blocks_failed_or_placeholder_drafts(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    responses = {
+        "/api/races/ca-house-01-2026/data": {
+            "candidates": [{"name": "Ready Candidate"}],
+            "validation_grade": {"passed": True},
+            "run_health": {"status": "healthy"},
+            "pipeline_state": {"complete": True},
+        },
+        "/races/ca-house-01-2026": {"candidates": [{"name": "Old Candidate"}]},
+        "/api/races/ca-house-02-2026/data": {
+            "candidates": [{"name": "DRAFT"}],
+            "validation_grade": {"passed": False},
+            "run_health": {"verdict": "failed"},
+            "pipeline_state": {"complete": False},
+        },
+        "/races/ca-house-02-2026": RuntimeError("not published"),
+    }
+    monkeypatch.setattr(server, "_client", lambda: _StubRacesClient(responses))
+
+    result = await server.assess_publish_readiness(["ca-house-01-2026", "ca-house-02-2026"])
+
+    assert result["ready_race_ids"] == ["ca-house-01-2026"]
+    assert result["blocked_race_ids"] == ["ca-house-02-2026"]
+    assert result["rows"][0]["warnings"] == ["candidate_roster_changes"]
+    assert set(result["rows"][1]["blockers"]) == {
+        "validation_not_passed",
+        "run_health_failed",
+        "literal_placeholder_content",
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_races_never_posts_when_readiness_is_blocked(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    client = type("Client", (), {"post": AsyncMock()})()
+    monkeypatch.setattr(server, "_client", lambda: client)
+    monkeypatch.setattr(
+        server,
+        "assess_publish_readiness",
+        AsyncMock(
+            return_value={
+                "all_ready": False,
+                "blocked_race_ids": ["ca-house-02-2026"],
+                "ready_race_ids": ["ca-house-01-2026"],
+            }
+        ),
+    )
+
+    result = await server.publish_races(["ca-house-01-2026", "ca-house-02-2026"])
+
+    assert result["published"] == []
+    client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_queue_races_and_run_race_forward_debug_mode(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    client = type("Client", (), {"post": AsyncMock(return_value={"added": []})})()
+    monkeypatch.setattr(server, "_client", lambda: client)
+
+    await server.queue_races(["ca-house-05-2026"], debug_mode=True)
+    await server.run_race("ca-house-05-2026", debug_mode=True)
+
+    first_call, second_call = client.post.await_args_list
+    assert first_call.kwargs["json"]["options"]["debug_mode"] is True
+    assert second_call.kwargs["json"]["debug_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_run_logs_forwards_opaque_cursor(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    client = type("Client", (), {"get": AsyncMock(return_value={"logs": [], "next_cursor": "002"})})()
+    monkeypatch.setattr(server, "_client", lambda: client)
+
+    await server.get_run_logs("run-1", cursor="001", limit=25)
+
+    client.get.assert_awaited_once_with("/runs/run-1/logs", params={"cursor": "001", "limit": 25})
+
+
+@pytest.mark.asyncio
 async def test_summarize_run_costs_normalizes_nested_and_top_level_fields(monkeypatch):
     if find_spec("mcp") is None:
         pytest.skip("MCP SDK is optional outside the local MCP environment")
@@ -185,6 +413,8 @@ async def test_summarize_run_costs_normalizes_nested_and_top_level_fields(monkey
             "race_id": "ar-governor-2026",
             "status": "completed",
             "estimated_usd": 3.6,
+            "prompt_tokens": 111,
+            "completion_tokens": 11,
             "model_breakdown": {
                 "google/gemini-2.5-flash": {"prompt_tokens": 100, "completion_tokens": 10},
             },
@@ -212,8 +442,8 @@ async def test_summarize_run_costs_normalizes_nested_and_top_level_fields(monkey
     assert result["active_run_ids"] == []
     assert result["totals"] == {
         "cost": 3.6,
-        "prompt_tokens": 300,
-        "completion_tokens": 30,
+        "prompt_tokens": 311,
+        "completion_tokens": 31,
         "run_count": 3,
     }
 
@@ -225,6 +455,44 @@ async def test_summarize_run_costs_normalizes_nested_and_top_level_fields(monkey
     assert nested_row["cost"] == 0.0
     assert nested_row["prompt_tokens"] == 200
     assert missing_row == {"run_id": "run-missing", "status": "missing"}
+
+
+@pytest.mark.asyncio
+async def test_summarize_run_costs_prefers_exact_metrics_record(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    responses = {
+        "/pipeline/metrics": {
+            "records": [
+                {
+                    "run_id": "run-1",
+                    "race_id": "ca-house-05-2026",
+                    "cost_usd": 0.6037413091999998,
+                    "estimated_usd": 0.595471,
+                    "cost_source": "provider",
+                    "prompt_tokens": 2813117,
+                    "completion_tokens": 303664,
+                    "model_breakdown": {},
+                }
+            ]
+        },
+        "/runs/run-1": {
+            "run_id": "run-1",
+            "race_id": "ca-house-05-2026",
+            "status": "completed",
+        },
+    }
+    monkeypatch.setattr(server, "_client", lambda: _StubRacesClient(responses))
+
+    result = await server.summarize_run_costs(["run-1"])
+
+    assert result["rows"][0]["cost"] == 0.6037413091999998
+    assert result["rows"][0]["cost_source"] == "provider"
+    assert result["rows"][0]["prompt_tokens"] == 2813117
+    assert result["totals"]["cost"] == 0.6037413091999998
 
 
 def test_compact_options_keeps_false_and_drops_none():

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -155,6 +155,13 @@ export type ForecastRating =
   | "safe_r"
   | "other";
 
+export interface ForecastEvidence {
+  claim: string;
+  source_url: string;
+  kind: "polling" | "market" | "finance" | "race_context" | "other";
+  inferred: boolean;
+}
+
 export interface RaceForecast {
   predicted_winner_name?: string;
   predicted_winner_party?: string;
@@ -171,6 +178,7 @@ export interface RaceForecast {
   generated_at: string;
   model: string;
   source_urls: string[];
+  evidence_lineage?: ForecastEvidence[];
   market_signals: ForecastMarketSignal[];
 }
 
@@ -234,6 +242,9 @@ export interface PipelineState {
   remaining_candidates: string[];
   remaining_steps: string[];
   completed_units: string[];
+  issue_attempts: Record<string, number>;
+  step_failures: StepFailure[];
+  deterministic_cleanup: Record<string, number>;
   race_identity?: RaceIdentityBrief;
 }
 


### PR DESCRIPTION
## What changed

- Adds prioritized catalog scans, materialized health tiers, field-level freshness, and persisted asset audits.
- Returns independently queueable race/candidate repair groups with observed per-phase cost calibration and static safety floors.
- Adds forecast evidence cleanup and claim-to-source lineage.
- Adds logical-run global/phase search and token ceilings plus page/context ceilings.
- Persists exact phase-level token, provider cost, search, and page attribution across continuations.
- Expands MCP diagnostics, cost summaries, readiness checks, run visibility, and catalog-management controls.

## Why

The catalog had enough discovery coverage to make blanket reruns wasteful, but lacked cheap targeting signals and safe step/candidate scoping. It also could not distinguish URL presence from asset health or explain spend by phase.

## Validation

- `python -m pytest -q` — 976 passed
- `npm run check` — 0 errors, 0 warnings
- `python -m black --check shared smartervote_mcp services/races-api tests pipeline_client functions scripts`
- `python -m isort --check-only shared smartervote_mcp services/races-api tests pipeline_client functions scripts`
- `git diff --cached --check`

The autonomous-agent extraction work and other unrelated working-tree changes are intentionally excluded.
