### PR TITLE
Record cost for cancelled local runs

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -165,6 +165,10 @@ Common tools:
 - `get_run_diagnostics`, `summarize_run_costs`: run health and exact cost
 - `get_pipeline_metrics`, `get_pipeline_metrics_summary`: cost reporting
 
+Local-worker cancellation snapshots the live token, provider-cost, search, and
+phase accumulators before clearing the run, so `summarize_run_costs` reports
+actual partial spend instead of an unevidenced zero for future cancelled runs.
+
 Queue each `repair_groups` item independently. The combined
 `recommended_steps` and `candidate_names` fields are summaries, not a safe
 queue payload when candidates need different work. Estimates use a 25% margin

--- a/pipeline_client/backend/queue_processor.py
+++ b/pipeline_client/backend/queue_processor.py
@@ -340,6 +340,49 @@ async def process_claimed_item(
                     logger.debug("Could not delete followed continuation item %s", exc.continuation_item_id, exc_info=True)
     except AgentCancelled as exc:
         logger.info("Local run %s cancelled: %s", run_id, exc)
+        try:
+            from pipeline_client.agent.cost import _cost_ctx, estimate_cost
+            from pipeline_client.backend.pipeline_metrics import get_pipeline_metrics_store
+
+            acc = _cost_ctx.get() or {}
+            breakdown = acc.get("model_breakdown", {})
+            estimated_usd = sum(
+                estimate_cost(model, counts.get("prompt_tokens", 0), counts.get("completion_tokens", 0))
+                for model, counts in breakdown.items()
+            )
+            search_cost_usd = int(acc.get("serper_calls", 0) or 0) * 0.001
+            llm_cost_usd = float(acc.get("provider_cost_usd", 0.0) or 0.0)
+            has_exact_cost = int(acc.get("priced_calls", 0) or 0) > 0 and int(acc.get("unpriced_calls", 0) or 0) == 0
+            cancelled_metrics = {
+                "model": options.get("research_model", ""),
+                "model_profile": options.get("model_profile"),
+                "prompt_tokens": int(acc.get("prompt_tokens", 0) or 0),
+                "completion_tokens": int(acc.get("completion_tokens", 0) or 0),
+                "total_tokens": int(acc.get("prompt_tokens", 0) or 0) + int(acc.get("completion_tokens", 0) or 0),
+                "llm_cost_usd": llm_cost_usd if has_exact_cost else None,
+                "search_cost_usd": search_cost_usd,
+                "cost_usd": llm_cost_usd + search_cost_usd if has_exact_cost else None,
+                "cost_source": "provider" if has_exact_cost else "estimated",
+                "estimated_usd": estimated_usd + search_cost_usd,
+                "model_breakdown": breakdown,
+                "phase_breakdown": acc.get("phase_breakdown", {}),
+                "page_fetches": int(acc.get("page_fetches", 0) or 0),
+                "fetched_chars": int(acc.get("fetched_chars", 0) or 0),
+                "page_budget_blocked": int(acc.get("page_budget_blocked", 0) or 0),
+                "duration_s": round(_time.perf_counter() - started_at, 1),
+                "serper_calls": int(acc.get("serper_calls", 0) or 0),
+            }
+            await get_pipeline_metrics_store().record_run(
+                run_id,
+                race_id,
+                cancelled_metrics,
+                "cancelled",
+                cheap_mode=bool(options.get("cheap_mode", True)),
+                serper_calls=cancelled_metrics["serper_calls"],
+            )
+            _cost_ctx.set(None)
+        except Exception:
+            logger.warning("Failed to record metrics for cancelled local run %s", run_id, exc_info=True)
         item_ref.update(
             {
                 "status": "cancelled",

--- a/tests/test_queue_worker.py
+++ b/tests/test_queue_worker.py
@@ -1,7 +1,7 @@
 """Tests for the local-worker queue processor (no-handoff execution)."""
 
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -207,6 +207,51 @@ async def test_process_marks_cancelled_run_health_on_agent_cancelled():
     cancelled_updates = [u for u in run_updates if u.get("status") == "cancelled"]
     assert cancelled_updates
     assert cancelled_updates[-1]["run_health"]["reasons"] == ["cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_process_records_live_provider_cost_when_cancelled():
+    from pipeline_client.agent.cost import _cost_ctx
+    from pipeline_client.backend import queue_processor as qp
+    from pipeline_client.backend.handlers.agent import AgentCancelled
+
+    item = {
+        "race_id": "ca-house-01-2026",
+        "run_id": "run-cost-cancelled",
+        "options": {"cheap_mode": True, "research_model": "test/model"},
+    }
+    db, _item_ref, _run_ref, _race_ref = _fs_mock(item)
+    metrics_store = MagicMock()
+    metrics_store.record_run = AsyncMock()
+
+    async def cancelled(*_args):
+        _cost_ctx.set(
+            {
+                "prompt_tokens": 1200,
+                "completion_tokens": 300,
+                "provider_cost_usd": 0.012,
+                "priced_calls": 2,
+                "unpriced_calls": 0,
+                "serper_calls": 2,
+                "model_breakdown": {"test/model": {"prompt_tokens": 1200, "completion_tokens": 300}},
+                "phase_breakdown": {"discovery": {"prompt_tokens": 1200, "completion_tokens": 300}},
+            }
+        )
+        raise AgentCancelled("cancelled by admin")
+
+    with (
+        patch.object(qp, "_run_agent", side_effect=cancelled),
+        patch("pipeline_client.backend.pipeline_metrics.get_pipeline_metrics_store", return_value=metrics_store),
+    ):
+        await qp.process_claimed_item(db, MagicMock(), "bucket", "item-cost", item, "owner-cost")
+
+    metrics_store.record_run.assert_awaited_once()
+    args = metrics_store.record_run.await_args.args
+    assert args[:4] == ("run-cost-cancelled", "ca-house-01-2026", args[2], "cancelled")
+    assert args[2]["prompt_tokens"] == 1200
+    assert args[2]["completion_tokens"] == 300
+    assert args[2]["cost_usd"] == pytest.approx(0.014)
+    assert args[2]["cost_source"] == "provider"
 
 
 def test_claim_local_item_claims_pending_local():


### PR DESCRIPTION
## What changed

- snapshot the live model token, provider cost, search, page, and phase accumulators when a local run is cancelled
- persist cancelled-run metrics before the worker clears terminal state
- document that future partial runs have auditable spend

## Root cause

The local worker returned immediately from its `AgentCancelled` handler. Failed and completed runs recorded the live cost accumulator, but cancelled runs did not, so MCP cost summaries fell back to a misleading `$0` with `has_cost=false` despite paid calls in the debug trace.

## Validation

- `python -m pytest tests/test_queue_worker.py tests/test_pipeline_metrics.py -q` — 13 passed
- Black, isort, pre-commit hooks, and `git diff --check` passed