### PR TITLE
Avoid false image-quality flags on rate limits

### DIFF
--- a/services/races-api/routers/races_admin/records.py
+++ b/services/races-api/routers/races_admin/records.py
@@ -230,7 +230,11 @@ async def _probe_asset(client: httpx.AsyncClient, kind: str, url: str) -> Dict[s
         image_quality = None
         if kind == "image" and image_valid is False:
             image_quality = "invalid_content_type"
-        elif kind == "image" and (suspicious_thumbnail or (content_length is not None and content_length < 10_000)):
+        elif (
+            kind == "image"
+            and image_valid is True
+            and (suspicious_thumbnail or (content_length is not None and content_length < 10_000))
+        ):
             image_quality = "suspicious_small"
         elif kind == "image" and image_valid is True:
             image_quality = "content_type_valid"

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -1817,12 +1817,13 @@ async def test_asset_probe_blocks_private_targets_and_validates_image_content_ty
     assert result["content_length"] == 1234
 
     response.status_code = 429
-    response.headers = {"content-type": "text/html"}
+    response.headers = {"content-type": "text/html", "content-length": "1974"}
     with patch("routers.races_admin.records._host_resolves_public", AsyncMock(return_value=True)):
         limited = await _probe_asset(client, "image", "https://example.com/photo.jpg")
     assert limited["status"] == "rate_limited"
     assert limited["reachable"] is True
     assert limited["image_content_type_valid"] is None
+    assert limited["image_quality"] is None
 
 
 def test_list_races_exposes_public_and_draft_quality_separately():


### PR DESCRIPTION
Summary: Only apply image size heuristics after validating an image content type. Keep HTTP 429 image probes reachable and rate-limited without treating the small HTML error body as a suspicious image. Adds regression coverage for the production-observed case. Validation: targeted asset probe test, Black, and isort all pass.