### PR TITLE
Guard phantom roster removals and proxy fetches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,13 @@ OPENROUTER_API_KEY=sk-or-your-openrouter-key-here
 # Get your key at: https://serper.dev/
 SERPER_API_KEY=your-serper-key-here
 
+# Jina Reader - Optional but strongly recommended for page fetching.
+# Pages that block direct fetches are retrieved through https://r.jina.ai/.
+# The anonymous quota is shared and low; once spent it returns 403 for every
+# host, which strands all roster evidence at snippet tier. A key restores the
+# authenticated quota. Get one at: https://jina.ai/reader/
+JINA_API_KEY=your-jina-key-here
+
 # =============================================================================
 # PIPELINE CONFIGURATION
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SmarterVote uses a multi-phase AI agent to research election races and produce s
 
 - Python 3.11+
 - Node.js 22+
-- `OPENROUTER_API_KEY` and `SERPER_API_KEY` for agent runs; `SEARLO_API_KEY` enables the search fallback when Serper credits are exhausted
+- `OPENROUTER_API_KEY` and `SERPER_API_KEY` for agent runs; `SEARLO_API_KEY` enables the search fallback when Serper credits are exhausted; `JINA_API_KEY` gives page fetches an authenticated Jina Reader quota (without it the shared anonymous quota 403s for every host once spent, leaving all evidence at snippet tier)
 
 ## Local Development
 

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -204,6 +204,30 @@ exact-race Ballotpedia page and reputable news/campaign sources. The
 contain stale-cycle, primary, or unrelated navigation tables. Its names must
 never drive an add/removal alone or override a current official source.
 
+Removals have three paths, chosen by what the evidence actually supports:
+
+- **Exited the race** — a reason describing the withdrawal, disqualification, or
+  dated primary loss. A cited current-cycle source naming the candidate satisfies
+  this on its own; the reason text does not also have to match a keyword.
+- **`wrong_contest=true`** — evidence placing the candidate in another
+  office/district. The handler checks the citation is a real, current-cycle
+  source naming the candidate; whether the page describes a different office is
+  the model's reading, not a keyword match, so this works for every race type.
+- **`not_on_roster=true`** — nothing supports the candidacy and the best roster
+  listing for this exact race omits them. The listing must name at least two
+  other candidates on the profile (proving it loaded and enumerates the field)
+  and must not name the candidate being removed. It cannot remove the incumbent.
+
+Absence is only evidence when it comes from a source that demonstrably has the
+roster. A page that failed to load, returned nothing, or was truncated is not
+proof of absence, which is why the two-corroborating-names rule exists.
+
+Page fetches that hit bot protection retry through the Jina Reader text proxy.
+Set `JINA_API_KEY` for the authenticated quota — the anonymous quota is shared
+and low, and once spent it answers 403 for every host, which silently strands all
+roster evidence at snippet (tier 3). A run whose proxy fetches all fail logs a
+single explicit outage warning rather than one indistinguishable error per URL.
+
 Logical runs enforce both global and phase search/token ceilings. They also cap
 uncached page fetches and fetched characters, and persist per-phase
 token/provider/search/page attribution across continuation handoffs. Defaults

--- a/pipeline_client/agent/ballotpedia.py
+++ b/pipeline_client/agent/ballotpedia.py
@@ -17,6 +17,8 @@ from urllib.parse import quote, quote_plus
 
 import httpx
 
+from pipeline_client.agent.web_tools import text_proxy_headers, text_proxy_url
+
 logger = logging.getLogger("pipeline")
 
 _BROWSER_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
@@ -150,8 +152,8 @@ async def lookup_candidate_data(candidate_name: str) -> Dict[str, Any]:
             html = resp.text
             if _is_unusable_ballotpedia_html(html):
                 proxy_resp = await client.get(
-                    f"https://r.jina.ai/{page_url}",
-                    headers={"User-Agent": _BROWSER_UA},
+                    text_proxy_url(page_url),
+                    headers=text_proxy_headers(),
                 )
                 if proxy_resp.status_code == 200 and not _is_unusable_ballotpedia_html(proxy_resp.text):
                     html = proxy_resp.text
@@ -740,8 +742,8 @@ async def lookup_election_page(race_id: str) -> Dict[str, Any]:
                     resp.status_code,
                 )
                 proxy_resp = await client.get(
-                    f"https://r.jina.ai/{page_url}",
-                    headers={"User-Agent": _BROWSER_UA},
+                    text_proxy_url(page_url),
+                    headers=text_proxy_headers(),
                     timeout=15,
                 )
                 if proxy_resp.status_code == 200 and not _is_unusable_ballotpedia_html(proxy_resp.text):

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -98,34 +98,94 @@ def _source_supports_exact_contest(source: Dict[str, Any], *, race_id: str) -> b
     return federal_house and exact_district
 
 
+def _source_is_current_cycle(source: Dict[str, Any], *, race_id: str, text: str) -> bool:
+    """Check a source belongs to this race's cycle, by publish date or explicit year."""
+    year_match = re.search(r"(?:19|20)\d{2}", race_id)
+    if not year_match:
+        return True
+    valid_years = {int(year_match.group()) - 1, int(year_match.group())}
+    try:
+        published_year = datetime.fromisoformat(str(source.get("published_at") or "").replace("Z", "+00:00")).year
+    except ValueError:
+        published_year = None
+    if published_year is not None:
+        return published_year in valid_years
+    return any(str(year) in text for year in valid_years)
+
+
+def _source_names_candidate(text: str, candidate_name: str) -> bool:
+    """True when every word of the candidate's name appears in the source text."""
+    name_words = re.findall(r"[a-z0-9]+", candidate_name.casefold())
+    return bool(name_words) and all(word in text for word in name_words)
+
+
 def _source_proves_different_contest(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> bool:
-    """Return true for evidence that places a candidate in a different contest."""
-    parsed_url = urlparse(str(source.get("url") or ""))
+    """Validate that a wrong-contest removal cites real, current, on-topic evidence.
+
+    Deliberately structural. Whether the cited page describes a *different* office
+    is a reading-comprehension judgment, and the model that fetched the page has
+    already made it. Re-deriving it from keyword patterns does not stop a model
+    that wants to fabricate — bogus evidence text matches an office regex just as
+    easily as honest text — it only rejects correctly-reasoned removals whose
+    wording differs, which is how this check previously failed every race that was
+    not a U.S. House contest.
+    """
     if source.get("type") not in {"official", "fec", "campaign", "ballotpedia", "news"}:
         return False
+    parsed_url = urlparse(str(source.get("url") or ""))
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         return False
     text = _roster_source_text(source)
-    name_words = re.findall(r"[a-z0-9]+", candidate_name.casefold())
-    if not name_words or not all(word in text for word in name_words):
+    if not _source_names_candidate(text, candidate_name):
         return False
-    if re.fullmatch(r"[a-z]{2}-house-\d{1,2}-(?:19|20)\d{2}", race_id):
-        candidate_pos = text.find(candidate_name.casefold())
-        candidate_context = (
-            text[max(0, candidate_pos - 180) : candidate_pos + len(candidate_name) + 80] if candidate_pos >= 0 else text
-        )
-        state_house = bool(
-            re.search(r"\bstate\s+(?:house|representative)", candidate_context)
-            or re.search(
-                r"\b[a-z ]+\s+house of representatives[\s,]+(?:district|hd)\b",
-                candidate_context,
-            )
-        )
-        # Candidate-specific evidence often says "state House, not U.S. House".
-        # The target-office phrase is negated there, so global keyword matching
-        # must not turn valid wrong-contest proof into exact-contest evidence.
-        return state_house
-    return False
+    return _source_is_current_cycle(source, race_id=race_id, text=text)
+
+
+def _source_omits_candidate_from_roster(
+    source: Dict[str, Any],
+    *,
+    candidate_name: str,
+    race_id: str,
+    other_roster_names: list[str],
+) -> bool:
+    """Return true when a roster listing for THIS race enumerates the field and omits the candidate.
+
+    Absence of evidence is only meaningful from a source that demonstrably *has*
+    the roster, so this requires the listing to name at least two other candidates
+    currently on the profile. That is what separates a real "never in this race"
+    finding from a blocked, empty, or truncated page — the failure mode that
+    otherwise deletes real candidates.
+    """
+    if source.get("type") not in {"official", "fec", "ballotpedia", "news"}:
+        return False
+    parsed_url = urlparse(str(source.get("url") or ""))
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        return False
+    if source.get("race_id") != race_id or not source.get("evidence"):
+        return False
+    if not _source_supports_exact_contest(source, race_id=race_id):
+        return False
+
+    text = _roster_source_text(source)
+    if not _source_is_current_cycle(source, race_id=race_id, text=text):
+        return False
+
+    # The candidate must be genuinely absent. Matching on *any* name word would
+    # trip over a shared first name ("Justin Maldonado" vs. "Justin Murphy" in the
+    # same listing), so treat them as present when the full name appears or when
+    # their surname does — the discriminating token, and the conservative choice.
+    name_words = [word for word in re.findall(r"[a-z0-9]+", candidate_name.casefold()) if len(word) > 2]
+    if not name_words:
+        return False
+    if all(word in text for word in name_words) or name_words[-1] in text:
+        return False
+
+    corroborating = 0
+    for other in other_roster_names:
+        other_words = [word for word in re.findall(r"[a-z0-9]+", other.casefold()) if len(word) > 2]
+        if other_words and all(word in text for word in other_words):
+            corroborating += 1
+    return corroborating >= 2
 
 
 def _normalize_source(source: Any, *, default_type: str = "finance") -> Dict[str, Any] | None:
@@ -519,18 +579,60 @@ def _make_editing_handlers(
         name = args["name"]
         reason = args.get("reason", "").strip()
         candidates = race_json.get("candidates", [])
-        if args.get("wrong_contest") is True:
+        if args.get("wrong_contest") is True or args.get("not_on_roster") is True:
             race_id = str(race_json.get("id") or "").strip()
-            proof = [
+            not_on_roster = args.get("not_on_roster") is True and args.get("wrong_contest") is not True
+            normalized_sources = [
                 source
                 for source in (_normalize_roster_source(item, race_id=race_id) for item in args.get("sources") or [])
-                if source and _source_proves_different_contest(source, candidate_name=name, race_id=race_id)
+                if source
             ]
-            if not proof:
-                return (
-                    f"ERROR: wrong-contest removal blocked for '{name}'. Provide a current source that names the "
-                    "candidate and explicitly identifies the different office/district."
-                )
+
+            if not_on_roster:
+                target = _find_candidate(name)
+                if isinstance(target, dict) and target.get("incumbent") is True:
+                    return (
+                        f"ERROR: roster-absence removal blocked for '{name}': they are recorded as the incumbent. "
+                        "An incumbent missing from one listing is far more likely a bad snippet than a phantom "
+                        "candidate. Use a withdrawal/retirement reason with a dated source instead."
+                    )
+                other_roster_names = [
+                    str(candidate.get("name") or "")
+                    for candidate in candidates
+                    if isinstance(candidate, dict) and candidate.get("name") and candidate.get("name") != name
+                ]
+                proof = [
+                    source
+                    for source in normalized_sources
+                    if _source_omits_candidate_from_roster(
+                        source,
+                        candidate_name=name,
+                        race_id=race_id,
+                        other_roster_names=other_roster_names,
+                    )
+                ]
+                if not proof:
+                    return (
+                        f"ERROR: roster-absence removal blocked for '{name}'. Cite the best roster listing you have "
+                        "for this exact race and cycle — an official/certified candidate list, or the current "
+                        "Ballotpedia election page. Its evidence text must name at least two other candidates who "
+                        "are on this profile (proving the listing actually loaded and enumerates the field) and "
+                        f"must not mention '{name}'. A blocked, empty, or truncated page is not evidence of absence."
+                    )
+                label = "unlisted"
+            else:
+                proof = [
+                    source
+                    for source in normalized_sources
+                    if _source_proves_different_contest(source, candidate_name=name, race_id=race_id)
+                ]
+                if not proof:
+                    return (
+                        f"ERROR: wrong-contest removal blocked for '{name}'. Provide a current source that names the "
+                        "candidate and explicitly identifies the different office/district."
+                    )
+                label = "wrong-contest"
+
             active_after = [
                 candidate
                 for candidate in candidates
@@ -540,14 +642,14 @@ def _make_editing_handlers(
                 and candidate.get("withdrawn") is not True
             ]
             if not active_after:
-                return f"ERROR: wrong-contest removal blocked. Add the verified correct roster before removing '{name}'."
+                return f"ERROR: {label} removal blocked. Add the verified correct roster before removing '{name}'."
             original_count = len(candidates)
             race_json["candidates"] = [
                 candidate for candidate in candidates if not isinstance(candidate, dict) or candidate.get("name") != name
             ]
             if len(race_json["candidates"]) < original_count:
-                log("info", f"    Removed wrong-contest candidate: {name} ({reason or proof[0].get('url')})")
-                return f"Removed wrong-contest candidate '{name}' from the active roster."
+                log("info", f"    Removed {label} candidate: {name} ({reason or proof[0].get('url')})")
+                return f"Removed {label} candidate '{name}' from the active roster."
             return f"Candidate '{name}' not found - no action taken."
 
         # Guard: reject removals that are clearly data-quality fixes rather than
@@ -625,8 +727,20 @@ def _make_editing_handlers(
             )
         )
         has_former_officeholder_signal = has_former_status_signal and has_not_current_signal
+        # Evidence outranks phrasing. The keyword scans below grade English prose,
+        # which reliably rejects correct removals that happen to be worded
+        # differently. When the caller cites a real, current-cycle source that names
+        # this candidate, that citation is the stronger signal — accept it and let
+        # the reason text be prose rather than an incantation.
+        cited_race_id = str(race_json.get("id") or "").strip()
+        has_cited_evidence = any(
+            _source_proves_different_contest(source, candidate_name=name, race_id=cited_race_id)
+            for source in (_normalize_roster_source(item, race_id=cited_race_id) for item in args.get("sources") or [])
+            if source
+        )
         has_withdrawal_signal = (
-            has_exit_signal
+            has_cited_evidence
+            or has_exit_signal
             or has_former_officeholder_signal
             # A specific date *or* an explicit official-result citation is enough
             # corroboration for a primary loss; requiring both rejected reasons like
@@ -654,8 +768,9 @@ def _make_editing_handlers(
                 f"contest with an official result source and date, OR is a former officeholder / "
                 f"prior-cycle candidate who is not a candidate this cycle — state that explicitly "
                 f"(e.g. 'former U.S. Representative who left office in 2023 and is not a candidate "
-                f"in 2026'). Do NOT use this tool because a page has no listing or to fix data "
-                f"quality issues."
+                f"in 2026'). If instead you found no evidence this person was ever a candidate here, "
+                f"call remove_candidate with not_on_roster=true and cite the roster listing for this "
+                f"race that enumerates the field without them. Do NOT use this tool to fix data quality issues."
             )
 
         if is_structural_garbage:

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -1136,6 +1136,11 @@ IMPORTANT — remove_candidate rules:
   name + primary results before deciding, and keep them if uncertainty remains.
 - Do NOT infer winners or losers from an empty/stale Ballotpedia page, a missing
   candidate listing, or a generated Ballotpedia URL that fails to load.
+- If a name in the profile has no evidence of candidacy anywhere AND your best
+  roster listing for this exact race lists the other candidates without them,
+  remove them with not_on_roster=true and cite that listing. This is the correct
+  path for phantom entries — do not force it into a withdrawal reason, and do not
+  use it when the listing failed to load, came back empty, or was truncated.
 - Treat articles and candidate pages published before a completed primary as
   historical evidence, not proof that the person remains active as of
   {current_date}. Verify primary outcomes before adding anyone from an older

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -187,7 +187,12 @@ REMOVE_CANDIDATE_TOOL: Dict = {
     "type": "function",
     "function": {
         "name": "remove_candidate",
-        "description": "Remove a candidate who exited this race or was proven to belong to a different contest.",
+        "description": (
+            "Remove a candidate. Three paths: (1) they exited this race — give a reason naming the "
+            "withdrawal, disqualification, or dated primary loss; (2) wrong_contest=true — evidence puts "
+            "them in a different office/district; (3) not_on_roster=true — they never were a candidate "
+            "here, evidenced by a roster listing for this race that enumerates the field without them."
+        ),
         "parameters": {
             "type": "object",
             "properties": {
@@ -197,9 +202,22 @@ REMOVE_CANDIDATE_TOOL: Dict = {
                     "type": "boolean",
                     "description": "True only when current evidence proves this entry belongs to another office/district.",
                 },
+                "not_on_roster": {
+                    "type": "boolean",
+                    "description": (
+                        "True when no evidence supports this candidacy and the best roster listing you have for "
+                        "this exact race omits them. Cite that listing in `sources`: its evidence text must name "
+                        "at least two other candidates on this profile and must not mention the removed name. "
+                        "A page that failed to load, returned nothing, or was truncated does not qualify. "
+                        "Cannot be used on the incumbent."
+                    ),
+                },
                 "sources": {
                     "type": "array",
-                    "description": "Current evidence proving a wrong-contest entry belongs to another exact contest.",
+                    "description": (
+                        "Evidence for the removal: a wrong-contest proof, or (with not_on_roster) the roster "
+                        "listing for this race that enumerates the field without the candidate."
+                    ),
                     "items": {
                         "type": "object",
                         "properties": {

--- a/pipeline_client/agent/web_tools.py
+++ b/pipeline_client/agent/web_tools.py
@@ -270,6 +270,59 @@ def _get_fetch_client() -> httpx.AsyncClient:
     return client
 
 
+TEXT_PROXY_BASE = "https://r.jina.ai/"
+
+# Anonymous r.jina.ai is aggressively rate limited and answers 403/429 once the
+# shared quota is spent — which looks identical to "the site blocked us" at every
+# call site. Configure JINA_API_KEY to get the authenticated quota.
+_proxy_attempts = 0
+_proxy_failures = 0
+_proxy_outage_logged = False
+
+
+def text_proxy_url(url: str) -> str:
+    return f"{TEXT_PROXY_BASE}{url}"
+
+
+def text_proxy_headers() -> Dict[str, str]:
+    headers = {"User-Agent": _BROWSER_UA}
+    api_key = os.environ.get("JINA_API_KEY", "").strip()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def record_proxy_result(*, ok: bool) -> None:
+    """Track proxy health so a systemic outage is visible instead of silent.
+
+    Every roster/evidence path degrades to unsourced guesses when the proxy is
+    down, so a run that never lands a single proxy fetch should say so loudly
+    rather than emit one indistinguishable per-URL failure at a time.
+    """
+    global _proxy_attempts, _proxy_failures, _proxy_outage_logged
+    _proxy_attempts += 1
+    if not ok:
+        _proxy_failures += 1
+    if (
+        not _proxy_outage_logged
+        and _proxy_attempts >= 5
+        and _proxy_failures == _proxy_attempts
+        and not os.environ.get("JINA_API_KEY", "").strip()
+    ):
+        _proxy_outage_logged = True
+        logger.warning(
+            "Text proxy (%s) has failed all %d attempts this run. Anonymous quota is likely exhausted; "
+            "set JINA_API_KEY so page fetches can reach retrievable (tier 1/2) evidence instead of "
+            "falling back to search snippets.",
+            TEXT_PROXY_BASE,
+            _proxy_attempts,
+        )
+
+
+def proxy_health_snapshot() -> Dict[str, int]:
+    return {"attempts": _proxy_attempts, "failures": _proxy_failures}
+
+
 def _get_serper_client() -> httpx.AsyncClient:
     """Return a per-event-loop AsyncClient for Serper API calls."""
     loop_id = id(asyncio.get_running_loop())
@@ -338,10 +391,11 @@ async def _fetch_page(url: str) -> str:
             # short pages, opportunistically try the proxy and prefer richer content.
             if len(text.strip()) < _PAGE_PROXY_RETRY_CHARS:
                 try:
-                    proxy_url = f"https://r.jina.ai/{url}"
-                    proxy_resp = await _get_validated(client, proxy_url)
+                    proxy_url = text_proxy_url(url)
+                    proxy_resp = await _get_validated(client, proxy_url, headers=text_proxy_headers())
                     proxy_resp.raise_for_status()
                     proxy_text = proxy_resp.text.strip()
+                    record_proxy_result(ok=not _is_unusable_page_text(proxy_text))
                     if (not _is_unusable_page_text(proxy_text)) and (len(proxy_text) > len(text) + 200):
                         if len(proxy_text) > _PAGE_MAX_CHARS:
                             proxy_text = proxy_text[:_PAGE_MAX_CHARS] + f"\n\n[...truncated at {_PAGE_MAX_CHARS} chars]"
@@ -350,6 +404,7 @@ async def _fetch_page(url: str) -> str:
                             cache.set_page(url, proxy_text)
                         return proxy_text
                 except Exception as exc:
+                    record_proxy_result(ok=False)
                     failure_reasons.append(f"short-page proxy probe: {exc}")
 
             if len(text) > _PAGE_MAX_CHARS:
@@ -362,11 +417,12 @@ async def _fetch_page(url: str) -> str:
             failure_reasons.append(str(exc))
 
     # Fallback: jina text proxy often succeeds when direct fetches hit bot checks.
-    proxy_url = f"https://r.jina.ai/{url}"
+    proxy_url = text_proxy_url(url)
     try:
-        proxy_resp = await _get_validated(client, proxy_url)
+        proxy_resp = await _get_validated(client, proxy_url, headers=text_proxy_headers())
         proxy_resp.raise_for_status()
         proxy_text = proxy_resp.text.strip()
+        record_proxy_result(ok=not _is_unusable_page_text(proxy_text))
         if not _is_unusable_page_text(proxy_text):
             if len(proxy_text) > _PAGE_MAX_CHARS:
                 proxy_text = proxy_text[:_PAGE_MAX_CHARS] + f"\n\n[...truncated at {_PAGE_MAX_CHARS} chars]"
@@ -376,6 +432,7 @@ async def _fetch_page(url: str) -> str:
             return proxy_text
         failure_reasons.append("proxy_unusable_content")
     except Exception as exc:
+        record_proxy_result(ok=False)
         failure_reasons.append(f"proxy: {exc}")
 
     # Campaign issue pages are often blocked while other site pages remain accessible.
@@ -999,9 +1056,9 @@ async def get_homepage_policy_links(homepage_url: str) -> List[str]:
         html_content = resp.text
     except Exception as exc:
         # Fallback to Jina Reader proxy
-        proxy_url = f"https://r.jina.ai/{homepage_url}"
+        proxy_url = text_proxy_url(homepage_url)
         try:
-            proxy_resp = await _get_validated(client, proxy_url)
+            proxy_resp = await _get_validated(client, proxy_url, headers=text_proxy_headers())
             proxy_resp.raise_for_status()
             # If jina returns markdown, extract links using markdown regex [text](url)
             markdown = proxy_resp.text or ""

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1427,3 +1427,160 @@ def test_blocked_roster_edit_names_the_failing_check():
         }
     )
     assert "candidate name" in wrong_name.lower()
+
+
+# ---------------------------------------------------------------------------
+# Roster-absence removal ("never was a candidate here")
+# ---------------------------------------------------------------------------
+
+
+def _nj_roster_race():
+    return {
+        "id": "nj-senate-2026",
+        "state": "New Jersey",
+        "office": "U.S. Senate",
+        "candidates": [
+            {"name": "Cory Booker", "party": "Democratic", "incumbent": True},
+            {"name": "Justin Murphy", "party": "Republican"},
+            {"name": "Veronica Fernandez", "party": "Independent"},
+            {"name": "Justin Maldonado", "party": "Unknown"},
+        ],
+    }
+
+
+def _nj_roster_listing():
+    """A real Ballotpedia race-page snippet that enumerates the field."""
+    return {
+        "url": "https://ballotpedia.org/United_States_Senate_election_in_New_Jersey,_2026",
+        "type": "ballotpedia",
+        "title": "United States Senate election in New Jersey, 2026",
+        "text": (
+            "Incumbent Cory Booker, Justin Murphy, Veronica Fernandez, and Joanne Kuniansky are "
+            "running in the general election for U.S. Senate New Jersey on November 3, 2026"
+        ),
+        "retrieved": "2026-08-01",
+    }
+
+
+def test_not_on_roster_removes_phantom_candidate_with_roster_listing():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    result = handlers["remove_candidate"](
+        {
+            "name": "Justin Maldonado",
+            "reason": "No evidence of candidacy; absent from the race roster listing.",
+            "not_on_roster": True,
+            "sources": [_nj_roster_listing()],
+        }
+    )
+
+    assert "unlisted" in result
+    assert "Justin Maldonado" not in [candidate["name"] for candidate in race_json["candidates"]]
+
+
+def test_not_on_roster_rejects_a_listing_that_does_not_enumerate_the_field():
+    """A blocked or truncated page must not read as proof of absence."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    empty_page = _nj_roster_listing() | {
+        "text": "United States Senate election in New Jersey, 2026. Please enable JavaScript."
+    }
+
+    result = handlers["remove_candidate"](
+        {"name": "Justin Maldonado", "reason": "Not found anywhere.", "not_on_roster": True, "sources": [empty_page]}
+    )
+
+    assert "blocked" in result.lower()
+    assert "Justin Maldonado" in [candidate["name"] for candidate in race_json["candidates"]]
+
+
+def test_not_on_roster_rejects_a_listing_that_names_the_candidate():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    listing = _nj_roster_listing()
+    listing["text"] = listing["text"].replace("Joanne Kuniansky", "Justin Maldonado")
+
+    result = handlers["remove_candidate"](
+        {"name": "Justin Maldonado", "reason": "No evidence.", "not_on_roster": True, "sources": [listing]}
+    )
+
+    assert "blocked" in result.lower()
+    assert "Justin Maldonado" in [candidate["name"] for candidate in race_json["candidates"]]
+
+
+def test_not_on_roster_refuses_to_remove_the_incumbent():
+    """An incumbent missing from one snippet is a bad snippet, not a phantom."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    listing = _nj_roster_listing()
+    listing["text"] = "Justin Murphy, Veronica Fernandez, and Joanne Kuniansky are running in 2026"
+
+    result = handlers["remove_candidate"](
+        {"name": "Cory Booker", "reason": "Absent from listing.", "not_on_roster": True, "sources": [listing]}
+    )
+
+    assert "incumbent" in result.lower()
+    assert "Cory Booker" in [candidate["name"] for candidate in race_json["candidates"]]
+
+
+def test_wrong_contest_removal_works_for_non_house_races():
+    """Wrong-contest proof was previously impossible for anything but a U.S. House race."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    result = handlers["remove_candidate"](
+        {
+            "name": "Justin Maldonado",
+            "reason": "Official filing list places him in the New Jersey General Assembly race, not U.S. Senate.",
+            "wrong_contest": True,
+            "sources": [
+                {
+                    "url": "https://www.nj.gov/state/elections/2026-candidates.html",
+                    "title": "2026 Certified Candidates",
+                    "text": "General Assembly District 24 - Justin Maldonado",
+                    "published_at": "2026-06-10",
+                }
+            ],
+        }
+    )
+
+    assert "wrong-contest" in result
+    assert "Justin Maldonado" not in [candidate["name"] for candidate in race_json["candidates"]]
+
+
+def test_cited_evidence_waives_the_withdrawal_keyword_scan():
+    """A real current-cycle source naming the candidate beats prose phrasing."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    result = handlers["remove_candidate"](
+        {
+            "name": "Justin Maldonado",
+            # Deliberately avoids every _EXIT_KEYWORDS phrase.
+            "reason": "His campaign ended before the filing deadline.",
+            "sources": [
+                {
+                    "url": "https://newjerseyglobe.com/congress/maldonado-ends-bid/",
+                    "type": "news",
+                    "title": "Justin Maldonado ends U.S. Senate bid",
+                    "text": "Justin Maldonado will not appear on the 2026 ballot.",
+                    "published_at": "2026-06-10",
+                }
+            ],
+        }
+    )
+
+    assert "withdrawn" in result.lower()

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -631,3 +631,59 @@ async def test_fetch_page_sitemap_blocked_falls_back_to_homepage_crawl():
     assert "Recovered issue-related content" in result
     assert "healthcare" in result.lower()
     assert "economy" in result.lower()
+
+
+def test_text_proxy_headers_include_api_key_when_configured(monkeypatch):
+    """Anonymous r.jina.ai quota exhaustion looks identical to a site block at every call site."""
+    from pipeline_client.agent import web_tools
+
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    assert "Authorization" not in web_tools.text_proxy_headers()
+
+    monkeypatch.setenv("JINA_API_KEY", "test-key")
+    assert web_tools.text_proxy_headers()["Authorization"] == "Bearer test-key"
+
+
+def test_text_proxy_url_is_unchanged():
+    from pipeline_client.agent import web_tools
+
+    assert web_tools.text_proxy_url("https://ballotpedia.org/X") == "https://r.jina.ai/https://ballotpedia.org/X"
+
+
+def test_total_proxy_failure_is_logged_once(monkeypatch, caplog):
+    """A run where every proxy fetch fails must say so, not emit N look-alike per-URL errors."""
+    import logging
+
+    from pipeline_client.agent import web_tools
+
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    monkeypatch.setattr(web_tools, "_proxy_attempts", 0)
+    monkeypatch.setattr(web_tools, "_proxy_failures", 0)
+    monkeypatch.setattr(web_tools, "_proxy_outage_logged", False)
+
+    with caplog.at_level(logging.WARNING, logger=web_tools.logger.name):
+        for _ in range(8):
+            web_tools.record_proxy_result(ok=False)
+
+    outage_warnings = [record for record in caplog.records if "has failed all" in record.getMessage()]
+    assert len(outage_warnings) == 1
+    assert "JINA_API_KEY" in outage_warnings[0].getMessage()
+    assert web_tools.proxy_health_snapshot() == {"attempts": 8, "failures": 8}
+
+
+def test_proxy_success_prevents_outage_warning(monkeypatch, caplog):
+    import logging
+
+    from pipeline_client.agent import web_tools
+
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    monkeypatch.setattr(web_tools, "_proxy_attempts", 0)
+    monkeypatch.setattr(web_tools, "_proxy_failures", 0)
+    monkeypatch.setattr(web_tools, "_proxy_outage_logged", False)
+
+    with caplog.at_level(logging.WARNING, logger=web_tools.logger.name):
+        web_tools.record_proxy_result(ok=True)
+        for _ in range(8):
+            web_tools.record_proxy_result(ok=False)
+
+    assert not [record for record in caplog.records if "has failed all" in record.getMessage()]


### PR DESCRIPTION
## What changed

- add a guarded not-on-roster removal path for phantom candidate entries
- require a loaded exact-race roster that names at least two other known candidates and never remove the incumbent by absence alone
- authenticate Jina Reader proxy requests when JINA_API_KEY is configured and expose proxy-health warnings
- centralize proxy URL/header handling across general fetches and Ballotpedia
- document roster removal evidence rules and text-proxy setup

## Why

The roster agent could identify phantom entries but had no safe removal path unless it forced the evidence into withdrawal or wrong-contest semantics. Separately, anonymous text-proxy quota exhaustion silently reduced all page evidence to snippets.

## Validation

- 171 focused roster, agent-loop, Ballotpedia, and web-tool tests
- Black and isort checks
- git diff whitespace check
