### PR TITLE
Harden catalog audit and backfill retries

### DIFF
--- a/services/races-api/routers/races_admin/records.py
+++ b/services/races-api/routers/races_admin/records.py
@@ -216,10 +216,10 @@ async def _probe_asset(client: httpx.AsyncClient, kind: str, url: str) -> Dict[s
     try:
         response = await client.head(url, follow_redirects=False)
         content_type = response.headers.get("content-type", "").split(";")[0].lower()
-        reachable = response.status_code < 400 or response.status_code in {401, 403, 405}
+        reachable = response.status_code < 400 or response.status_code in {401, 403, 405, 429}
         image_valid = (
             None
-            if kind != "image" or response.status_code in {401, 403, 405} or not content_type
+            if kind != "image" or response.status_code in {401, 403, 405, 429} or not content_type
             else content_type.startswith("image/")
         )
         content_length = int(response.headers.get("content-length") or 0) or None
@@ -237,7 +237,7 @@ async def _probe_asset(client: httpx.AsyncClient, kind: str, url: str) -> Dict[s
         return {
             "kind": kind,
             "url": url,
-            "status": "reachable" if reachable else "broken",
+            "status": "rate_limited" if response.status_code == 429 else "reachable" if reachable else "broken",
             "reachable": reachable,
             "http_status": response.status_code,
             "content_type": content_type or None,

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -692,11 +692,20 @@ async def recheck_all_races() -> Dict[str, Any]:
     updated = 0
     page_count = 0
     while True:
-        result = await client.request(
-            "POST",
-            "/api/races/recheck",
-            params={"limit": 50, **({"cursor": cursor} if cursor else {})},
-        )
+        result = None
+        for attempt in range(3):
+            try:
+                result = await client.request(
+                    "POST",
+                    "/api/races/recheck",
+                    params={"limit": 10, **({"cursor": cursor} if cursor else {})},
+                )
+                break
+            except RuntimeError:
+                if attempt == 2:
+                    raise
+                await asyncio.sleep(3 * (attempt + 1))
+        assert result is not None
         page_count += 1
         checked += int(result.get("checked") or 0)
         updated += int(result.get("updated") or 0)

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -1816,6 +1816,14 @@ async def test_asset_probe_blocks_private_targets_and_validates_image_content_ty
     assert result["image_content_type_valid"] is True
     assert result["content_length"] == 1234
 
+    response.status_code = 429
+    response.headers = {"content-type": "text/html"}
+    with patch("routers.races_admin.records._host_resolves_public", AsyncMock(return_value=True)):
+        limited = await _probe_asset(client, "image", "https://example.com/photo.jpg")
+    assert limited["status"] == "rate_limited"
+    assert limited["reachable"] is True
+    assert limited["image_content_type_valid"] is None
+
 
 def test_list_races_exposes_public_and_draft_quality_separately():
     """Admin/MCP records should keep draft and published catalog metadata separate."""


### PR DESCRIPTION
Treat HTTP 429 assets as reachable but unverified, so rate-limited Wikimedia/Kalshi URLs do not become false broken-link targets. Use the production-proven ten-race MCP recheck page size with bounded retries. Validated with 122 focused API/MCP tests.