### PR TITLE
Escalate blocked roster research

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -181,8 +181,18 @@ Roster editing tools accept both normalized evidence fields and the native
 `web_search` result aliases (`text`, `retrieved`). The handler preserves those
 as durable evidence, infers only recognizable source classes, and still applies
 current-cycle and exact-contest checks. A blocked/error tool result is surfaced
-to the model as a failure so it can correct its next call instead of looping on
-the same invalid payload.
+to the model as a failure. After two consecutive blocked edits, roster sync
+keeps the accumulated research but escalates subsequent synthesis to the
+stronger roster fallback and directs it to obtain higher-priority evidence
+instead of repeating the same invalid payload.
+
+Roster authority order is: official election authority/certified ballot or
+result; official party qualification list when the party administers primary
+qualification; FEC corroboration for federal candidates; then a current
+exact-race Ballotpedia page and reputable news/campaign sources. The
+`ballotpedia_election_lookup` extraction is advisory only because a page can
+contain stale-cycle, primary, or unrelated navigation tables. Its names must
+never drive an add/removal alone or override a current official source.
 
 Logical runs enforce both global and phase search/token ceilings. They also cap
 uncached page fetches and fetched characters, and persist per-phase

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -74,7 +74,7 @@ def _source_proves_different_contest(source: Dict[str, Any], *, candidate_name: 
     if re.fullmatch(r"[a-z]{2}-house-\d{1,2}-(?:19|20)\d{2}", race_id):
         state_house = bool(
             re.search(r"\bstate\s+(?:house|representative)", text)
-            or re.search(r"\b[a-z ]+\s+house of representatives\s+(?:district|hd)\b", text)
+            or re.search(r"\b[a-z ]+\s+house of representatives[\s,]+(?:district|hd)\b", text)
         )
         return state_house and not _source_supports_exact_contest(source, race_id=race_id)
     return False
@@ -110,7 +110,7 @@ def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any
             source_type = "ballotpedia"
         elif host == "fec.gov" or host.endswith(".fec.gov"):
             source_type = "fec"
-        elif host.endswith(".gov") or "qualified candidates" in title_and_url:
+        elif host.endswith(".gov") or re.search(r"\bqualified\b.*\bcandidates?\b", title_and_url):
             source_type = "official"
         else:
             source_type = "other"
@@ -389,7 +389,7 @@ def _make_editing_handlers(
             race_id = str(race_json.get("id") or "").strip()
             proof = [
                 source
-                for source in (_normalize_roster_source(item) for item in args.get("sources") or [])
+                for source in (_normalize_roster_source(item, race_id=race_id) for item in args.get("sources") or [])
                 if source and _source_proves_different_contest(source, candidate_name=name, race_id=race_id)
             ]
             if not proof:

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -448,6 +448,7 @@ async def _agent_loop(
     return_tool_trace: bool = False,
     required_final_tool_name: str | None = None,
     required_final_instruction: str = "",
+    tool_error_escalation_model: str | None = None,
 ) -> Dict[str, Any]:
     """Run a single agent loop.
 
@@ -477,6 +478,8 @@ async def _agent_loop(
     _MAX_JSON_RETRIES = 3
     token_budget_nudged = False
     required_final_tool_succeeded = False
+    consecutive_tool_errors = 0
+    tool_errors_escalated = False
     tool_trace = {
         "search_calls": 0,
         "page_fetches": 0,
@@ -502,6 +505,8 @@ async def _agent_loop(
             token_budget_nudged = True
             log("warning", f"  [{phase_name}] token ceiling reached; forcing finalization without search tools")
         active_model = model
+        if tool_errors_escalated and tool_error_escalation_model:
+            active_model = tool_error_escalation_model
         if _json_parse_failures > 0:
             norm_model = normalize_model_id(model)
             if norm_model in CHEAP_TO_DEFAULT_MODEL_FALLBACK:
@@ -755,8 +760,10 @@ async def _agent_loop(
                         if fn.name == required_final_tool_name and not _tool_result_is_error(handler_result):
                             required_final_tool_succeeded = True
                         if _tool_result_is_error(handler_result):
+                            consecutive_tool_errors += 1
                             log("warning", f"    🔧 {fn.name} → BLOCKED")
                         else:
+                            consecutive_tool_errors = 0
                             log("info", f"    🔧 {fn.name} → OK")
                     except Exception as exc:
                         handler_result = f"Error: {exc}"
@@ -777,6 +784,24 @@ async def _agent_loop(
                             "content": f"Error: unknown tool '{fn.name}'",
                         }
                     )
+            if consecutive_tool_errors >= 2 and tool_error_escalation_model and not tool_errors_escalated:
+                tool_errors_escalated = True
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "Multiple editing calls were blocked by evidence guards. Do not repeat those calls "
+                            "with the same sources. Review the blocked results and all research already collected, "
+                            "then pivot to higher-priority official evidence. Only retry an edit when the new "
+                            "evidence directly satisfies the guard; otherwise leave the roster unchanged."
+                        ),
+                    }
+                )
+                log(
+                    "warning",
+                    f"  [{phase_name}] repeated blocked edits; escalating subsequent synthesis to "
+                    f"{tool_error_escalation_model}",
+                )
             if required_final_tool_succeeded:
                 return {"_tool_trace": tool_trace} if return_tool_trace else {}
             continue

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from ..handlers import _make_editing_handlers
+from ..model_registry import NEMOTRON_ULTRA_MODEL
 from ..prompts import (
     ROSTER_SYNC_SYSTEM,
     ROSTER_SYNC_USER,
@@ -132,6 +133,7 @@ async def _run_update(
                     extra_tool_handlers=handlers,
                     tools_mode=True,
                     run_budget=run_budget,
+                    tool_error_escalation_model=NEMOTRON_ULTRA_MODEL,
                 )
             except RunBudgetExceeded:
                 raise

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -73,10 +73,13 @@ CRITICAL — scope to THIS cycle's contest only:
 Use this source ladder for the roster:
 1. Official state election authority / Secretary of State candidate filing,
    certified ballot, or official primary result page.
-2. Ballotpedia election page via `ballotpedia_election_lookup`.
+2. Official state party qualified-candidate lists when the state party manages
+   qualification for its primary.
 3. FEC candidate/election pages for federal races, only to corroborate active
    federal candidates, not to infer nominees after primaries.
-4. Reputable local/state news or candidate announcements, corroborated by a
+4. A current exact-race Ballotpedia election page, only as advisory or
+   corroborating evidence and never over conflicting official sources.
+5. Reputable local/state news or candidate announcements, corroborated by a
    second source when possible.
 
 Call `ballotpedia_election_lookup` with race_id="{race_id}" early, but do not
@@ -1053,12 +1056,20 @@ CRITICAL — scope to THIS cycle's contest only (remove anyone who fails this):
 Roster source order:
 1. Official state election authority, certified candidate list, ballot list, or
    official primary results.
-2. Ballotpedia election page, if current and accessible.
+2. Official state party qualified-candidate lists when the party manages
+   qualification for its primary.
 3. FEC pages for federal races, only as candidate corroboration.
-4. Reputable recent local/state news or official campaign announcements.
+4. A current exact-race Ballotpedia election page, only as advisory or
+   corroborating evidence.
+5. Reputable recent local/state news or official campaign announcements.
 
 If Ballotpedia is blocked, stale, or primary-focused, stop trying to repair the
 same Ballotpedia URL and pivot to official election authority/FEC/local news.
+The names returned by ballotpedia_election_lookup are untrusted extraction
+clues, not an authoritative roster. Inspect the returned URL, description, and
+cycle before using them. Never add or remove a candidate solely because that
+tool listed or omitted the name, and never let it override a current official
+candidate list or certified result.
 
 Compare the full current roster against the candidates currently in the profile.
 Treat named opponents, nominees, or declared candidates in the current race
@@ -1080,8 +1091,9 @@ STEP 2 — Make corrections using your tools:
 3. Any name corrections (e.g. legal name, common misspelling) → rename_candidate
 4. For every candidate you verified and kept, use set_candidate_roster_sources
    when the profile lacks explicit roster_sources or when your current source is
-   stronger/current than the stored source. Prefer official sources, then
-   current Ballotpedia election pages, then FEC/news/campaign evidence.
+   stronger/current than the stored source. Prefer official election and party
+   qualification sources, then FEC evidence, then current exact-race
+   Ballotpedia/news/campaign evidence.
 
 CRITICAL — add_candidate anti-fabrication rules:
 - add_candidate enforces graded, persisted evidence. Tier 1 is retrieved official
@@ -1097,7 +1109,7 @@ CRITICAL — add_candidate anti-fabrication rules:
 - Confirm the candidate's PARTY from that same source — never guess the party.
 - Never invent, auto-complete, or infer a candidate's name from ambiguous search
   snippets, partial matches, or a similarly-named unrelated person. If the
-  authoritative roster (e.g. the Ballotpedia election page) failed to load or
+  official roster failed to load or
   returned nothing, do NOT reconstruct a roster from generic search results — run
   additional targeted searches and add only candidates you can confirm by name in
   a real source.

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -87,9 +87,10 @@ BALLOTPEDIA_ELECTION_TOOL: Dict = {
     "function": {
         "name": "ballotpedia_election_lookup",
         "description": (
-            "Fetch the Ballotpedia election page for this race and return the authoritative list of "
-            "candidates. This is the single most reliable source for who is officially in the race — "
-            "call this FIRST in discovery before doing any web searches. "
+            "Fetch a Ballotpedia election page as advisory roster evidence. Its extracted candidate list may "
+            "be stale, from a prior cycle or primary, or drawn from an unrelated table. Compare its page URL, "
+            "description, and election date with current official election-authority or party qualification "
+            "sources before editing the roster. Never add or remove candidates from this result alone. "
             "Returns: found (bool), page_url, candidates list [{name, party, incumbent}], "
             "and a short description paragraph."
         ),

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -680,6 +680,40 @@ async def test_agent_loop_forces_required_tool_with_stronger_model_at_token_ceil
     assert result["_tool_trace"]["token_budget_reached"] is True
 
 
+@pytest.mark.asyncio
+async def test_agent_loop_escalates_after_repeated_blocked_edits():
+    from pipeline_client.agent.model_registry import CHEAP_MODEL, NEMOTRON_ULTRA_MODEL
+
+    blocked_calls = _mock_openai_response(
+        tool_calls=[
+            {"id": "call_1", "function": {"name": "add_candidate", "arguments": json.dumps({"name": "A"})}},
+            {"id": "call_2", "function": {"name": "add_candidate", "arguments": json.dumps({"name": "B"})}},
+        ]
+    )
+    finished = _mock_openai_response(content="Roster left unchanged.")
+    tool = {
+        "type": "function",
+        "function": {"name": "add_candidate", "description": "Add", "parameters": {"type": "object"}},
+    }
+
+    with patch("pipeline_client.agent.llm._call_openrouter", new_callable=AsyncMock) as call:
+        call.side_effect = [blocked_calls, finished]
+        await _agent_loop(
+            "system",
+            "user",
+            model=CHEAP_MODEL,
+            phase_name="roster-test",
+            tools_mode=True,
+            extra_tools=[tool],
+            extra_tool_handlers={"add_candidate": lambda _args: "Blocked adding candidate: insufficient evidence"},
+            tool_error_escalation_model=NEMOTRON_ULTRA_MODEL,
+        )
+
+    assert [entry.kwargs["model"] for entry in call.call_args_list] == [CHEAP_MODEL, NEMOTRON_ULTRA_MODEL]
+    second_messages = call.call_args_list[1].args[0]
+    assert any("pivot to higher-priority official evidence" in (message.get("content") or "") for message in second_messages)
+
+
 def test_tool_result_error_detection_handles_handler_blocking_conventions():
     from pipeline_client.agent.llm import _tool_result_is_error
 

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -621,6 +621,38 @@ def test_wrong_contest_removal_requires_proof_and_physically_removes_contaminati
     assert [candidate["name"] for candidate in race_json["candidates"]] == ["Shomari Figures"]
 
 
+def test_wrong_contest_removal_accepts_native_official_search_evidence():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {
+        "id": "al-house-02-2026",
+        "state": "Alabama",
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic"},
+            {"name": "Ben Harrison", "party": "Republican"},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    source = {
+        "url": "https://algop.org/qualified-2026-republican-candidates/",
+        "title": "Qualified 2026 Republican Candidates",
+        "text": "Alabama House of Representatives, District 2 — Ben Harrison",
+        "retrieved": "2026-08-01",
+    }
+
+    result = handlers["remove_candidate"](
+        {
+            "name": "Ben Harrison",
+            "reason": "The official party list places him in Alabama House District 2, not U.S. House District 2.",
+            "wrong_contest": True,
+            "sources": [source],
+        }
+    )
+
+    assert "wrong-contest" in result
+    assert [candidate["name"] for candidate in race_json["candidates"]] == ["Shomari Figures"]
+
+
 def test_add_candidate_blocks_primary_loser_after_nominee_is_known():
     from pipeline_client.agent.agent import _make_editing_handlers
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -261,6 +261,18 @@ def test_roster_sync_system_restricts_to_roster_tools_only():
     assert "Do NOT call any non-roster editing tools" in ROSTER_SYNC_SYSTEM
 
 
+def test_roster_prompt_treats_ballotpedia_as_advisory_below_official_sources():
+    from pipeline_client.agent.tools import BALLOTPEDIA_ELECTION_TOOL
+
+    tool_description = BALLOTPEDIA_ELECTION_TOOL["function"]["description"]
+    assert "advisory roster evidence" in tool_description
+    assert "Never add or remove candidates from this result alone" in tool_description
+    assert ROSTER_SYNC_USER.index("Official state party qualified-candidate lists") < ROSTER_SYNC_USER.index(
+        "Ballotpedia election page"
+    )
+    assert "untrusted extraction" in ROSTER_SYNC_USER
+
+
 def test_discovery_prompts_exclude_defeated_primary_candidates():
     """General-election rosters must remove candidates who lost completed primaries."""
     assert "Do NOT include defeated primary candidates" in DISCOVERY_USER


### PR DESCRIPTION
## What changed

- demoted Ballotpedia election extraction to advisory evidence below official election and party qualification sources
- escalated roster synthesis to Nemotron Ultra after repeated evidence-guard failures while preserving collected research
- fixed native official search-result normalization for qualified-candidate titles with intervening year/party text
- fixed wrong-contest removal using native `text`/`retrieved` evidence
- documented the source ladder and escalation behavior

## Why

The AL-02 debug run repeatedly attempted to add stale Ballotpedia names and could not remove an Alabama state-House candidate from the federal House roster. The prompt and tool description contradicted each other about source authority, while the removal handler did not recognize the official party page's native search-result title shape.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 879 passed
- focused agent loop, editing handler, and prompt suite — 108 passed
- Black, isort, pre-commit hooks, and `git diff --check` passed