### PR TITLE
Page catalog rechecks to avoid request timeout

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -179,6 +179,11 @@ uncached page fetches and fetched characters, and persist per-phase
 token/provider/search/page attribution across continuation handoffs. Defaults
 are documented in `.env.example`.
 
+The all-catalog recheck is cursor-paged because a full storage hydration can
+outlive the Cloud Run request deadline. MCP `recheck_all_races` follows all
+bounded pages automatically; direct API callers must continue with
+`next_cursor` while `has_more` is true.
+
 Example targeted update:
 
 ```json

--- a/services/races-api/routers/races_admin/records.py
+++ b/services/races-api/routers/races_admin/records.py
@@ -94,36 +94,53 @@ async def list_draft_races() -> Dict[str, Any]:
 
 
 @router.post("/api/races/recheck", dependencies=[Depends(verify_token)])
-async def recheck_all_race_statuses() -> Dict[str, Any]:
-    """Re-derive status for all race records and hydrate missing catalog metadata from storage."""
+async def recheck_all_race_statuses(cursor: str | None = None, limit: int = 50) -> Dict[str, Any]:
+    """Reconcile one bounded catalog page and return an opaque continuation cursor."""
     db = firestore_helpers._get_fs()
-    docs = db.collection("races").limit(1000).stream()
+    docs = db.collection("races").limit(10000).stream()
     races: list[Dict[str, Any]] = []
     updated = 0
-    seen_race_ids: set[str] = set()
+    docs_by_race_id: dict[str, Any] = {}
     for doc in docs:
         race_data = firestore_helpers._doc_to_plain(doc)
         if not race_data:
             continue
-        race_id = race_data.get("race_id") or race_data.get("id") or doc.id
+        race_id = str(race_data.get("race_id") or race_data.get("id") or doc.id)
         if not race_data.get("race_id"):
             race_data["race_id"] = race_id
-        seen_race_ids.add(str(race_id))
-        latest, changed = _recheck_race_status(db, race_id, race_data)
-        if latest:
-            races.append(latest)
-        if changed:
-            updated += 1
+        docs_by_race_id[race_id] = race_data
 
     storage_ids = set(gcs_helpers._gcs_list_race_ids("races") or [])
     storage_ids.update(gcs_helpers._gcs_list_race_ids("drafts") or [])
-    for race_id in sorted(storage_ids - seen_race_ids):
-        update = _backfill_catalog_from_storage(race_id)
-        if update is None:
+    all_race_ids = sorted(set(docs_by_race_id) | {str(race_id) for race_id in storage_ids})
+    if cursor:
+        all_race_ids = [race_id for race_id in all_race_ids if race_id > cursor]
+    limit = max(1, min(int(limit), 200))
+    page_ids = all_race_ids[:limit]
+
+    for race_id in page_ids:
+        race_data = docs_by_race_id.get(race_id)
+        if race_data is not None:
+            latest, changed = _recheck_race_status(db, race_id, race_data)
+            if latest:
+                races.append(latest)
+            updated += int(changed)
             continue
-        races.append({"race_id": race_id, **update})
-        updated += 1
-    return {"message": f"Rechecked {len(races)} races", "checked": len(races), "updated": updated, "races": races}
+        update = _backfill_catalog_from_storage(race_id)
+        if update is not None:
+            races.append({"race_id": race_id, **update})
+            updated += 1
+
+    has_more = len(all_race_ids) > len(page_ids)
+    next_cursor = page_ids[-1] if has_more and page_ids else None
+    return {
+        "message": f"Rechecked {len(races)} races",
+        "checked": len(races),
+        "updated": updated,
+        "races": races,
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
 
 
 @router.post("/api/races/repair-plan", dependencies=[Depends(verify_token)])

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -685,8 +685,32 @@ async def recheck_race(race_id: str) -> Dict[str, Any]:
 
 @mcp.tool(structured_output=False)
 async def recheck_all_races() -> Dict[str, Any]:
-    """Reconcile all race statuses from storage and Firestore state."""
-    return await _client().post("/api/races/recheck")
+    """Reconcile all race statuses through bounded cursor pages."""
+    client = _client()
+    cursor: str | None = None
+    checked = 0
+    updated = 0
+    page_count = 0
+    while True:
+        result = await client.request(
+            "POST",
+            "/api/races/recheck",
+            params={"limit": 50, **({"cursor": cursor} if cursor else {})},
+        )
+        page_count += 1
+        checked += int(result.get("checked") or 0)
+        updated += int(result.get("updated") or 0)
+        cursor = result.get("next_cursor")
+        if not result.get("has_more") or not cursor:
+            break
+        if page_count >= 100:
+            raise RuntimeError("Catalog recheck exceeded 100 pages; refusing an unbounded loop.")
+    return {
+        "message": f"Rechecked {checked} races across {page_count} page(s)",
+        "checked": checked,
+        "updated": updated,
+        "page_count": page_count,
+    }
 
 
 _US_STATES: Dict[str, str] = {

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -2414,6 +2414,41 @@ def test_recheck_all_clears_stale_current_run_for_inactive_race():
     mock_update.assert_called_once_with("co-senate-2026", {"current_run_id": None})
 
 
+def test_recheck_all_uses_bounded_cursor_pages():
+    os.environ["SKIP_AUTH"] = "true"
+    os.environ["ADMIN_API_KEY"] = "test-key"
+
+    import main as app_module
+
+    docs = []
+    for race_id in ("race-a", "race-b", "race-c"):
+        doc = _make_existing_doc({"race_id": race_id, "status": "published"})
+        doc.id = race_id
+        docs.append(doc)
+    races_coll = MagicMock()
+    races_coll.limit.return_value.stream.return_value = iter(docs)
+    db = _build_empty_firestore_mock()
+    db.collection.side_effect = lambda name: races_coll if name == "races" else MagicMock()
+
+    from fastapi.testclient import TestClient
+
+    with (
+        patch("firestore_helpers._get_fs", return_value=db),
+        patch("gcs_helpers._gcs_list_race_ids", return_value=[]),
+        patch(
+            "routers.races_admin.records._recheck_race_status",
+            side_effect=lambda _db, race_id, race: (race, race_id == "race-b"),
+        ),
+    ):
+        response = TestClient(app_module.app).post("/api/races/recheck?limit=2")
+
+    assert response.status_code == 200
+    assert response.json()["checked"] == 2
+    assert response.json()["updated"] == 1
+    assert response.json()["has_more"] is True
+    assert response.json()["next_cursor"] == "race-b"
+
+
 def test_recheck_reconciles_empty_race_to_draft_when_draft_exists():
     """Recheck should correct inactive status drift from empty to draft based on storage."""
     os.environ["SKIP_AUTH"] = "true"

--- a/tests/test_smartervote_mcp_client.py
+++ b/tests/test_smartervote_mcp_client.py
@@ -304,6 +304,39 @@ async def test_audit_race_assets_forwards_persistence_controls(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_recheck_all_races_follows_bounded_cursor_pages(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    client = type(
+        "Client",
+        (),
+        {
+            "request": AsyncMock(
+                side_effect=[
+                    {"checked": 50, "updated": 10, "has_more": True, "next_cursor": "race-050"},
+                    {"checked": 8, "updated": 2, "has_more": False, "next_cursor": None},
+                ]
+            )
+        },
+    )()
+    monkeypatch.setattr(server, "_client", lambda: client)
+
+    result = await server.recheck_all_races()
+
+    assert result == {
+        "message": "Rechecked 58 races across 2 page(s)",
+        "checked": 58,
+        "updated": 12,
+        "page_count": 2,
+    }
+    assert client.request.await_count == 2
+    assert client.request.await_args_list[1].kwargs["params"]["cursor"] == "race-050"
+
+
+@pytest.mark.asyncio
 async def test_assess_publish_readiness_blocks_failed_or_placeholder_drafts(monkeypatch):
     if find_spec("mcp") is None:
         pytest.skip("MCP SDK is optional outside the local MCP environment")


### PR DESCRIPTION
## What changed

- Pages `/api/races/recheck` by stable race ID with `limit`, `next_cursor`, and `has_more`.
- Makes MCP `recheck_all_races` follow bounded pages automatically.
- Adds API and MCP pagination regression tests.

## Why

The first production catalog backfill after #195 attempted all 508 races in one synchronous Cloud Run request and returned 503 after roughly 80 seconds. Catalog reconciliation needs to be safely resumable and bounded.

## Validation

- `python -m pytest -q` — 978 passed
- `npm run check` — 0 errors, 0 warnings
- focused races-api/MCP suite — 122 passed
