### PR TITLE
Add auditable core race refresh workflow

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -153,6 +153,9 @@ Common tools:
   groups with calibrated-or-static cost and search ceilings
 - `audit_race_assets`: bounded source/photo URL and image-quality checks;
   `persist=true` stores the evidence on the catalog record
+- `refresh_race_core`: canonical low-cost roster/summary, image, polling,
+  forecast, and voter-resource refresh. Discovery must establish exact-contest
+  roster evidence before downstream work; debug evidence is enabled by default.
 - `queue_races`: one or more races with full options
 - `run_race`: one race
 - `list_active_runs`, `get_queue`: queue/worker state
@@ -178,6 +181,27 @@ Logical runs enforce both global and phase search/token ceilings. They also cap
 uncached page fetches and fetched characters, and persist per-phase
 token/provider/search/page attribution across continuation handoffs. Defaults
 are documented in `.env.example`.
+
+For an issue unit, a ceiling ends further searching but does not manufacture a
+result. The last turn escalates from an economy model when a stronger configured
+fallback exists, receives the accumulated evidence, and is forced to call
+`set_issue_stance`. Its terminal result must be either a sourced factual stance
+or exactly `No public position found`. The latter is accepted only when the
+durable `pipeline_state.issue_research` audit records at least two search/fetch
+actions. Retry exhaustion leaves the unit incomplete and visible to review;
+it is never converted into a no-position finding.
+
+Example core refresh:
+
+```json
+{
+  "race_ids": ["pa-house-10-2026"],
+  "baseline_source": "latest",
+  "cheap_mode": true,
+  "debug_mode": true,
+  "goal": "Verify the exact-contest roster and refresh summaries, polling, and forecast."
+}
+```
 
 The all-catalog recheck is cursor-paged because a full storage hydration can
 outlive the Cloud Run request deadline. MCP `recheck_all_races` follows all

--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -386,7 +386,7 @@ def _sanitize_candidate_issues(race_json: Dict[str, Any], log: Any | None = None
                 issue["issue"] = LEGACY_ISSUE_NAMES.get(str(issue.get("issue") or key), str(issue.get("issue") or key))
                 stance = str(issue.get("stance") or "").strip()
                 if _is_missing_stance_text(stance):
-                    if _is_placeholder_junk_stance(stance):
+                    if _is_placeholder_junk_stance(stance) and "no public position found" not in stance.casefold():
                         # A literal placeholder artifact (e.g. a stance that is
                         # just the word "DRAFT") — distinct from a deliberate
                         # "no public position found" research conclusion. Register
@@ -397,9 +397,12 @@ def _sanitize_candidate_issues(race_json: Dict[str, Any], log: Any | None = None
                             RunFailureReason.PLACEHOLDER_CONTENT,
                             f"{_candidate_name(candidate)}/{key}: literal placeholder stance {stance!r}",
                         )
-                    issue["stance"] = "No public position found after repeated research attempts."
-                    issue["confidence"] = "low"
-                    issue.setdefault("sources", [])
+                    if "no public position found" in stance.casefold():
+                        issue["stance"] = "No public position found"
+                        issue["confidence"] = "low"
+                        issue.setdefault("sources", [])
+                    else:
+                        issue["stance"] = ""
                     if log:
                         log("warning", f"Normalized placeholder stance for candidates[{candidate_index}].issues.{key}")
             if key not in normalized or _issue_quality(issue) > _issue_quality(normalized[key]):

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -11,7 +11,7 @@ import re
 from datetime import datetime, timezone
 from difflib import get_close_matches
 from typing import Any, Callable, Dict, Optional
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 # Pattern matching metadata field names (snake_case, no spaces) — clearly not human names
 _METADATA_KEY_RE = re.compile(r"^[a-z][a-z0-9_]+$")
@@ -35,6 +35,49 @@ _CONTEST_STAGES = {
     "special",
     "unknown",
 }
+
+
+def _roster_source_text(source: Dict[str, Any]) -> str:
+    return unquote(" ".join(str(source.get(key) or "") for key in ("title", "evidence", "url"))).casefold()
+
+
+def _source_supports_exact_contest(source: Dict[str, Any], *, race_id: str) -> bool:
+    """Reject same-number state-legislative evidence for federal House races."""
+    match = re.fullmatch(r"[a-z]{2}-house-(\d{1,2})-(?:19|20)\d{2}", race_id)
+    if not match:
+        return True
+    district = str(int(match.group(1)))
+    text = _roster_source_text(source)
+    federal_house = bool(
+        re.search(r"\b(?:u\.?s\.?|united states)\s+(?:house|representative)", text)
+        or re.search(r"\bcongress(?:ional)?\b", text)
+    )
+    exact_district = bool(
+        re.search(rf"\b0*{re.escape(district)}(?:st|nd|rd|th)?\s+(?:congressional\s+)?district\b", text)
+        or re.search(rf"\b(?:congressional\s+)?district\s*(?:no\.?\s*)?#?0*{re.escape(district)}\b", text)
+        or re.search(rf"\bcd\s*[-#]?\s*0*{re.escape(district)}\b", text)
+    )
+    return federal_house and exact_district
+
+
+def _source_proves_different_contest(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> bool:
+    """Return true for evidence that places a candidate in a different contest."""
+    parsed_url = urlparse(str(source.get("url") or ""))
+    if source.get("type") not in {"official", "fec", "campaign", "ballotpedia", "news"}:
+        return False
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        return False
+    text = _roster_source_text(source)
+    name_words = re.findall(r"[a-z0-9]+", candidate_name.casefold())
+    if not name_words or not all(word in text for word in name_words):
+        return False
+    if re.fullmatch(r"[a-z]{2}-house-\d{1,2}-(?:19|20)\d{2}", race_id):
+        state_house = bool(
+            re.search(r"\bstate\s+(?:house|representative)", text)
+            or re.search(r"\b[a-z ]+\s+house of representatives\s+(?:district|hd)\b", text)
+        )
+        return state_house and not _source_supports_exact_contest(source, race_id=race_id)
+    return False
 
 
 def _normalize_source(source: Any, *, default_type: str = "finance") -> Dict[str, Any] | None:
@@ -85,6 +128,8 @@ def _source_supports_candidate_addition(source: Dict[str, Any], *, candidate_nam
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         return False
     if source.get("race_id") != race_id or not source.get("title") or not source.get("evidence"):
+        return False
+    if not _source_supports_exact_contest(source, race_id=race_id):
         return False
     name_words = re.findall(r"[a-z0-9]+", candidate_name.lower())
     evidence_text = f"{source.get('title', '')} {source.get('evidence', '')}".lower()
@@ -323,6 +368,37 @@ def _make_editing_handlers(
     def remove_candidate(args: Dict[str, Any]) -> str:
         name = args["name"]
         reason = args.get("reason", "").strip()
+        candidates = race_json.get("candidates", [])
+        if args.get("wrong_contest") is True:
+            race_id = str(race_json.get("id") or "").strip()
+            proof = [
+                source
+                for source in (_normalize_roster_source(item) for item in args.get("sources") or [])
+                if source and _source_proves_different_contest(source, candidate_name=name, race_id=race_id)
+            ]
+            if not proof:
+                return (
+                    f"ERROR: wrong-contest removal blocked for '{name}'. Provide a current source that names the "
+                    "candidate and explicitly identifies the different office/district."
+                )
+            active_after = [
+                candidate
+                for candidate in candidates
+                if isinstance(candidate, dict)
+                and candidate.get("name") != name
+                and candidate.get("name")
+                and candidate.get("withdrawn") is not True
+            ]
+            if not active_after:
+                return f"ERROR: wrong-contest removal blocked. Add the verified correct roster before removing '{name}'."
+            original_count = len(candidates)
+            race_json["candidates"] = [
+                candidate for candidate in candidates if not isinstance(candidate, dict) or candidate.get("name") != name
+            ]
+            if len(race_json["candidates"]) < original_count:
+                log("info", f"    Removed wrong-contest candidate: {name} ({reason or proof[0].get('url')})")
+                return f"Removed wrong-contest candidate '{name}' from the active roster."
+            return f"Candidate '{name}' not found - no action taken."
 
         # Guard: reject removals that are clearly data-quality fixes rather than
         # actual race withdrawals. Withdrawal reasons must mention a concrete
@@ -432,8 +508,6 @@ def _make_editing_handlers(
                 f"quality issues."
             )
 
-        candidates = race_json.get("candidates", [])
-
         if is_structural_garbage:
             # Physically delete malformed/non-human entries from the list
             orig_len = len(candidates)
@@ -482,9 +556,10 @@ def _make_editing_handlers(
         c = _find_candidate(name)
         if not c:
             return f"Candidate '{name}' not found."
-        sources = [src for src in (_normalize_roster_source(source) for source in args.get("sources", [])) if src]
+        race_id = str(race_json.get("id") or "").strip()
+        sources = _qualifying_candidate_addition_sources(args.get("sources"), candidate_name=name, race_id=race_id)
         if not sources:
-            return "ERROR: At least one roster source with a URL, title, or evidence note is required."
+            return "ERROR: At least one qualifying current-cycle exact-contest roster source is required."
         c["roster_sources"] = sources
         log("info", f"    Set {len(sources)} roster source(s) for {name}")
         return f"Set {len(sources)} roster source(s) for '{name}'."
@@ -573,7 +648,7 @@ def _make_editing_handlers(
             return (
                 f"ERROR: {stance_text!r} looks like a placeholder, not a real position. "
                 "If no position was found after a good-faith search, use exactly "
-                "'No public position found after repeated research attempts.' with confidence 'low'."
+                "'No public position found' with confidence 'low'."
             )
         existing_stance = c.get("issues", {}).get(issue)
         existing_sources = existing_stance.get("sources") if isinstance(existing_stance, dict) else []
@@ -586,7 +661,7 @@ def _make_editing_handlers(
             return (
                 f"ERROR: A substantive {issue} stance requires at least one supporting source. "
                 "Provide sources, or record a documented absence with "
-                "'No public position found after repeated research attempts.'"
+                "'No public position found'."
             )
         stance_data: Dict[str, Any] = {
             "stance": args["stance"],

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -184,6 +184,7 @@ async def _call_openrouter(
     *,
     model: str,
     tools: List[Dict[str, Any]] | None = None,
+    tool_choice: Any = None,
     max_retries: int = 3,
     max_tokens: int = 16384,
     run_budget: RunBudget | None = None,
@@ -215,7 +216,7 @@ async def _call_openrouter(
         kwargs["temperature"] = 0.2
     if tools:
         kwargs["tools"] = tools
-        kwargs["tool_choice"] = "auto"
+        kwargs["tool_choice"] = tool_choice or "auto"
 
     rate_limit_wait = 0.0
     transient_wait = 0.0
@@ -440,6 +441,9 @@ async def _agent_loop(
     run_budget: RunBudget | None = None,
     max_request_retries: int = 3,
     allow_search_tools: bool = True,
+    return_tool_trace: bool = False,
+    required_final_tool_name: str | None = None,
+    required_final_instruction: str = "",
 ) -> Dict[str, Any]:
     """Run a single agent loop.
 
@@ -468,9 +472,18 @@ async def _agent_loop(
     _json_parse_failures = 0
     _MAX_JSON_RETRIES = 3
     token_budget_nudged = False
+    required_final_tool_succeeded = False
+    tool_trace = {
+        "search_calls": 0,
+        "page_fetches": 0,
+        "editing_calls": 0,
+        "token_budget_reached": False,
+        "max_iterations_reached": False,
+    }
 
     for iteration in range(max_iterations):
         token_budget_reached = total_token_budget_reached()
+        tool_trace["token_budget_reached"] = bool(tool_trace["token_budget_reached"] or token_budget_reached)
         if token_budget_reached and not token_budget_nudged:
             messages.append(
                 {
@@ -494,6 +507,20 @@ async def _agent_loop(
                     f"  [{phase_name}] JSON parsing failed previously — elevating model from {model} to {active_model} for retry prompt",
                 )
 
+        force_final_tool = bool(required_final_tool_name and (token_budget_reached or iteration == max_iterations - 1))
+        if force_final_tool:
+            fallback_model = CHEAP_TO_DEFAULT_MODEL_FALLBACK.get(normalize_model_id(active_model) or active_model)
+            if fallback_model:
+                log("info", f"  [{phase_name}] escalating final evidence synthesis to {fallback_model}")
+                active_model = fallback_model
+            messages.append(
+                {
+                    "role": "user",
+                    "content": required_final_instruction
+                    or f"Finalize the evidence now by calling {required_final_tool_name}. Do not perform more research.",
+                }
+            )
+
         log("info", f"  [{phase_name}] iteration {iteration + 1}/{max_iterations} — calling {active_model}...")
 
         if tools_mode:
@@ -503,6 +530,10 @@ async def _agent_loop(
                 else []
             )
             tools_for_call = search_tools + _extra_tools if (search_tools or _extra_tools) else None
+            if force_final_tool:
+                tools_for_call = [
+                    tool for tool in _extra_tools if tool.get("function", {}).get("name") == required_final_tool_name
+                ]
 
             if iteration == nudge_at and len(messages) > 2:
                 messages.append(
@@ -555,6 +586,9 @@ async def _agent_loop(
                 prepared.messages,
                 model=active_model,
                 tools=tools_for_call,
+                tool_choice=(
+                    {"type": "function", "function": {"name": required_final_tool_name}} if force_final_tool else None
+                ),
                 max_retries=max_request_retries,
                 max_tokens=context_budget.max_output_tokens,
                 run_budget=run_budget,
@@ -590,6 +624,7 @@ async def _agent_loop(
             for tool_call in message.tool_calls:
                 fn = tool_call.function
                 if fn.name == "web_search":
+                    tool_trace["search_calls"] += 1
                     args = json.loads(fn.arguments)
                     query = args.get("query", "")
                     log("info", f"    🔍 {query}")
@@ -613,6 +648,7 @@ async def _agent_loop(
                         }
                     )
                 elif fn.name == "web_image_search":
+                    tool_trace["search_calls"] += 1
                     args = json.loads(fn.arguments)
                     query = args.get("query", "")
                     log("info", f"    🖼️ {query}")
@@ -636,6 +672,7 @@ async def _agent_loop(
                         }
                     )
                 elif fn.name == "fetch_page":
+                    tool_trace["page_fetches"] += 1
                     args = json.loads(fn.arguments)
                     url = args.get("url", "")
                     log("info", f"    📄 fetching {url[:80]}")
@@ -658,6 +695,7 @@ async def _agent_loop(
                         }
                     )
                 elif fn.name == "ballotpedia_lookup":
+                    tool_trace["search_calls"] += 1
                     args = json.loads(fn.arguments)
                     candidate_name = args.get("candidate_name", "")
                     log("info", f"    📋 Ballotpedia lookup: {candidate_name}")
@@ -677,6 +715,7 @@ async def _agent_loop(
                         }
                     )
                 elif fn.name == "ballotpedia_election_lookup":
+                    tool_trace["search_calls"] += 1
                     args = json.loads(fn.arguments)
                     election_race_id = args.get("race_id", race_id or "")
                     log("info", f"    🗳️  Ballotpedia election lookup: {election_race_id}")
@@ -697,6 +736,8 @@ async def _agent_loop(
                         }
                     )
                 elif fn.name in _extra_handlers:
+                    if fn.name != "read_profile":
+                        tool_trace["editing_calls"] += 1
                     args = json.loads(fn.arguments)
                     log("info", f"    🔧 {fn.name}({', '.join(f'{k}={v!r}' for k, v in args.items())})")
                     try:
@@ -707,6 +748,10 @@ async def _agent_loop(
                             )
                         else:
                             handler_result = _extra_handlers[fn.name](args)
+                        if fn.name == required_final_tool_name and not (
+                            isinstance(handler_result, str) and handler_result.startswith("Error:")
+                        ):
+                            required_final_tool_succeeded = True
                         if isinstance(handler_result, str) and handler_result.startswith("Error:"):
                             log("warning", f"    🔧 {fn.name} → BLOCKED")
                         else:
@@ -730,12 +775,14 @@ async def _agent_loop(
                             "content": f"Error: unknown tool '{fn.name}'",
                         }
                     )
+            if required_final_tool_succeeded:
+                return {"_tool_trace": tool_trace} if return_tool_trace else {}
             continue
 
         # No tool calls — in tools_mode this means the LLM is done editing
         if tools_mode:
             log("info", f"  [{phase_name}] tools-mode complete (no more tool calls)")
-            return {}
+            return {"_tool_trace": tool_trace} if return_tool_trace else {}
 
         # Normal json mode — try to parse the answer
         content = message.content or ""
@@ -785,5 +832,6 @@ async def _agent_loop(
 
     if tools_mode:
         log("warning", f"  [{phase_name}] tools-mode hit max iterations — returning")
-        return {}
+        tool_trace["max_iterations_reached"] = True
+        return {"_tool_trace": tool_trace} if return_tool_trace else {}
     raise RuntimeError(f"[{phase_name}] did not produce output within {max_iterations} iterations")

--- a/pipeline_client/agent/phases/issues.py
+++ b/pipeline_client/agent/phases/issues.py
@@ -242,7 +242,7 @@ async def _research_issue_unit(
     candidate_issue_urls: List[str],
     run_budget: RunBudget | None,
     race_identity_context: str = "",
-) -> Dict[str, Any] | None:
+) -> tuple[Dict[str, Any] | None, Dict[str, Any]]:
     """Research one issue against an isolated candidate copy and return its patch."""
     from . import _agent_loop
 
@@ -295,8 +295,9 @@ async def _research_issue_unit(
             race_identity_context=identity_context,
         )
 
+    loop_result: Dict[str, Any] = {}
     try:
-        await _agent_loop(
+        loop_result = await _agent_loop(
             system_prompt,
             user_prompt,
             model=model,
@@ -308,6 +309,14 @@ async def _research_issue_unit(
             extra_tools=ISSUE_TOOLS + [READ_PROFILE_TOOL],
             extra_tool_handlers=handlers,
             tools_mode=True,
+            return_tool_trace=True,
+            required_final_tool_name="set_issue_stance",
+            required_final_instruction=(
+                "Stop searching and synthesize all evidence already collected. You MUST call set_issue_stance now. "
+                "Record a concise factual stance with every supporting source you found. If and only if the research "
+                "found no attributable position, set stance to exactly 'No public position found', confidence to "
+                "'low', and sources to []. Do not infer or invent a position."
+            ),
             run_budget=run_budget,
         )
     except RunBudgetExceeded:
@@ -318,11 +327,7 @@ async def _research_issue_unit(
         if _is_control_flow_exception(exc):
             raise
         if exc.code == "policy_violation":
-            return {
-                "stance": "No public position found (research blocked by content policy)",
-                "confidence": "low",
-                "sources": [],
-            }
+            return None, {"status": "blocked_policy", "search_calls": 0, "page_fetches": 0}
         log("warning", f"    Issue sub-agent failed for {candidate_name}/{issue}: {exc}")
     except Exception as exc:
         if _is_control_flow_exception(exc):
@@ -331,15 +336,20 @@ async def _research_issue_unit(
 
     candidate = local_race["candidates"][0]
     result = candidate.get("issues", {}).get(issue)
+    trace = loop_result.get("_tool_trace", {}) if isinstance(loop_result, dict) else {}
     if not isinstance(result, dict):
-        return None
+        return None, trace
     if result == existing_issue_data:
         # set_issue_stance was never called this attempt (crash, timeout, ran out
         # of iterations) — this is a genuine failure, not a conclusion, so signal
         # "nothing happened" rather than echoing back stale pre-existing data
         # (which could otherwise be mistaken for a fresh verdict by the caller).
-        return None
-    return copy.deepcopy(result)
+        research_actions = int(trace.get("search_calls", 0) or 0) + int(trace.get("page_fetches", 0) or 0)
+        if is_update and research_actions > 0 and str(result.get("stance") or "").strip():
+            trace["confirmed_existing"] = True
+            return copy.deepcopy(result), trace
+        return None, trace
+    return copy.deepcopy(result), trace
 
 
 async def run_issues_phase(
@@ -374,10 +384,15 @@ async def run_issues_phase(
     iss_t0 = time.perf_counter()
     completed_units = _pipeline_completed_units(race_json)
     issue_attempts = _pipeline_issue_attempts(race_json)
+    issue_research = race_json.setdefault("pipeline_state", {}).setdefault("issue_research", {})
+    if not isinstance(issue_research, dict):
+        issue_research = {}
+        race_json["pipeline_state"]["issue_research"] = issue_research
     if not resume_partial:
         completed_units = {unit for unit in completed_units if not unit.startswith("issues:")}
         race_json["pipeline_state"]["completed_units"] = sorted(completed_units)
         issue_attempts.clear()
+        issue_research.clear()
     else:
         candidates_by_name = {
             str(candidate.get("name")): candidate
@@ -451,23 +466,19 @@ async def run_issues_phase(
             if issue_attempts.get(unit_id, 0) >= max_issue_attempts:
                 log(
                     "warning",
-                    f"    Issue retry limit reached for {cand_name}/{issue}; " "recording a low-confidence no-position result",
+                    f"    Issue retry limit reached for {cand_name}/{issue}; leaving the unit incomplete for explicit retry",
                 )
-                candidate.setdefault("issues", {})[issue] = {
-                    "issue": issue,
-                    "stance": "No public position found after repeated research attempts.",
-                    "confidence": "low",
-                    "sources": [],
+                prior_audit = issue_research.get(unit_id)
+                issue_research[unit_id] = {
+                    **(prior_audit if isinstance(prior_audit, dict) else {}),
+                    "status": "retry_limit",
+                    "attempts": issue_attempts.get(unit_id, 0),
                 }
-                _mark_pipeline_unit_complete(race_json, unit_id)
-                completed_units.add(unit_id)
-                completed_count += 1
-                track(
-                    "progress",
+                _record_step_failure(
+                    race_json,
                     "issues",
-                    pct=int(completed_count / total_units * 100),
-                    message=(f"Issues checkpoint - {cand_name} ({ci + 1}/{rn}) - " f"{issue} ({issue_idx + 1}/{n_issues})"),
-                    race_json=race_json,
+                    RunFailureReason.STEP_NO_DATA,
+                    f"{cand_name}/{issue}: retry limit reached without a research verdict",
                 )
                 continue
 
@@ -501,7 +512,7 @@ async def run_issues_phase(
                         "info",
                         f"    Issue {canonical_issue_index + 1}/{n_issues}: " f"{candidate_name} / {issue_name}",
                     )
-                    patch = await _research_issue_unit(
+                    patch, trace = await _research_issue_unit(
                         candidate_name,
                         issue_name,
                         candidate_data,
@@ -516,6 +527,38 @@ async def run_issues_phase(
                         run_budget=run_budget,
                         race_identity_context=_race_identity_context(race_json),
                     )
+                    sources = patch.get("sources", []) if isinstance(patch, dict) else []
+                    stance = str(patch.get("stance") or "") if isinstance(patch, dict) else ""
+                    prior_audit = issue_research.get(unit_id)
+                    prior_audit = prior_audit if isinstance(prior_audit, dict) else {}
+                    search_calls = int(prior_audit.get("search_calls", 0) or 0) + int(trace.get("search_calls", 0) or 0)
+                    page_fetches = int(prior_audit.get("page_fetches", 0) or 0) + int(trace.get("page_fetches", 0) or 0)
+                    research_actions = search_calls + page_fetches
+                    if "no public position found" in stance.lower() and research_actions < 2:
+                        log(
+                            "warning",
+                            f"    Rejecting unsupported no-position result for {candidate_name}/{issue_name}: "
+                            f"only {research_actions} research action(s) were recorded",
+                        )
+                        patch = None
+                        audit_status = "insufficient_research"
+                    else:
+                        audit_status = (
+                            "completed"
+                            if patch is not None
+                            else trace.get("status")
+                            if trace.get("status") == "blocked_policy"
+                            else "no_verdict"
+                        )
+                    issue_research[unit_id] = {
+                        "status": audit_status,
+                        "attempts": issue_attempts.get(unit_id, 0),
+                        "search_calls": search_calls,
+                        "page_fetches": page_fetches,
+                        "source_count": len(sources) if isinstance(sources, list) else 0,
+                        "token_budget_reached": bool(trace.get("token_budget_reached", False)),
+                        "max_iterations_reached": bool(trace.get("max_iterations_reached", False)),
+                    }
                     # A non-None patch means the sub-agent successfully called
                     # set_issue_stance — either with a real stance, or (the only
                     # other way past that handler's validation) a deliberate
@@ -570,7 +613,7 @@ async def run_issues_phase(
     pipeline_state["remaining_candidates"] = remaining_candidates
     pipeline_state["remaining_steps"] = ["issues"] if remaining_candidates else []
     pipeline_state["complete"] = not remaining_candidates
-    if remaining_candidates and continue_incomplete_work:
+    if remaining_candidates and continue_incomplete_work and tasks:
         track(
             "progress",
             "issues",

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -555,6 +555,9 @@ Review this candidate profile for the race "{race_id}":
 Revision context:
 {change_manifest}
 
+Durable issue-research execution evidence:
+{research_effort_context}
+
 Complete semantic profile:
 {profile_json}
 
@@ -626,7 +629,9 @@ IMPORTANT — Missing data policy:
   genuinely obscure), do NOT penalize the score. Absence of public information
   is NOT a quality failure.
 - A "no public position found" result after a good-faith search is acceptable.
-- Treat a documented "No public position found after repeated research attempts"
+- Use the durable issue-research execution evidence in the user prompt to
+  distinguish a good-faith search from an unattempted empty/default result.
+- Treat a documented "No public position found"
   as COMPLETE coverage for that issue, not a gap. Do not deduct from the
   Coverage-effort component for correctly-recorded unavailable data.
 - Differences in how candidates are described that merely reflect differing
@@ -988,6 +993,9 @@ remove:
 - Lost a completed primary, runoff, or convention/nomination contest and is
   therefore eliminated, confirmed by an official/certified result source with a
   specific date
+- The entry was contaminated from a different exact office or district. Add the
+  verified correct roster first, then call remove_candidate with
+  wrong_contest=true and current evidence naming the candidate's actual contest.
 NEVER remove a candidate for any other reason — not to fix data quality
 issues, not to correct information, not to replace a candidate entry, not
 because you think data about them is wrong or incomplete, and not because one
@@ -1018,6 +1026,9 @@ the same state. A person
 running for U.S. Senate, Secretary of State, or another statewide office is not
 running for Governor unless a retrieved source explicitly says they filed for
 Governor.
+For a U.S. House race, reject state House/Assembly candidates even when the
+district number is identical. Evidence must explicitly say U.S./United States
+Representative, Congress, or Congressional District and the exact district.
 
 CRITICAL — scope to THIS cycle's contest only (remove anyone who fails this):
 - U.S. Senate race: only candidates for the single seat up this cycle. Do NOT
@@ -1063,6 +1074,9 @@ STEP 2 — Make corrections using your tools:
    this race → remove_candidate
    (include reason citing a dated official/certified result source or specific
    news source confirming the exit)
+   OR whose current evidence explicitly proves they belong to a different exact
+   contest: first add the verified correct candidate(s), then call
+   remove_candidate with wrong_contest=true and include that evidence.
 3. Any name corrections (e.g. legal name, common misspelling) → rename_candidate
 4. For every candidate you verified and kept, use set_candidate_roster_sources
    when the profile lacks explicit roster_sources or when your current source is
@@ -1303,7 +1317,9 @@ UPDATE_ISSUE_SUBAGENT_SYSTEM = f"""\
 You are a nonpartisan political research agent updating ONE candidate's
 position on ONE issue. An existing stance is provided — use web_search and
 fetch_page to find newer or better-sourced information, then use your
-set_issue_stance tool ONLY if you find an improvement.
+set_issue_stance tool if you find an improvement. If the current stance is
+missing, you MUST record either a sourced position or, only after at least two
+good-faith searches, exactly "No public position found".
 
 {_SHARED_RULES}"""
 
@@ -1336,6 +1352,7 @@ Source prioritization (highest to lowest):
 Before broad web searching, check if any of the known issue/policy URLs above
 are relevant to "{issue}" — if so, fetch that URL first.
 
-Use set_issue_stance ONLY if you find genuinely new or better data than the
-current stance. If the existing stance is already accurate and well-sourced,
-reply with a short confirmation and make no tool call."""
+If the current stance is missing, always call set_issue_stance with the best
+sourced result you find, or exactly "No public position found" after at least
+two good-faith searches. If an existing stance is already accurate and
+well-sourced, reply with a short confirmation and make no tool call."""

--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -103,6 +103,51 @@ def serialize_semantic_review_packet(packet: Dict[str, Any]) -> str:
     return json.dumps(packet, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
 
 
+def build_issue_research_effort_context(race_json: Dict[str, Any]) -> str:
+    """Summarize durable issue attempts so reviewers can distinguish absence from omission."""
+    state = race_json.get("pipeline_state") if isinstance(race_json.get("pipeline_state"), dict) else {}
+    attempts = state.get("issue_attempts") if isinstance(state.get("issue_attempts"), dict) else {}
+    research = state.get("issue_research") if isinstance(state.get("issue_research"), dict) else {}
+    lines: List[str] = []
+    required = [issue.value for issue in CanonicalIssue]
+    for candidate in race_json.get("candidates") or []:
+        if not isinstance(candidate, dict) or not candidate.get("name"):
+            continue
+        name = str(candidate["name"])
+        issues = candidate.get("issues") if isinstance(candidate.get("issues"), dict) else {}
+        attempted_slots = sum(int(attempts.get(f"issues:{name}:{issue}", 0) or 0) > 0 for issue in required)
+        total_attempts = sum(max(0, int(attempts.get(f"issues:{name}:{issue}", 0) or 0)) for issue in required)
+        completed_slots = sum(bool(str((issues.get(issue) or {}).get("stance") or "").strip()) for issue in required)
+        no_position_slots = sum(
+            _is_documented_absence(str((issues.get(issue) or {}).get("stance") or "")) for issue in required
+        )
+        unproven_absence = sum(
+            _is_documented_absence(str((issues.get(issue) or {}).get("stance") or ""))
+            and (
+                not isinstance(research.get(f"issues:{name}:{issue}"), dict)
+                or research[f"issues:{name}:{issue}"].get("status") != "completed"
+                or int(research[f"issues:{name}:{issue}"].get("search_calls", 0) or 0)
+                + int(research[f"issues:{name}:{issue}"].get("page_fetches", 0) or 0)
+                < 2
+            )
+            for issue in required
+        )
+        researched_slots = sum(
+            isinstance(research.get(f"issues:{name}:{issue}"), dict)
+            and int(research[f"issues:{name}:{issue}"].get("search_calls", 0) or 0)
+            + int(research[f"issues:{name}:{issue}"].get("page_fetches", 0) or 0)
+            > 0
+            for issue in required
+        )
+        lines.append(
+            f"- {name}: {completed_slots}/12 terminal issue outputs; {attempted_slots}/12 slots with recorded "
+            f"pipeline attempts ({total_attempts} total attempts); {no_position_slots} documented no-position "
+            f"outputs; {researched_slots}/12 slots with recorded search/fetch activity; {unproven_absence} "
+            f"no-position outputs without sufficient research provenance."
+        )
+    return "\n".join(lines) or "- No candidate issue-research attempt evidence is present."
+
+
 def build_review_change_manifest(previous: Dict[str, Any] | None, current: Dict[str, Any]) -> str:
     """Build a deterministic changed-field manifest while always sending the full packet."""
     if previous is None:
@@ -198,6 +243,7 @@ async def _run_single_review(
     metrics_sink: Optional[Dict[str, Any]] = None,
     run_budget: RunBudget | None = None,
     race_identity_context_text: str = "",
+    research_effort_context_text: str = "",
 ) -> Optional[Dict[str, Any]]:
     """Run a single review agent role (claude, gemini, or grok)."""
     log = make_logger(on_log)
@@ -206,6 +252,7 @@ async def _run_single_review(
         profile_json=profile_json,
         change_manifest=change_manifest,
         race_identity_context=race_identity_context_text,
+        research_effort_context=research_effort_context_text,
     )
     if provider not in _REVIEW_MODELS:
         return None
@@ -547,6 +594,9 @@ def check_profile_quality(race_json: Dict[str, Any]) -> Dict[str, Any]:
         )
 
     required_issues = {issue.value for issue in CanonicalIssue}
+    state = race_json.get("pipeline_state") if isinstance(race_json.get("pipeline_state"), dict) else {}
+    issue_attempts = state.get("issue_attempts") if isinstance(state.get("issue_attempts"), dict) else {}
+    issue_research = state.get("issue_research") if isinstance(state.get("issue_research"), dict) else {}
     for index, candidate in enumerate(race_json.get("candidates") or []):
         if not isinstance(candidate, dict):
             continue
@@ -597,6 +647,27 @@ def check_profile_quality(race_json: Dict[str, Any]) -> Dict[str, Any]:
                 if not isinstance(issue_data, dict):
                     continue
                 stance = str(issue_data.get("stance") or "").strip()
+                attempt_key = f"issues:{candidate.get('name')}:{issue_name}"
+                audit = issue_research.get(attempt_key)
+                researched_actions = (
+                    int(audit.get("search_calls", 0) or 0) + int(audit.get("page_fetches", 0) or 0)
+                    if isinstance(audit, dict)
+                    else 0
+                )
+                if _is_documented_absence(stance) and (
+                    int(issue_attempts.get(attempt_key, 0) or 0) < 1
+                    or not isinstance(audit, dict)
+                    or audit.get("status") != "completed"
+                    or researched_actions < 2
+                ):
+                    flags.append(
+                        {
+                            "field": f"candidates[{index}].issues.{issue_name}.stance",
+                            "concern": "No-position result lacks a completed audit with at least two recorded research actions.",
+                            "suggestion": "Run the issues phase so absence is documented after an actual bounded search.",
+                            "severity": "error",
+                        }
+                    )
                 if stance and not _is_documented_absence(stance) and not issue_data.get("sources"):
                     flags.append(
                         {
@@ -653,7 +724,8 @@ async def run_reviews(
     packet = semantic_packet if semantic_packet is not None else build_semantic_review_packet(race_json)
     validate_semantic_review_packet(race_json, packet)
     profile_json = serialize_semantic_review_packet(packet)
-    packet_key = hashlib.sha256(profile_json.encode("ascii")).hexdigest()
+    research_effort_context = build_issue_research_effort_context(race_json)
+    packet_key = hashlib.sha256(f"{profile_json}\n{research_effort_context}".encode("utf-8")).hexdigest()
     if metrics_sink is not None:
         metrics_sink["whole_profile"] = True
         metrics_sink["configured_providers"] = requested_providers
@@ -678,6 +750,7 @@ async def run_reviews(
                 metrics_sink=metrics_sink,
                 run_budget=run_budget,
                 race_identity_context_text=identity_context,
+                research_effort_context_text=research_effort_context,
             )
         )
 

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -187,12 +187,33 @@ REMOVE_CANDIDATE_TOOL: Dict = {
     "type": "function",
     "function": {
         "name": "remove_candidate",
-        "description": "Remove a candidate who has dropped out or withdrawn from the race.",
+        "description": "Remove a candidate who exited this race or was proven to belong to a different contest.",
         "parameters": {
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Exact name of the candidate to remove."},
                 "reason": {"type": "string", "description": "Brief reason for removal (e.g. 'withdrew', 'disqualified')."},
+                "wrong_contest": {
+                    "type": "boolean",
+                    "description": "True only when current evidence proves this entry belongs to another office/district.",
+                },
+                "sources": {
+                    "type": "array",
+                    "description": "Current evidence proving a wrong-contest entry belongs to another exact contest.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                            "type": {"type": "string", "enum": ["official", "ballotpedia", "fec", "news", "campaign"]},
+                            "title": {"type": "string"},
+                            "evidence": {"type": "string"},
+                            "published_at": {"type": "string"},
+                            "race_id": {"type": "string"},
+                            "evidence_tier": {"type": "integer", "enum": [1, 2, 3]},
+                            "retrieval_status": {"type": "string", "enum": ["content", "snippet"]},
+                        },
+                    },
+                },
             },
             "required": ["name"],
         },
@@ -236,6 +257,10 @@ SET_CANDIDATE_ROSTER_SOURCES_TOOL: Dict = {
                             },
                             "title": {"type": "string"},
                             "evidence": {"type": "string"},
+                            "published_at": {"type": "string"},
+                            "race_id": {"type": "string"},
+                            "evidence_tier": {"type": "integer", "enum": [1, 2, 3]},
+                            "retrieval_status": {"type": "string", "enum": ["content", "snippet"]},
                         },
                     },
                 },

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -116,6 +116,7 @@ CHECKED_MODELS: Dict[str, Type[BaseModel]] = {
     "RaceIdentityBrief": shared_models.RaceIdentityBrief,
     "RunAudit": shared_models.RunAudit,
     "PipelineState": shared_models.PipelineState,
+    "IssueResearchAudit": shared_models.IssueResearchAudit,
     "Race": shared_models.RaceJSON,  # renamed on the TS side
     # PipelineRunOptions is the wire-level ("caller may omit anything")
     # schema shared by the races-api and worker request models; RunOptions is

--- a/shared/models.py
+++ b/shared/models.py
@@ -440,6 +440,18 @@ class RunAudit(BaseModel):
     publish_attention: List[str] = Field(default_factory=list)
 
 
+class IssueResearchAudit(BaseModel):
+    """Durable proof that an issue result came from research rather than a fallback."""
+
+    status: Literal["completed", "no_verdict", "insufficient_research", "retry_limit", "blocked_policy"] = "no_verdict"
+    attempts: int = 0
+    search_calls: int = 0
+    page_fetches: int = 0
+    source_count: int = 0
+    token_budget_reached: bool = False
+    max_iterations_reached: bool = False
+
+
 class PipelineState(BaseModel):
     """Draft-only progress state for batched research runs."""
 
@@ -448,6 +460,7 @@ class PipelineState(BaseModel):
     remaining_steps: List[str] = Field(default_factory=list)
     completed_units: List[str] = Field(default_factory=list)
     issue_attempts: Dict[str, int] = Field(default_factory=dict)
+    issue_research: Dict[str, IssueResearchAudit] = Field(default_factory=dict)
     step_failures: List[StepFailure] = Field(default_factory=list)
     deterministic_cleanup: Dict[str, int] = Field(default_factory=dict)
     race_identity: Optional[RaceIdentityBrief] = None

--- a/shared/repair_planner.py
+++ b/shared/repair_planner.py
@@ -23,6 +23,16 @@ _PER_CANDIDATE_COST_USD = {
 }
 _PER_ISSUE_COST_USD = 0.05
 _CANONICAL_ISSUES = {issue.value for issue in CanonicalIssue}
+_ISSUE_RESEARCH_SAFETY_STEPS = {
+    "issues",
+    "finance",
+    "refinement",
+    "polling",
+    "forecast",
+    "voter_resources",
+    "review",
+    "iteration",
+}
 
 
 def _ordered_steps(steps: set[str]) -> List[str]:
@@ -117,8 +127,8 @@ def build_repair_plan(race_id: str, race_data: Dict[str, Any], *, freshness: str
         )
         candidate_missing_issues = max(0, len(_CANONICAL_ISSUES) - terminal_issues)
         if candidate_missing_issues:
-            steps.add("issues")
-            candidate_steps.add("issues")
+            steps.update(_ISSUE_RESEARCH_SAFETY_STEPS)
+            candidate_steps.update(_ISSUE_RESEARCH_SAFETY_STEPS)
             candidate_reasons.append(f"{candidate_missing_issues} issue slot(s) lack a terminal verdict.")
         donor_sources = candidate.get("donor_sources")
         if not candidate.get("donor_summary") or not (

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -587,6 +587,52 @@ async def queue_races(
 
 
 @mcp.tool(structured_output=False)
+async def refresh_race_core(
+    race_ids: List[str],
+    baseline_source: Literal["latest", "published"] = "latest",
+    include_images: bool = True,
+    include_voter_resources: bool = True,
+    cheap_mode: bool = True,
+    debug_mode: bool = True,
+    save_artifact: bool = True,
+    runner: str = "local",
+    note: str | None = None,
+    goal: str | None = None,
+) -> Dict[str, Any]:
+    """Queue the standard roster-and-race core refresh workflow.
+
+    This is the preferred MCP operation for correcting a suspect roster without
+    hand-editing RaceJSON. Discovery verifies the exact-contest roster and
+    refreshes candidate summaries/race metadata; optional images then run before
+    polling, forecast, and voter-resource refreshes. Debug evidence and artifacts
+    default on so roster decisions remain auditable.
+    """
+    steps = ["discovery"]
+    if include_images:
+        steps.append("images")
+    steps.extend(["polling", "forecast"])
+    if include_voter_resources:
+        steps.append("voter_resources")
+    result = await queue_races(
+        race_ids,
+        cheap_mode=cheap_mode,
+        force_fresh=False,
+        baseline_source=baseline_source,
+        save_artifact=save_artifact,
+        enabled_steps=steps,
+        debug_mode=debug_mode,
+        note=note or "Pipeline-driven core refresh: roster, summaries, polling, forecast, and resources.",
+        goal=goal
+        or (
+            "Verify the exact office/district roster from current-cycle evidence, remove wrong-contest contamination, "
+            "refresh candidate summaries, then update polling and the evidence-backed forecast."
+        ),
+        runner=runner,
+    )
+    return {**result, "mode": "core_refresh", "enabled_steps": steps}
+
+
+@mcp.tool(structured_output=False)
 async def run_race(
     race_id: str,
     cheap_mode: bool | None = True,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -634,6 +634,53 @@ async def test_agent_loop_nudges_model_toward_final_answer_in_json_mode():
 
 
 @pytest.mark.asyncio
+async def test_agent_loop_forces_required_tool_with_stronger_model_at_token_ceiling():
+    from pipeline_client.agent.model_registry import CHEAP_MODEL, DEFAULT_MODEL
+
+    final_response = _mock_openai_response(
+        tool_calls=[
+            {
+                "id": "call_final",
+                "function": {
+                    "name": "set_issue_stance",
+                    "arguments": json.dumps({"stance": "No public position found"}),
+                },
+            }
+        ]
+    )
+    handler = MagicMock(return_value="OK")
+    final_tool = {
+        "type": "function",
+        "function": {"name": "set_issue_stance", "description": "Record result", "parameters": {"type": "object"}},
+    }
+
+    with (
+        patch("pipeline_client.agent.llm.total_token_budget_reached", return_value=True),
+        patch("pipeline_client.agent.llm._call_openrouter", new_callable=AsyncMock, return_value=final_response) as call,
+    ):
+        result = await _agent_loop(
+            "system",
+            "user",
+            model=CHEAP_MODEL,
+            phase_name="issue-test",
+            tools_mode=True,
+            extra_tools=[final_tool],
+            extra_tool_handlers={"set_issue_stance": handler},
+            required_final_tool_name="set_issue_stance",
+            required_final_instruction="Choose a sourced stance or the exact absence marker.",
+            return_tool_trace=True,
+        )
+
+    assert handler.call_count == 1
+    assert call.call_args.kwargs["model"] == DEFAULT_MODEL
+    assert call.call_args.kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "set_issue_stance"},
+    }
+    assert result["_tool_trace"]["token_budget_reached"] is True
+
+
+@pytest.mark.asyncio
 async def test_agent_loop_propagates_policy_violation_runtime_error():
     with patch(
         "pipeline_client.agent.llm._call_openrouter",

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -502,7 +502,7 @@ def test_add_candidate_tier3_requires_independent_sources_unless_authoritative()
 def test_roster_sources_and_race_identity_handlers():
     from pipeline_client.agent.agent import _make_editing_handlers
 
-    race_json = {"candidates": [{"name": "Alice", "party": "Democratic"}]}
+    race_json = {"id": "ga-governor-2026", "candidates": [{"name": "Alice", "party": "Democratic"}]}
     handlers = _make_editing_handlers(race_json, lambda l, m: None)
 
     identity_result = handlers["set_race_identity"](
@@ -524,6 +524,10 @@ def test_roster_sources_and_race_identity_handlers():
                     "type": "official",
                     "title": "Certified candidate list",
                     "evidence": "Alice is listed as a gubernatorial nominee.",
+                    "published_at": "2026-06-10",
+                    "race_id": "ga-governor-2026",
+                    "evidence_tier": 1,
+                    "retrieval_status": "content",
                 }
             ],
         }
@@ -535,6 +539,63 @@ def test_roster_sources_and_race_identity_handlers():
     assert "Set 1 roster source" in source_result
     assert race_json["candidates"][0]["roster_sources"][0]["type"] == "official"
     assert race_json["candidates"][0]["roster_sources"][0]["last_accessed"]
+
+
+def test_federal_house_roster_rejects_same_number_state_house_evidence():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {"id": "al-house-02-2026", "state": "Alabama", "candidates": []}
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    source = {
+        "url": "https://example.gov/alabama-house-2",
+        "type": "official",
+        "title": "Alabama House of Representatives District 2",
+        "evidence": "Rick Pressnell is a candidate for Alabama House of Representatives District 2.",
+        "published_at": "2026-01-15",
+        "race_id": "al-house-02-2026",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+
+    result = handlers["add_candidate"]({"name": "Rick Pressnell", "party": "Democratic", "roster_sources": [source]})
+
+    assert "Blocked adding" in result
+    assert race_json["candidates"] == []
+
+
+def test_wrong_contest_removal_requires_proof_and_physically_removes_contamination():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {
+        "id": "al-house-02-2026",
+        "state": "Alabama",
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic"},
+            {"name": "Rick Pressnell", "party": "Democratic"},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    source = {
+        "url": "https://aldemocrats.org/2026-qualified-candidates",
+        "type": "official",
+        "title": "2026 qualified candidates",
+        "evidence": "State Representative, District 2 - Rick Pressnell",
+        "published_at": "2026-01-15",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+
+    result = handlers["remove_candidate"](
+        {
+            "name": "Rick Pressnell",
+            "reason": "Official list places him in Alabama State House District 2, not U.S. House District 2.",
+            "wrong_contest": True,
+            "sources": [source],
+        }
+    )
+
+    assert "wrong-contest" in result
+    assert [candidate["name"] for candidate in race_json["candidates"]] == ["Shomari Figures"]
 
 
 def test_add_candidate_blocks_primary_loser_after_nominee_is_known():

--- a/tests/test_models_review.py
+++ b/tests/test_models_review.py
@@ -35,6 +35,18 @@ def _valid_review_profile():
                 },
             }
         ],
+        "pipeline_state": {
+            "issue_attempts": {f"issues:Alice Example:{issue.value}": 1 for issue in CanonicalIssue},
+            "issue_research": {
+                f"issues:Alice Example:{issue.value}": {
+                    "status": "completed",
+                    "attempts": 1,
+                    "search_calls": 2,
+                    "page_fetches": 0,
+                }
+                for issue in CanonicalIssue
+            },
+        },
     }
 
 
@@ -346,6 +358,71 @@ def test_pipeline_state_preserves_durable_retry_failure_and_cleanup_fields():
     assert state["issue_attempts"] == {"issues:Alice:Economy": 2}
     assert state["step_failures"][0]["step"] == "forecast"
     assert state["deterministic_cleanup"] == {"text_changes": 1}
+
+
+def test_issue_research_effort_context_distinguishes_attempted_absence_from_omission():
+    from pipeline_client.agent.review import build_issue_research_effort_context
+
+    race = {
+        "candidates": [
+            {
+                "name": "Alice",
+                "issues": {
+                    "Economy": {
+                        "stance": "No public position found after repeated research attempts.",
+                        "confidence": "low",
+                        "sources": [],
+                    }
+                },
+            }
+        ],
+        "pipeline_state": {
+            "issue_attempts": {"issues:Alice:Economy": 2},
+            "issue_research": {
+                "issues:Alice:Economy": {
+                    "status": "completed",
+                    "attempts": 2,
+                    "search_calls": 2,
+                    "page_fetches": 1,
+                }
+            },
+        },
+    }
+
+    context = build_issue_research_effort_context(race)
+
+    assert "1/12 terminal issue outputs" in context
+    assert "1/12 slots with recorded pipeline attempts (2 total attempts)" in context
+    assert "1/12 slots with recorded search/fetch activity" in context
+    assert "0 no-position outputs without sufficient research provenance" in context
+
+
+def test_profile_quality_rejects_no_position_marker_without_attempt_provenance():
+    from pipeline_client.agent.review import check_profile_quality
+    from shared.models import CanonicalIssue
+
+    race = {
+        "candidates": [
+            {
+                "name": "Alice",
+                "issues": {
+                    issue.value: {
+                        "stance": "No public position found after repeated research attempts.",
+                        "confidence": "low",
+                        "sources": [],
+                    }
+                    for issue in CanonicalIssue
+                },
+            }
+        ],
+        "pipeline_state": {"issue_attempts": {}},
+    }
+
+    review = check_profile_quality(race)
+
+    provenance_flags = [flag for flag in review["flags"] if "completed audit" in flag["concern"]]
+    assert len(provenance_flags) == 12
+    assert all(flag["severity"] == "error" for flag in provenance_flags)
 
 
 def test_review_change_manifest_reports_changed_paths_without_reducing_packet():

--- a/tests/test_repair_planner.py
+++ b/tests/test_repair_planner.py
@@ -15,7 +15,18 @@ def test_discovery_race_plan_targets_missing_research_with_conservative_ceiling(
 
     assert plan["needs_repair"] is True
     assert plan["research_tier"] == "discovery_only"
-    assert plan["recommended_steps"] == ["discovery", "images", "issues", "finance", "forecast"]
+    assert plan["recommended_steps"] == [
+        "discovery",
+        "images",
+        "issues",
+        "finance",
+        "refinement",
+        "polling",
+        "forecast",
+        "voter_resources",
+        "review",
+        "iteration",
+    ]
     assert plan["candidate_names"] == ["Alice", "Bob"]
     assert plan["estimated_max_cost_usd"] > 1
     assert plan["estimated_max_search_calls"] >= 240
@@ -25,6 +36,9 @@ def test_discovery_race_plan_targets_missing_research_with_conservative_ceiling(
         ("Alice",),
         ("Bob",),
     }
+    for group in plan["repair_groups"][1:]:
+        assert group["enabled_steps"][-2:] == ["review", "iteration"]
+        assert "issues" in group["enabled_steps"]
 
 
 def test_validated_complete_race_needs_no_repair():

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -66,8 +66,7 @@ def test_sanitize_candidate_issues_normalizes_placeholder_variant():
     _sanitize_candidate_issues(race_json, log=None)
 
     stance = race_json["candidates"][0]["issues"]["Civil Rights & Equality"]
-    assert stance["stance"] == "No public position found after repeated research attempts."
-    assert stance["confidence"] == "low"
+    assert stance["stance"] == ""
 
 
 def test_sanitize_candidate_issues_removes_noncanonical_and_malformed_duplicates():
@@ -1025,7 +1024,7 @@ async def test_run_agent_normalizes_schema_version_legacy_issues_and_missing_sta
     assert result["schema_version"] == "0.3"
     assert "Reproductive Rights" not in issues
     assert issues["Abortion & Reproductive Health"]["stance"] == "Supports abortion access."
-    assert issues["Tech & AI"]["stance"] == "No public position found after repeated research attempts."
+    assert issues["Tech & AI"]["stance"] == ""
 
 
 @pytest.mark.asyncio
@@ -1763,8 +1762,9 @@ async def test_run_agent_continuation_caps_repeated_issue_attempts(monkeypatch):
         )
 
     assert mock_loop.call_count == 0
-    assert "repeated research attempts" in result["candidates"][0]["issues"][capped_issue]["stance"]
-    assert f"issues:Alice:{capped_issue}" in result["pipeline_state"]["completed_units"]
+    assert not result["candidates"][0]["issues"][capped_issue]["stance"]
+    assert f"issues:Alice:{capped_issue}" not in result["pipeline_state"]["completed_units"]
+    assert result["pipeline_state"]["issue_research"][f"issues:Alice:{capped_issue}"]["status"] == "retry_limit"
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_agent_health.py
+++ b/tests/test_run_agent_health.py
@@ -94,7 +94,7 @@ async def test_run_agent_registers_placeholder_content_for_literal_junk_stance()
         )
 
     stance = result["candidates"][0]["issues"]["Economy"]["stance"]
-    assert stance == "No public position found after repeated research attempts."
+    assert stance == ""
 
     reasons = result["run_health"]["reasons"]
     assert "placeholder_content" in reasons

--- a/tests/test_smartervote_mcp_client.py
+++ b/tests/test_smartervote_mcp_client.py
@@ -35,6 +35,7 @@ async def test_smartervote_mcp_exposes_lean_tool_surface():
         "audit_race_assets",
         "assess_publish_readiness",
         "queue_races",
+        "refresh_race_core",
         "run_race",
         "publish_race",
         "publish_races",
@@ -300,6 +301,37 @@ async def test_audit_race_assets_forwards_persistence_controls(monkeypatch):
     client.post.assert_awaited_once_with(
         "/api/races/asset-audit",
         json={"race_ids": ["ca-house-05-2026"], "persist": True, "max_urls_per_race": 25},
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_race_core_queues_auditable_standard_step_set(monkeypatch):
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    queued = AsyncMock(return_value={"added": [{"race_id": "al-house-02-2026"}], "errors": []})
+    monkeypatch.setattr(server, "queue_races", queued)
+
+    result = await server.refresh_race_core(["al-house-02-2026"])
+
+    assert result["mode"] == "core_refresh"
+    assert result["enabled_steps"] == ["discovery", "images", "polling", "forecast", "voter_resources"]
+    queued.assert_awaited_once_with(
+        ["al-house-02-2026"],
+        cheap_mode=True,
+        force_fresh=False,
+        baseline_source="latest",
+        save_artifact=True,
+        enabled_steps=["discovery", "images", "polling", "forecast", "voter_resources"],
+        debug_mode=True,
+        note="Pipeline-driven core refresh: roster, summaries, polling, forecast, and resources.",
+        goal=(
+            "Verify the exact office/district roster from current-cycle evidence, remove wrong-contest contamination, "
+            "refresh candidate summaries, then update polling and the evidence-backed forecast."
+        ),
+        runner="local",
     )
 
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -243,9 +243,20 @@ export interface PipelineState {
   remaining_steps: string[];
   completed_units: string[];
   issue_attempts: Record<string, number>;
+  issue_research: Record<string, IssueResearchAudit>;
   step_failures: StepFailure[];
   deterministic_cleanup: Record<string, number>;
   race_identity?: RaceIdentityBrief;
+}
+
+export interface IssueResearchAudit {
+  status: "completed" | "no_verdict" | "insufficient_research" | "retry_limit" | "blocked_policy";
+  attempts: number;
+  search_calls: number;
+  page_fetches: number;
+  source_count: number;
+  token_budget_reached: boolean;
+  max_iterations_reached: boolean;
 }
 
 export interface RaceIdentityBrief {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -250,7 +250,12 @@ export interface PipelineState {
 }
 
 export interface IssueResearchAudit {
-  status: "completed" | "no_verdict" | "insufficient_research" | "retry_limit" | "blocked_policy";
+  status:
+    | "completed"
+    | "no_verdict"
+    | "insufficient_research"
+    | "retry_limit"
+    | "blocked_policy";
   attempts: number;
   search_calls: number;
   page_fetches: number;


### PR DESCRIPTION
## What changed

- adds a first-class refresh_race_core MCP operation for exact-contest roster verification, summaries, images, polling, forecasts, and voter resources
- permits pipeline-driven removal of candidates proven to belong to a different contest while strengthening exact-office/district evidence checks
- forces issue evidence synthesis with a stronger fallback model at the research boundary
- records per-issue search/fetch provenance and rejects unsupported no-position outcomes
- leaves exhausted work visibly incomplete instead of manufacturing absence markers
- makes repair plans include the full safe issue/review chain

## Root cause

The issue runner treated repeated empty sub-agent responses, including responses caused by an exhausted logical-run ceiling, as proof that no public position existed. Roster evidence validation also did not distinguish a federal House contest from a same-number state House contest.

## Validation

- 827 pipeline/shared/MCP tests passed
- 96 races-api admin tests passed
- 45 races-api service tests passed
- Black and isort passed
- Svelte type check and lint passed