### PR TITLE
Improve roster evidence recovery

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -25,6 +25,44 @@ from pipeline_client.agent.source_types import normalize_source_type
 
 _CANONICAL_ISSUE_SET = set(CANONICAL_ISSUES)
 _ROSTER_SOURCE_TYPES = {"official", "ballotpedia", "fec", "news", "campaign", "other"}
+# Source classes that can actually carry roster evidence. "other" is a parking
+# slot for unclassifiable input and never qualifies on its own.
+_QUALIFYING_ROSTER_SOURCE_TYPES = {"official", "fec", "campaign", "ballotpedia", "news"}
+# Free-form labels models emit for roster evidence, mapped onto the classes
+# above. Mirrors source_types.SOURCE_TYPE_ALIASES, which exists for the same
+# reason: models reliably invent plausible synonyms for enum values.
+_ROSTER_SOURCE_TYPE_ALIASES = {
+    "article": "news",
+    "ballot": "official",
+    "certified ballot": "official",
+    "election authority": "official",
+    "election official": "official",
+    "election results": "official",
+    "filing": "official",
+    "government": "official",
+    "gov": "official",
+    "media": "news",
+    "news article": "news",
+    "newspaper": "news",
+    "party": "official",
+    "party list": "official",
+    "press": "news",
+    "qualified candidates": "official",
+    "secretary of state": "official",
+    "sos": "official",
+    "state": "official",
+    "state election authority": "official",
+    "campaign site": "campaign",
+    "campaign website": "campaign",
+    "candidate site": "campaign",
+    "candidate website": "campaign",
+    "official campaign": "campaign",
+    "fec filing": "fec",
+    "federal election commission": "fec",
+    "encyclopedia": "ballotpedia",
+    "wiki": "ballotpedia",
+    "wikipedia": "ballotpedia",
+}
 _CONTEST_STAGES = {
     "pre_primary",
     "post_primary_general",
@@ -105,6 +143,33 @@ def _normalize_source(source: Any, *, default_type: str = "finance") -> Dict[str
     return normalized
 
 
+def _classify_roster_source_type(raw_type: Any, *, title: str | None, url: str | None, host: str) -> str:
+    """Map a free-form roster source label onto a known roster source class.
+
+    Mirrors ``source_types.normalize_source_type``: a recognized label wins, then
+    an alias, then host/title inference. Inference runs even when the model
+    supplied an unrecognized label — otherwise a plausible synonym such as
+    ``"web"`` or ``"election_authority"`` would be parked in ``"other"``, which
+    never satisfies the roster evidence contract.
+    """
+    label = str(raw_type or "").strip().lower().replace("_", " ").replace("-", " ")
+    label = re.sub(r"\s+", " ", label)
+    if label in _ROSTER_SOURCE_TYPES and label != "other":
+        return label
+    aliased = _ROSTER_SOURCE_TYPE_ALIASES.get(label)
+    if aliased:
+        return aliased
+
+    title_and_url = f"{title or ''} {url or ''}".casefold()
+    if host == "ballotpedia.org" or host.endswith(".ballotpedia.org"):
+        return "ballotpedia"
+    if host == "fec.gov" or host.endswith(".fec.gov"):
+        return "fec"
+    if host.endswith(".gov") or re.search(r"\bqualified\b.*\bcandidates?\b", title_and_url):
+        return "official"
+    return "other"
+
+
 def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any] | None:
     """Normalize source evidence used only for candidate roster membership."""
     if not isinstance(source, dict):
@@ -113,19 +178,7 @@ def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any
     title = str(source.get("title") or "").strip() or None
     evidence = str(source.get("evidence") or source.get("text") or source.get("context") or "").strip() or None
     host = urlparse(url or "").netloc.casefold()
-    source_type = str(source.get("type") or "").strip().lower()
-    if not source_type:
-        title_and_url = f"{title or ''} {url or ''}".casefold()
-        if host == "ballotpedia.org" or host.endswith(".ballotpedia.org"):
-            source_type = "ballotpedia"
-        elif host == "fec.gov" or host.endswith(".fec.gov"):
-            source_type = "fec"
-        elif host.endswith(".gov") or re.search(r"\bqualified\b.*\bcandidates?\b", title_and_url):
-            source_type = "official"
-        else:
-            source_type = "other"
-    if source_type not in _ROSTER_SOURCE_TYPES:
-        source_type = "other"
+    source_type = _classify_roster_source_type(source.get("type"), title=title, url=url, host=host)
     if not any((url, title, evidence)):
         return None
     normalized: Dict[str, Any] = {

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -146,27 +146,37 @@ def _normalize_source(source: Any, *, default_type: str = "finance") -> Dict[str
 def _classify_roster_source_type(raw_type: Any, *, title: str | None, url: str | None, host: str) -> str:
     """Map a free-form roster source label onto a known roster source class.
 
-    Mirrors ``source_types.normalize_source_type``: a recognized label wins, then
-    an alias, then host/title inference. Inference runs even when the model
-    supplied an unrecognized label — otherwise a plausible synonym such as
-    ``"web"`` or ``"election_authority"`` would be parked in ``"other"``, which
-    never satisfies the roster evidence contract.
+    Host evidence is checked first, then the model's label via the recognized set
+    and ``_ROSTER_SOURCE_TYPE_ALIASES``. Classification never depends on the label
+    being well-formed: a plausible synonym such as ``"web"`` or
+    ``"election_authority"`` used to be parked in ``"other"``, which can never
+    satisfy the roster evidence contract, so valid Ballotpedia and official
+    sources were rejected on a spelling technicality.
     """
+    title_and_url = f"{title or ''} {url or ''}".casefold()
+
+    # Host evidence outranks the model's label. "official"/"fec" are the classes that
+    # waive the tier-3 corroboration rule, so they must be earned by the host (or a
+    # party qualified-candidate list title) rather than self-declared — otherwise any
+    # page could be relabelled to bypass that guard.
+    host_class: str | None = None
+    if host == "ballotpedia.org" or host.endswith(".ballotpedia.org"):
+        host_class = "ballotpedia"
+    elif host == "fec.gov" or host.endswith(".fec.gov"):
+        host_class = "fec"
+    elif host.endswith(".gov") or re.search(r"\bqualified\b.*\bcandidates?\b", title_and_url):
+        host_class = "official"
+    if host_class:
+        return host_class
+
     label = str(raw_type or "").strip().lower().replace("_", " ").replace("-", " ")
     label = re.sub(r"\s+", " ", label)
-    if label in _ROSTER_SOURCE_TYPES and label != "other":
-        return label
-    aliased = _ROSTER_SOURCE_TYPE_ALIASES.get(label)
-    if aliased:
-        return aliased
-
-    title_and_url = f"{title or ''} {url or ''}".casefold()
-    if host == "ballotpedia.org" or host.endswith(".ballotpedia.org"):
-        return "ballotpedia"
-    if host == "fec.gov" or host.endswith(".fec.gov"):
-        return "fec"
-    if host.endswith(".gov") or re.search(r"\bqualified\b.*\bcandidates?\b", title_and_url):
-        return "official"
+    claimed = label if label in _ROSTER_SOURCE_TYPES and label != "other" else _ROSTER_SOURCE_TYPE_ALIASES.get(label)
+    if claimed in {"official", "fec"}:
+        # Unverifiable authority claim: keep the source usable but strip the waiver.
+        return "news"
+    if claimed:
+        return claimed
     return "other"
 
 
@@ -200,21 +210,33 @@ def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any
     return {key: value for key, value in normalized.items() if value is not None}
 
 
-def _source_supports_candidate_addition(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> bool:
-    """Validate one persisted source against the graded roster-evidence contract."""
-    if source.get("type") not in {"official", "fec", "campaign", "ballotpedia", "news"}:
-        return False
+def _roster_source_rejection_reason(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> str | None:
+    """Return why one persisted source fails the roster-evidence contract, or None if it passes.
+
+    Callers surface the reason verbatim to the model. A generic "not enough
+    evidence" message sends it hunting for more sources when the real problem is
+    often a single malformed field, which turns one bad call into a retry loop.
+    """
+    if source.get("type") not in _QUALIFYING_ROSTER_SOURCE_TYPES:
+        return (
+            f"source type {str(source.get('type'))!r} cannot carry roster evidence; "
+            f"use one of: {', '.join(sorted(_QUALIFYING_ROSTER_SOURCE_TYPES))}"
+        )
     parsed_url = urlparse(str(source.get("url") or ""))
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
-        return False
-    if source.get("race_id") != race_id or not source.get("title") or not source.get("evidence"):
-        return False
+        return "source needs an absolute http(s) url"
+    if source.get("race_id") != race_id:
+        return f"source race_id {str(source.get('race_id'))!r} does not match this race ({race_id!r})"
+    if not source.get("title"):
+        return "source needs a title"
+    if not source.get("evidence"):
+        return "source needs an 'evidence' (or 'text') quote naming the candidate and contest"
     if not _source_supports_exact_contest(source, race_id=race_id):
-        return False
+        return "evidence does not name this exact federal contest and district"
     name_words = re.findall(r"[a-z0-9]+", candidate_name.lower())
     evidence_text = f"{source.get('title', '')} {source.get('evidence', '')}".lower()
     if not name_words or not all(word in evidence_text for word in name_words):
-        return False
+        return f"evidence text does not contain the full candidate name {candidate_name!r}"
     year_match = re.search(r"(?:19|20)\d{2}", race_id)
     try:
         published = datetime.fromisoformat(str(source.get("published_at") or "").replace("Z", "+00:00"))
@@ -222,35 +244,77 @@ def _source_supports_candidate_addition(source: Dict[str, Any], *, candidate_nam
         published = None
     if year_match:
         valid_years = {int(year_match.group()) - 2, int(year_match.group()) - 1, int(year_match.group())}
+        years_label = "/".join(str(year) for year in sorted(valid_years))
         if published is not None:
             if published.year not in valid_years:
-                return False
+                return f"published_at year {published.year} is outside the current cycle ({years_label})"
         elif not any(str(year) in evidence_text for year in valid_years):
-            return False
+            return f"evidence has no current-cycle date; include a {years_label} published_at or cite the year in the text"
     tier = source.get("evidence_tier")
     status = source.get("retrieval_status")
     if tier == 1:
-        return status == "content" and source.get("type") in {"official", "fec"}
+        if status != "content" or source.get("type") not in {"official", "fec"}:
+            return "tier 1 requires retrieved page content from an official or FEC source"
+        return None
     if tier == 2:
-        return status == "content" and source.get("type") in {"campaign", "ballotpedia", "news"}
-    return tier == 3 and status == "snippet"
+        if status != "content" or source.get("type") not in {"campaign", "ballotpedia", "news"}:
+            return "tier 2 requires retrieved page content from a campaign, Ballotpedia, or news source"
+        return None
+    if tier == 3 and status == "snippet":
+        return None
+    return f"evidence_tier {tier!r}/retrieval_status {status!r} is not a recognized evidence grade"
 
 
-def _qualifying_candidate_addition_sources(sources: Any, *, candidate_name: str, race_id: str) -> list[Dict[str, Any]]:
-    """Return qualifying sources, enforcing corroboration for non-authoritative snippets."""
+def _source_supports_candidate_addition(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> bool:
+    """Validate one persisted source against the graded roster-evidence contract."""
+    return _roster_source_rejection_reason(source, candidate_name=candidate_name, race_id=race_id) is None
+
+
+def _qualifying_candidate_addition_sources(
+    sources: Any,
+    *,
+    candidate_name: str,
+    race_id: str,
+    require_corroboration: bool = True,
+) -> list[Dict[str, Any]]:
+    """Return qualifying sources, enforcing corroboration for non-authoritative snippets.
+
+    ``require_corroboration`` guards *adding* a candidate to the roster, where an
+    uncorroborated snippet is the fabrication risk. Attaching evidence to a
+    candidate who is already on the roster is a different operation and does not
+    need a second independent domain.
+    """
     normalized = [src for src in (_normalize_roster_source(source, race_id=race_id) for source in sources or []) if src]
     qualifying = [
         source
         for source in normalized
         if _source_supports_candidate_addition(source, candidate_name=candidate_name, race_id=race_id)
     ]
-    if qualifying and all(source.get("evidence_tier") == 3 for source in qualifying):
+    if require_corroboration and qualifying and all(source.get("evidence_tier") == 3 for source in qualifying):
         if any(source.get("type") in {"official", "fec"} for source in qualifying):
             return qualifying
         domains = {urlparse(str(source.get("url"))).netloc.lower() for source in qualifying}
         if len(domains) < 2:
             return []
     return qualifying
+
+
+def _roster_source_rejection_summary(sources: Any, *, candidate_name: str, race_id: str) -> str:
+    """Summarize per-source rejection reasons for a blocked roster edit."""
+    normalized = [src for src in (_normalize_roster_source(source, race_id=race_id) for source in sources or []) if src]
+    if not normalized:
+        return "no usable source objects were supplied"
+    reasons = []
+    for index, source in enumerate(normalized, start=1):
+        reason = _roster_source_rejection_reason(source, candidate_name=candidate_name, race_id=race_id)
+        if reason:
+            reasons.append(f"source {index} ({source.get('url') or 'no url'}): {reason}")
+    if not reasons:
+        return (
+            "each source is individually valid, but all of them are tier-3 snippets from a single domain; "
+            "cite a second independent domain or retrieve official/FEC page content"
+        )
+    return "; ".join(reasons)
 
 
 def _get_other_state_candidates(race_id: str, state: str | None) -> set[str]:
@@ -396,12 +460,14 @@ def _make_editing_handlers(
             args.get("roster_sources"), candidate_name=name, race_id=race_id
         )
         if not roster_sources:
-            log("warning", f"    add_candidate('{name}') BLOCKED: no qualifying current-cycle exact-contest evidence")
+            detail = _roster_source_rejection_summary(args.get("roster_sources"), candidate_name=name, race_id=race_id)
+            log("warning", f"    add_candidate('{name}') BLOCKED: {detail}")
             return (
-                f"Blocked adding '{name}': provide persisted, dated current-cycle evidence that explicitly names "
-                "the candidate and exact race. Retrieved official/FEC content is Tier 1; retrieved campaign, exact-race "
-                "Ballotpedia, or credible news content is Tier 2; blocked-page snippets are Tier 3 and require two "
-                "independent sources unless the snippet is from an official/FEC source."
+                f"Blocked adding '{name}': {detail}. "
+                "Provide persisted, dated current-cycle evidence that explicitly names the candidate and exact race. "
+                "Retrieved official/FEC content is Tier 1; retrieved campaign, exact-race Ballotpedia, or credible "
+                "news content is Tier 2; blocked-page snippets are Tier 3 and require two independent sources unless "
+                "the snippet is from an official/FEC source."
             )
         party = str(args.get("party") or "")
         party_key = "democratic" if "democrat" in party.lower() else "republican" if "republican" in party.lower() else ""
@@ -638,9 +704,16 @@ def _make_editing_handlers(
         if not c:
             return f"Candidate '{name}' not found."
         race_id = str(race_json.get("id") or "").strip()
-        sources = _qualifying_candidate_addition_sources(args.get("sources"), candidate_name=name, race_id=race_id)
+        # This candidate is already on the roster, so the corroboration rule that
+        # guards *adding* one does not apply — a single valid source is enough to
+        # attach evidence to an existing entry.
+        sources = _qualifying_candidate_addition_sources(
+            args.get("sources"), candidate_name=name, race_id=race_id, require_corroboration=False
+        )
         if not sources:
-            return "ERROR: At least one qualifying current-cycle exact-contest roster source is required."
+            detail = _roster_source_rejection_summary(args.get("sources"), candidate_name=name, race_id=race_id)
+            log("warning", f"    set_candidate_roster_sources('{name}') BLOCKED: {detail}")
+            return f"ERROR: no usable roster source for '{name}': {detail}."
         c["roster_sources"] = sources
         log("info", f"    Set {len(sources)} roster source(s) for {name}")
         return f"Set {len(sources)} roster source(s) for '{name}'."

--- a/pipeline_client/agent/phase_state.py
+++ b/pipeline_client/agent/phase_state.py
@@ -103,12 +103,8 @@ def race_identity_context(race_json: Dict[str, Any]) -> str:
         lines.append(f"- State: {state_name}")
     if district:
         lines.append(f"- District: {district}")
-    if contest_stage:
-        lines.append(f"- Contest stage: {contest_stage}")
     if election_date:
         lines.append(f"- Election date: {election_date}")
-    if primary_status:
-        lines.append(f"- Primary status: {primary_status}")
     if known_incumbent:
         lines.append(f"- Known incumbent: {known_incumbent}")
     if ineligible:
@@ -122,6 +118,20 @@ def race_identity_context(race_json: Dict[str, Any]) -> str:
         "exact office/state/district — not a different race in the same state or a "
         "different election cycle."
     )
+    # Contest stage advances with the calendar, so it is deliberately NOT part of the
+    # locked block above: presenting it as locked identity caused a stale "pre_primary"
+    # to be re-asserted run after run long after the primary had been decided.
+    if contest_stage or primary_status:
+        lines.append("")
+        lines.append("Time-sensitive status as last observed (re-verify against today's date; update it if it moved on):")
+        if contest_stage:
+            lines.append(f"- Contest stage was recorded as: {contest_stage}")
+        if primary_status:
+            lines.append(f"- Primary status was recorded as: {primary_status}")
+        lines.append(
+            "If a primary, runoff, or filing deadline has since concluded, record the current "
+            "stage with set_race_identity instead of repeating the stored value."
+        )
     return "\n".join(lines)
 
 

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -1145,6 +1145,19 @@ IMPORTANT — remove_candidate rules:
 - Data corrections (wrong biography, bad sources, etc.) are handled in later
   pipeline phases — ignore them here.
 
+STEP 2.6 — Record the CURRENT contest stage:
+Contest stage is a statement about the calendar as of {current_date}, not a
+permanent property of the race. A stored stage is a prior observation that may
+have expired — never re-assert it without checking.
+- Determine from your research whether this contest's primary has already been
+  held as of {current_date}. If it has, the stage is post_primary_general (or
+  runoff/top_two/top_four_rcv where the state's rules apply), NOT pre_primary.
+- Call set_race_identity with the stage you actually verified, and put the
+  evidence (primary date and outcome) in primary_status.
+- Getting this wrong is costly in both directions: a stale pre_primary keeps
+  defeated primary candidates on a general-election roster, while a premature
+  post_primary_general drops candidates before the primary has decided anything.
+
 Pay special attention to third-party candidates (Libertarian, Green, Independent),
 write-in candidates who qualified, and convention nominees who may not appear in
 initial profile data.

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -822,7 +822,7 @@ class AgentHandler:
                 f"Refusing to save draft '{race_id}': all candidate names are placeholders: {candidate_names}. "
                 "Re-queue the race with candidate_names or inspect discovery output."
             )
-        from pipeline_client.agent.handlers import _qualifying_candidate_addition_sources
+        from pipeline_client.agent.handlers import _qualifying_candidate_addition_sources, _roster_source_rejection_summary
 
         baseline_names = {name.casefold() for name in (verified_baseline_candidate_names or set())}
         unsupported_additions: List[str] = []
@@ -830,19 +830,23 @@ class AgentHandler:
             name = _candidate_name(candidate)
             if not name or name.casefold() in baseline_names:
                 continue
+            # Newly added candidates keep the strict corroboration rule: this is the
+            # anti-fabrication boundary. Candidates already in the baseline are exempt.
+            raw_sources = candidate.get("roster_sources") if isinstance(candidate, dict) else None
             sources = _qualifying_candidate_addition_sources(
-                candidate.get("roster_sources") if isinstance(candidate, dict) else None,
+                raw_sources,
                 candidate_name=name,
                 race_id=race_id,
             )
             if not sources:
-                unsupported_additions.append(name)
+                detail = _roster_source_rejection_summary(raw_sources, candidate_name=name, race_id=race_id)
+                unsupported_additions.append(f"{name} ({detail})")
             elif isinstance(candidate, dict):
                 candidate["roster_sources"] = sources
         if unsupported_additions:
             raise ValueError(
                 f"Refusing to save draft '{race_id}': new candidate(s) lack qualifying current-cycle "
-                f"exact-contest evidence: {', '.join(unsupported_additions)}."
+                f"exact-contest evidence: {'; '.join(unsupported_additions)}."
             )
 
         json_str = json.dumps(race_json, indent=2, default=str)

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -3,6 +3,8 @@
 import json
 import tempfile
 
+import pytest
+
 from pipeline_client.agent.agent import _select_target_candidates
 
 # ---------------------------------------------------------------------------
@@ -1247,3 +1249,121 @@ def test_search_cache_list_cached_for_race():
         assert len(result["searches"]) == 1
         assert result["searches"][0]["query"] == "test query"
         assert "https://r.com" in result["searches"][0]["urls"]
+
+
+def _nj_race_json():
+    return {
+        "id": "nj-senate-2026",
+        "state": "New Jersey",
+        "candidates": [
+            {"name": "Cory Booker", "party": "Democratic"},
+            {"name": "Veronica Fernandez", "party": "Unknown"},
+        ],
+    }
+
+
+def _nj_ballotpedia_source(source_type):
+    """The exact source shape the roster agent emitted for nj-senate-2026."""
+    source = {
+        "url": "https://ballotpedia.org/United_States_Senate_election_in_New_Jersey,_2026",
+        "title": "United States Senate election in New Jersey, 2026",
+        "text": (
+            "Incumbent Cory Booker, Justin Murphy, Veronica Fernandez, and Joanne Kuniansky are "
+            "running in the general election for U.S. Senate New Jersey on November 3, 2026"
+        ),
+        "retrieved": "2026-08-01",
+    }
+    if source_type is not None:
+        source["type"] = source_type
+    return source
+
+
+@pytest.mark.parametrize("source_type", ["web", "election_authority", "encyclopedia", None])
+def test_roster_source_type_inferred_from_host_for_unrecognized_labels(source_type):
+    """An unrecognized-but-plausible type label must not strand evidence in 'other'."""
+    from pipeline_client.agent.handlers import _normalize_roster_source
+
+    normalized = _normalize_roster_source(_nj_ballotpedia_source(source_type), race_id="nj-senate-2026")
+
+    assert normalized["type"] == "ballotpedia"
+
+
+def test_set_candidate_roster_sources_accepts_single_source_for_existing_candidate():
+    """Attaching evidence to a candidate already on the roster needs no corroboration."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_race_json()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    result = handlers["set_candidate_roster_sources"](
+        {"candidate_name": "Veronica Fernandez", "sources": [_nj_ballotpedia_source("web")]}
+    )
+
+    assert "Set 1 roster source(s)" in result
+    assert race_json["candidates"][1]["roster_sources"][0]["type"] == "ballotpedia"
+
+
+def test_add_candidate_still_requires_corroboration_for_tier3_snippets():
+    """The anti-fabrication gate on *new* candidates is unchanged."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_race_json()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    result = handlers["add_candidate"](
+        {
+            "name": "Joanne Kuniansky",
+            "party": "Socialist Workers Party",
+            "roster_sources": [_nj_ballotpedia_source("web")],
+        }
+    )
+
+    assert "Blocked adding" in result
+    assert [candidate["name"] for candidate in race_json["candidates"]] == ["Cory Booker", "Veronica Fernandez"]
+
+
+def test_self_declared_official_type_cannot_waive_corroboration():
+    """A model must not grant itself official authority by relabelling an arbitrary host."""
+    from pipeline_client.agent.handlers import _classify_roster_source_type, _qualifying_candidate_addition_sources
+
+    assert _classify_roster_source_type("official", title="T", url="https://randomblog.com/p", host="randomblog.com") == "news"
+
+    sources = [
+        {
+            "url": "https://randomblog.com/p",
+            "type": "official",
+            "title": "Veronica Fernandez 2026",
+            "evidence": "Veronica Fernandez is running for U.S. Senate New Jersey in 2026",
+        }
+    ]
+    assert _qualifying_candidate_addition_sources(sources, candidate_name="Veronica Fernandez", race_id="nj-senate-2026") == []
+
+
+def test_blocked_roster_edit_names_the_failing_check():
+    """A generic 'need better evidence' message sends the model hunting for the wrong thing."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_race_json()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    missing_evidence = handlers["set_candidate_roster_sources"](
+        {
+            "candidate_name": "Veronica Fernandez",
+            "sources": [
+                {
+                    "url": "https://ballotpedia.org/x",
+                    "type": "ballotpedia",
+                    "title": "United States Senate election in New Jersey, 2026",
+                }
+            ],
+        }
+    )
+    assert "evidence" in missing_evidence.lower()
+
+    wrong_name = handlers["set_candidate_roster_sources"](
+        {
+            "candidate_name": "Veronica Fernandez",
+            "sources": [_nj_ballotpedia_source("web") | {"text": "Cory Booker is running in 2026"}],
+        }
+    )
+    assert "candidate name" in wrong_name.lower()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -384,3 +384,35 @@ def test_forecast_prompt_formats_and_disallows_search():
     assert "Prediction market signals" in result
     assert "Do not search the web" in FORECAST_SYSTEM
     assert "Use set_forecast exactly once" in FORECAST_SYSTEM
+
+
+def test_roster_prompt_requires_current_contest_stage():
+    """A stale pre_primary keeps defeated primary candidates on general-election rosters."""
+    assert "STEP 2.6 — Record the CURRENT contest stage" in ROSTER_SYNC_USER
+    assert "not a\npermanent property of the race" in ROSTER_SYNC_USER
+    assert "post_primary_general" in ROSTER_SYNC_USER
+
+
+def test_contest_stage_is_not_presented_as_locked_identity():
+    """Contest stage advances with the calendar and must stay re-verifiable."""
+    from pipeline_client.agent.phase_state import race_identity_context
+
+    context = race_identity_context(
+        {
+            "office": "U.S. Senate",
+            "state": "New Jersey",
+            "pipeline_state": {
+                "race_identity": {
+                    "office": "U.S. Senate",
+                    "state": "New Jersey",
+                    "contest_stage": "pre_primary",
+                    "primary_status": "Primary scheduled for June 2026",
+                }
+            },
+        }
+    )
+
+    locked_block, _, status_block = context.partition("Time-sensitive status as last observed")
+    assert "pre_primary" not in locked_block
+    assert "pre_primary" in status_block
+    assert "re-verify against today's date" in context

--- a/tests/test_race_identity_brief.py
+++ b/tests/test_race_identity_brief.py
@@ -44,9 +44,11 @@ def test_race_identity_context_renders_locked_brief():
     assert "Locked race identity" in result
     assert "Office: Governor" in result
     assert "State: Alabama" in result
-    assert "Contest stage: post_primary_general" in result
     assert "Election date: 2026-11-03" in result
-    assert "Primary status: Republican and Democratic nominees certified." in result
+    # Contest stage and primary status track the calendar, so they render as a
+    # re-verifiable observation rather than locked identity.
+    assert "Contest stage was recorded as: post_primary_general" in result
+    assert "Primary status was recorded as: Republican and Democratic nominees certified." in result
     assert "Known incumbent: Kay Ivey" in result
     assert "known_ineligible_or_not_running" not in result  # rendered as prose, not the raw key
     assert "Kay Ivey" in result


### PR DESCRIPTION
## What changed

- normalize free-form roster source type aliases before applying evidence guards
- return specific per-source rejection reasons so the agent can repair malformed evidence instead of looping
- separate corroboration requirements for candidate additions from evidence attachment
- preserve calendar-derived race observations as re-verifiable context
- add focused regression coverage for aliases, rejection diagnostics, roster source attachment, and race identity context

## Why

Race research models can supply semantically valid evidence using plausible type aliases or slightly malformed fields. Generic rejection messages caused repeated blocked edits and unnecessary model escalation. These changes retain strict exact-contest and freshness guards while making recovery deterministic.

## Validation

- 130 focused roster-agent and race-identity tests
- Black and isort checks
- git diff whitespace check
