### PR TITLE
Reserve a final roster synthesis turn

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -182,7 +182,8 @@ forecast evidence lineage, and pipeline/validation health. Use
 thumbnail quality matters; presence alone is not treated as verification.
 
 Roster editing tools accept both normalized evidence fields and the native
-`web_search`/model result aliases (`text` or `context`, `retrieved`, and `date`). The handler preserves those
+`web_search`/model result aliases (`text`, `context`, or `snippet`, plus
+`retrieved` and `date`). The handler preserves those
 as durable evidence, infers only recognizable source classes, and still applies
 current-cycle and exact-contest checks. A blocked/error tool result is surfaced
 to the model as a failure. After two consecutive blocked edits, roster sync

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -186,7 +186,10 @@ def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any
         return None
     url = str(source.get("url") or "").strip() or None
     title = str(source.get("title") or "").strip() or None
-    evidence = str(source.get("evidence") or source.get("text") or source.get("context") or "").strip() or None
+    evidence = (
+        str(source.get("evidence") or source.get("text") or source.get("context") or source.get("snippet") or "").strip()
+        or None
+    )
     host = urlparse(url or "").netloc.casefold()
     source_type = _classify_roster_source_type(source.get("type"), title=title, url=url, host=host)
     if not any((url, title, evidence)):

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -517,7 +517,26 @@ async def _agent_loop(
                     f"  [{phase_name}] JSON parsing failed previously — elevating model from {model} to {active_model} for retry prompt",
                 )
 
+        prepare_final_tool = bool(required_final_tool_name and not token_budget_reached and iteration == max_iterations - 2)
         force_final_tool = bool(required_final_tool_name and (token_budget_reached or iteration == max_iterations - 1))
+        if prepare_final_tool:
+            fallback_model = (
+                CHEAP_TO_DEFAULT_MODEL_FALLBACK.get(normalize_model_id(active_model) or active_model)
+                or tool_error_escalation_model
+            )
+            if fallback_model:
+                log("info", f"  [{phase_name}] escalating evidence application to {fallback_model}")
+                active_model = fallback_model
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "Research is complete. Do not search or fetch again. Use the editing tools now to apply all "
+                        "supported findings from the accumulated evidence. Fix every validation error already "
+                        "reported, then leave the next turn for final validation."
+                    ),
+                }
+            )
         if force_final_tool:
             fallback_model = (
                 CHEAP_TO_DEFAULT_MODEL_FALLBACK.get(normalize_model_id(active_model) or active_model)
@@ -543,6 +562,8 @@ async def _agent_loop(
                 else []
             )
             tools_for_call = search_tools + _extra_tools if (search_tools or _extra_tools) else None
+            if prepare_final_tool:
+                tools_for_call = _extra_tools or None
             if force_final_tool:
                 tools_for_call = [
                     tool for tool in _extra_tools if tool.get("function", {}).get("name") == required_final_tool_name

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -159,6 +159,7 @@ ADD_CANDIDATE_TOOL: Dict = {
                             "title": {"type": "string"},
                             "evidence": {"type": "string", "description": "Short note explaining what the source confirms."},
                             "text": {"type": "string", "description": "Search-result evidence text; alias for evidence."},
+                            "snippet": {"type": "string", "description": "Search-result snippet; alias for evidence."},
                             "context": {
                                 "type": "string",
                                 "description": "Quoted/search-result context; alias for evidence.",
@@ -207,6 +208,7 @@ REMOVE_CANDIDATE_TOOL: Dict = {
                             "title": {"type": "string"},
                             "evidence": {"type": "string"},
                             "text": {"type": "string", "description": "Search-result evidence text; alias for evidence."},
+                            "snippet": {"type": "string", "description": "Search-result snippet; alias for evidence."},
                             "context": {
                                 "type": "string",
                                 "description": "Quoted/search-result context; alias for evidence.",
@@ -264,6 +266,7 @@ SET_CANDIDATE_ROSTER_SOURCES_TOOL: Dict = {
                             "title": {"type": "string"},
                             "evidence": {"type": "string"},
                             "text": {"type": "string", "description": "Search-result evidence text; alias for evidence."},
+                            "snippet": {"type": "string", "description": "Search-result snippet; alias for evidence."},
                             "context": {
                                 "type": "string",
                                 "description": "Quoted/search-result context; alias for evidence.",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -718,6 +718,61 @@ async def test_agent_loop_does_not_accept_early_stop_before_required_final_tool(
 
 
 @pytest.mark.asyncio
+async def test_agent_loop_reserves_strong_edit_turn_before_forced_finalization():
+    from pipeline_client.agent.model_registry import DEFAULT_MODEL, NEMOTRON_ULTRA_MODEL
+
+    searched = _mock_openai_response(
+        tool_calls=[
+            {"id": "search", "function": {"name": "web_search", "arguments": json.dumps({"query": "official roster"})}}
+        ]
+    )
+    edited = _mock_openai_response(
+        tool_calls=[{"id": "edit", "function": {"name": "set_sources", "arguments": json.dumps({"name": "Alice"})}}]
+    )
+    finalized = _mock_openai_response(
+        tool_calls=[
+            {
+                "id": "final",
+                "function": {"name": "finalize_roster", "arguments": json.dumps({"summary": "Official roster"})},
+            }
+        ]
+    )
+    edit_tool = {
+        "type": "function",
+        "function": {"name": "set_sources", "description": "Set", "parameters": {"type": "object"}},
+    }
+    final_tool = {
+        "type": "function",
+        "function": {"name": "finalize_roster", "description": "Finalize", "parameters": {"type": "object"}},
+    }
+
+    with (
+        patch("pipeline_client.agent.llm._call_openrouter", new_callable=AsyncMock) as call,
+        patch("pipeline_client.agent.llm._serper_search", new_callable=AsyncMock, return_value=[]),
+    ):
+        call.side_effect = [searched, edited, finalized]
+        result = await _agent_loop(
+            "system",
+            "user",
+            model=DEFAULT_MODEL,
+            phase_name="roster-final-turns",
+            max_iterations=3,
+            tools_mode=True,
+            extra_tools=[edit_tool, final_tool],
+            extra_tool_handlers={"set_sources": lambda _args: "OK", "finalize_roster": lambda _args: "OK"},
+            required_final_tool_name="finalize_roster",
+            tool_error_escalation_model=NEMOTRON_ULTRA_MODEL,
+            return_tool_trace=True,
+        )
+
+    assert result["_tool_trace"]["required_final_tool_succeeded"] is True
+    assert call.call_args_list[1].kwargs["model"] == NEMOTRON_ULTRA_MODEL
+    prep_tool_names = {tool["function"]["name"] for tool in call.call_args_list[1].kwargs["tools"]}
+    assert prep_tool_names == {"set_sources", "finalize_roster"}
+    assert call.call_args_list[2].kwargs["tool_choice"]["function"]["name"] == "finalize_roster"
+
+
+@pytest.mark.asyncio
 async def test_agent_loop_escalates_after_repeated_blocked_edits():
     from pipeline_client.agent.model_registry import CHEAP_MODEL, NEMOTRON_ULTRA_MODEL
 

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -716,6 +716,30 @@ def test_add_candidate_accepts_context_and_date_search_aliases():
     assert source["published_at"] == "2026-02-01"
 
 
+def test_add_candidate_accepts_native_search_snippet_alias():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {"id": "al-house-02-2026", "state": "Alabama", "candidates": []}
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    result = handlers["add_candidate"](
+        {
+            "name": "Shomari Figures",
+            "party": "Democratic",
+            "roster_sources": [
+                {
+                    "url": "https://aldemocrats.org/2026-qualified-candidates",
+                    "title": "2026 Qualified Candidates",
+                    "snippet": "US Representative, 2nd District - Shomari Figures",
+                    "retrieved": "2026-08-01",
+                }
+            ],
+        }
+    )
+
+    assert result == "Added candidate 'Shomari Figures'."
+    assert race_json["candidates"][0]["roster_sources"][0]["evidence"].startswith("US Representative")
+
+
 def test_finalize_roster_requires_evidence_for_every_active_candidate():
     from pipeline_client.agent.agent import _make_editing_handlers
 


### PR DESCRIPTION
## What changed

- accept the native `snippet` evidence alias in every roster source tool and normalizer
- reserve the penultimate required-finalizer iteration for a stronger no-search editing pass
- restrict only the final iteration to the validation tool
- add regressions for native snippets and the research → strong edit → forced finalization sequence

## Root cause

The AL-02 finalizer correctly failed closed, but the agent fetched the official party roster on its penultimate turn and then had only a validation-only turn remaining. It could not apply the evidence it had just found. Native search evidence also used `snippet`, which was not one of the preserved aliases.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 894 passed
- focused agent/roster/update suite — 191 passed
- touched-file Black/isort and `git diff --check` passed

The repository-wide formatting command currently names the removed `functions/` directory after concurrent PR #215; touched files pass directly.