### PR TITLE
Require evidence-backed roster finalization

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -185,6 +185,11 @@ to the model as a failure. After two consecutive blocked edits, roster sync
 keeps the accumulated research but escalates subsequent synthesis to the
 stronger roster fallback and directs it to obtain higher-priority evidence
 instead of repeating the same invalid payload.
+Roster sync receives the run goal and cannot end successfully until it calls
+`finalize_roster`; that gate requires a locked contest identity plus qualifying
+current-cycle exact-contest evidence for every active candidate. If the gate
+does not pass, the run stops before images, polling, and forecast work and keeps
+`discovery` visibly incomplete for a retry.
 
 Roster authority order is: official election authority/certified ballot or
 result; official party qualification list when the party administers primary

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -753,6 +753,40 @@ def _make_editing_handlers(
         log("info", f"    Locked race identity ({contest_stage})")
         return "Recorded race identity brief."
 
+    def finalize_roster(args: Dict[str, Any]) -> str:
+        race_id = str(race_json.get("id") or "").strip()
+        active_candidates = [
+            candidate
+            for candidate in race_json.get("candidates", [])
+            if isinstance(candidate, dict) and candidate.get("name") and candidate.get("withdrawn") is not True
+        ]
+        if not active_candidates:
+            return "ERROR: roster finalization blocked. Add at least one verified active candidate."
+
+        missing_evidence = []
+        for candidate in active_candidates:
+            name = str(candidate.get("name") or "").strip()
+            if not _qualifying_candidate_addition_sources(
+                candidate.get("roster_sources"),
+                candidate_name=name,
+                race_id=race_id,
+            ):
+                missing_evidence.append(name)
+        if missing_evidence:
+            return (
+                "ERROR: roster finalization blocked. These active candidates lack durable current-cycle "
+                f"exact-contest roster evidence: {', '.join(missing_evidence)}. Search/fetch authoritative "
+                "sources, then call set_candidate_roster_sources or remove proven wrong-contest entries."
+            )
+
+        identity = (race_json.get("pipeline_state") or {}).get("race_identity")
+        if not isinstance(identity, dict) or not identity.get("office") or not identity.get("contest_stage"):
+            return "ERROR: roster finalization blocked. Lock the exact office and contest stage with set_race_identity."
+
+        summary = str(args.get("summary") or "").strip()
+        log("info", f"    Finalized roster with {len(active_candidates)} active candidate(s): {summary}")
+        return f"Roster finalized with {len(active_candidates)} evidence-backed active candidate(s)."
+
     # --- Candidate field handlers ---
 
     def set_candidate_field(args: Dict[str, Any]) -> str:
@@ -1322,6 +1356,7 @@ def _make_editing_handlers(
         "rename_candidate": rename_candidate,
         "set_candidate_roster_sources": set_candidate_roster_sources,
         "set_race_identity": set_race_identity,
+        "finalize_roster": finalize_roster,
         "set_candidate_field": set_candidate_field,
         "set_candidate_summary": set_candidate_summary,
         "set_issue_stance": set_issue_stance,

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -486,6 +486,7 @@ async def _agent_loop(
         "editing_calls": 0,
         "token_budget_reached": False,
         "max_iterations_reached": False,
+        "required_final_tool_succeeded": False,
     }
 
     for iteration in range(max_iterations):
@@ -518,7 +519,10 @@ async def _agent_loop(
 
         force_final_tool = bool(required_final_tool_name and (token_budget_reached or iteration == max_iterations - 1))
         if force_final_tool:
-            fallback_model = CHEAP_TO_DEFAULT_MODEL_FALLBACK.get(normalize_model_id(active_model) or active_model)
+            fallback_model = (
+                CHEAP_TO_DEFAULT_MODEL_FALLBACK.get(normalize_model_id(active_model) or active_model)
+                or tool_error_escalation_model
+            )
             if fallback_model:
                 log("info", f"  [{phase_name}] escalating final evidence synthesis to {fallback_model}")
                 active_model = fallback_model
@@ -759,6 +763,7 @@ async def _agent_loop(
                             handler_result = _extra_handlers[fn.name](args)
                         if fn.name == required_final_tool_name and not _tool_result_is_error(handler_result):
                             required_final_tool_succeeded = True
+                            tool_trace["required_final_tool_succeeded"] = True
                         if _tool_result_is_error(handler_result):
                             consecutive_tool_errors += 1
                             log("warning", f"    🔧 {fn.name} → BLOCKED")
@@ -808,6 +813,20 @@ async def _agent_loop(
 
         # No tool calls — in tools_mode this means the LLM is done editing
         if tools_mode:
+            if required_final_tool_name and not required_final_tool_succeeded:
+                messages.append(message.model_dump())
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": required_final_instruction
+                        or f"You have not completed the task. Call {required_final_tool_name} before stopping.",
+                    }
+                )
+                log(
+                    "warning",
+                    f"  [{phase_name}] model stopped before {required_final_tool_name}; requiring finalization",
+                )
+                continue
             log("info", f"  [{phase_name}] tools-mode complete (no more tool calls)")
             return {"_tool_trace": tool_trace} if return_tool_trace else {}
 

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -113,10 +113,12 @@ async def _run_update(
         pre_sync_names = list(candidate_names)
         if "discovery.roster_sync" not in completed_units:
             log("info", "Update Phase 0: Verifying candidate roster...")
+            roster_sync_succeeded = False
             try:
-                await _agent_loop(
+                roster_result = await _agent_loop(
                     ROSTER_SYNC_SYSTEM,
-                    ROSTER_SYNC_USER.format(
+                    (f"## Run Goal\n{goal}\n\n" if goal else "")
+                    + ROSTER_SYNC_USER.format(
                         race_id=race_id,
                         last_updated=last_updated,
                         current_date=as_of_date,
@@ -134,7 +136,14 @@ async def _run_update(
                     tools_mode=True,
                     run_budget=run_budget,
                     tool_error_escalation_model=NEMOTRON_ULTRA_MODEL,
+                    required_final_tool_name="finalize_roster",
+                    required_final_instruction=(
+                        "Do not stop yet. Finish the authoritative exact-contest roster, ensure every active "
+                        "candidate has durable qualifying roster_sources, then call finalize_roster."
+                    ),
+                    return_tool_trace=True,
                 )
+                roster_sync_succeeded = bool((roster_result.get("_tool_trace") or {}).get("required_final_tool_succeeded"))
             except RunBudgetExceeded:
                 raise
             except Exception as exc:
@@ -149,6 +158,26 @@ async def _run_update(
                 operation="Ballotpedia roster sync",
             )
             _sanitize_roster(race_json, log)
+            if not roster_sync_succeeded:
+                _record_step_failure(
+                    race_json,
+                    "discovery",
+                    RunFailureReason.ROSTER_VERIFICATION_FAILED,
+                    "Roster agent did not complete evidence-backed finalization.",
+                )
+                pipeline_state = race_json.setdefault("pipeline_state", {})
+                pipeline_state["complete"] = False
+                remaining_steps = pipeline_state.setdefault("remaining_steps", [])
+                if "discovery" not in remaining_steps:
+                    remaining_steps.append("discovery")
+                track(
+                    "progress",
+                    "discovery",
+                    pct=30,
+                    message="Discovery stopped: roster finalization incomplete",
+                    race_json=race_json,
+                )
+                return race_json
             _mark_pipeline_unit_complete(race_json, "discovery.roster_sync")
             completed_units.add("discovery.roster_sync")
             track(

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -1199,7 +1199,9 @@ official ballot). Never assume a race is uncontested without at least one additi
 search verifying the other party's candidate status.
 
 When you have made all necessary corrections (or confirmed no changes are needed),
-stop making tool calls. Do NOT produce any text reply or JSON — just stop.
+call finalize_roster. It will reject incomplete or weakly sourced rosters and tell
+you exactly which candidate evidence remains to fix. You may stop only after
+finalize_roster succeeds. Do NOT produce any text reply or JSON.
 Do NOT modify any other data (issues, summaries, polls, etc.)."""
 
 ROSTER_VERIFY_SYSTEM = f"""\

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -318,12 +318,34 @@ SET_RACE_IDENTITY_TOOL: Dict = {
     },
 }
 
+FINALIZE_ROSTER_TOOL: Dict = {
+    "type": "function",
+    "function": {
+        "name": "finalize_roster",
+        "description": (
+            "Finish roster sync only after every active candidate has durable current-cycle exact-contest evidence. "
+            "The handler validates the roster and returns specific missing evidence to fix."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string",
+                    "description": "Brief description of the authoritative roster and contest stage used.",
+                }
+            },
+            "required": ["summary"],
+        },
+    },
+}
+
 ROSTER_TOOLS: List[Dict] = [
     ADD_CANDIDATE_TOOL,
     REMOVE_CANDIDATE_TOOL,
     RENAME_CANDIDATE_TOOL,
     SET_CANDIDATE_ROSTER_SOURCES_TOOL,
     SET_RACE_IDENTITY_TOOL,
+    FINALIZE_ROSTER_TOOL,
 ]
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -681,6 +681,43 @@ async def test_agent_loop_forces_required_tool_with_stronger_model_at_token_ceil
 
 
 @pytest.mark.asyncio
+async def test_agent_loop_does_not_accept_early_stop_before_required_final_tool():
+    stopped = _mock_openai_response(content="Done")
+    finalized = _mock_openai_response(
+        tool_calls=[
+            {
+                "id": "call_final",
+                "function": {"name": "finalize_roster", "arguments": json.dumps({"summary": "Official list"})},
+            }
+        ]
+    )
+    handler = MagicMock(return_value="Roster finalized")
+    final_tool = {
+        "type": "function",
+        "function": {"name": "finalize_roster", "description": "Finalize", "parameters": {"type": "object"}},
+    }
+
+    with patch("pipeline_client.agent.llm._call_openrouter", new_callable=AsyncMock) as call:
+        call.side_effect = [stopped, finalized]
+        result = await _agent_loop(
+            "system",
+            "user",
+            model="google/gemini-2.5-flash",
+            phase_name="roster-finalize-test",
+            tools_mode=True,
+            extra_tools=[final_tool],
+            extra_tool_handlers={"finalize_roster": handler},
+            required_final_tool_name="finalize_roster",
+            required_final_instruction="Finalize the roster before stopping.",
+            return_tool_trace=True,
+        )
+
+    assert call.call_count == 2
+    assert handler.call_count == 1
+    assert result["_tool_trace"]["required_final_tool_succeeded"] is True
+
+
+@pytest.mark.asyncio
 async def test_agent_loop_escalates_after_repeated_blocked_edits():
     from pipeline_client.agent.model_registry import CHEAP_MODEL, NEMOTRON_ULTRA_MODEL
 

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -52,7 +52,7 @@ def test_editing_tool_schemas_exist():
         UPDATE_RACE_FIELD_TOOL,
     )
 
-    assert len(ROSTER_TOOLS) == 5
+    assert len(ROSTER_TOOLS) == 6
     assert len(CANDIDATE_TOOLS) == 2
     assert len(ISSUE_TOOLS) == 1
     assert len(RECORD_TOOLS) == 4  # donor_summary, voting_summary, add_link, remove_candidate_source_url
@@ -82,6 +82,7 @@ def test_make_editing_handlers():
         "rename_candidate",
         "set_candidate_roster_sources",
         "set_race_identity",
+        "finalize_roster",
         "set_candidate_field",
         "set_candidate_summary",
         "set_issue_stance",
@@ -713,6 +714,41 @@ def test_add_candidate_accepts_context_and_date_search_aliases():
     source = race_json["candidates"][0]["roster_sources"][0]
     assert source["evidence"] == "U.S. Representative, 2nd District - Shomari Figures"
     assert source["published_at"] == "2026-02-01"
+
+
+def test_finalize_roster_requires_evidence_for_every_active_candidate():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {"race_identity": {"office": "U.S. House", "contest_stage": "pre_primary"}},
+        "candidates": [
+            {
+                "name": "Shomari Figures",
+                "party": "Democratic",
+                "roster_sources": [
+                    {
+                        "url": "https://aldemocrats.org/2026-qualified-candidates",
+                        "type": "official",
+                        "title": "2026 Qualified Candidates",
+                        "evidence": "US Representative, 2nd District - Shomari Figures",
+                        "race_id": "al-house-02-2026",
+                        "published_at": "2026-02-01",
+                        "evidence_tier": 1,
+                        "retrieval_status": "content",
+                    }
+                ],
+            },
+            {"name": "Unverified Candidate", "party": "Republican", "roster_sources": []},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    blocked = handlers["finalize_roster"]({"summary": "Official party lists"})
+    assert "Unverified Candidate" in blocked
+    race_json["candidates"].pop()
+    finalized = handlers["finalize_roster"]({"summary": "Official party list"})
+    assert finalized == "Roster finalized with 1 evidence-backed active candidate(s)."
 
 
 def test_add_candidate_blocks_primary_loser_after_nominee_is_known():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -259,6 +259,7 @@ def test_roster_sync_system_restricts_to_roster_tools_only():
     assert "set_candidate_roster_sources" in ROSTER_SYNC_SYSTEM
     assert "set_race_identity" in ROSTER_SYNC_SYSTEM
     assert "Do NOT call any non-roster editing tools" in ROSTER_SYNC_SYSTEM
+    assert "finalize_roster succeeds" in ROSTER_SYNC_USER
 
 
 def test_roster_prompt_treats_ballotpedia_as_advisory_below_official_sources():

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -502,12 +502,13 @@ async def test_discovery_only_update_uses_update_discovery_phases():
     }
 
     with patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop:
-        mock_loop.return_value = {}
+        mock_loop.side_effect = [{"_tool_trace": {"required_final_tool_succeeded": True}}, {}, {}]
         result = await run_agent(
             "al-senate-2026",
             cheap_mode=True,
             existing_data=existing,
             enabled_steps=["discovery"],
+            goal="Use the certified special-election roster.",
         )
 
     assert [call.kwargs["phase_name"] for call in mock_loop.call_args_list] == [
@@ -515,6 +516,34 @@ async def test_discovery_only_update_uses_update_discovery_phases():
         "roster-verify",
         "update-meta",
     ]
+    assert "Use the certified special-election roster." in mock_loop.call_args_list[0].args[1]
+
+
+@pytest.mark.asyncio
+async def test_incomplete_roster_finalization_stops_before_downstream_steps():
+    existing = {
+        "id": "al-house-02-2026",
+        "election_date": "2026-11-03",
+        "candidates": [{"name": "Wrong Contest", "party": "Unknown", "roster_sources": []}],
+        "updated_utc": "2026-01-01T00:00:00Z",
+    }
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
+        patch("pipeline_client.agent.phases._sync_ballotpedia_roster", new_callable=AsyncMock),
+    ):
+        mock_loop.return_value = {"_tool_trace": {"required_final_tool_succeeded": False}}
+        result = await run_agent(
+            "al-house-02-2026",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["discovery", "images", "polling", "forecast"],
+        )
+
+    assert mock_loop.await_count == 1
+    assert result["pipeline_state"]["complete"] is False
+    assert "discovery" in result["pipeline_state"]["remaining_steps"]
+    assert result["run_health"]["status"] == "failed"
 
 
 @pytest.mark.asyncio
@@ -1098,7 +1127,7 @@ async def test_run_agent_update_with_candidates():
         patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
         patch("pipeline_client.agent.agent._load_existing", return_value=existing),
     ):
-        mock_loop.return_value = {}
+        mock_loop.side_effect = [{"_tool_trace": {"required_final_tool_succeeded": True}}] + [{}] * 18
 
         result = await run_agent(
             "test-2024",
@@ -1568,6 +1597,7 @@ async def test_discovery_polling_forecast_refresh_does_not_require_review():
         patch("pipeline_client.agent.phases.fetch_kalshi_market_signals", new_callable=AsyncMock, return_value=[]),
         patch("pipeline_client.agent.agent._load_existing", return_value=existing),
     ):
+        mock_loop.side_effect = [{"_tool_trace": {"required_final_tool_succeeded": True}}] + [{}] * 4
         result = await run_agent(
             "market-refresh-2026",
             existing_data=existing,


### PR DESCRIPTION
## What changed

- pass the queued run goal into roster research
- add a required `finalize_roster` tool that validates a locked contest identity and qualifying exact-contest evidence for every active candidate
- refuse early tools-mode completion until a required final tool succeeds
- use the stronger roster model for the forced final synthesis turn
- stop a core refresh before images, polling, and forecast when roster finalization remains incomplete

## Root cause

The AL-02 debug run showed that roster sync could ignore the operator goal, make a partial edit, fail to add the actual federal candidate, and then stop voluntarily. The phase marked that partial result complete and continued into downstream work.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 882 passed
- focused agent/roster/update suite — 179 passed
- Black, isort, pre-commit hooks, and `git diff --check` passed