### PR TITLE
Deploy Jina API key to pipeline jobs

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -156,6 +156,7 @@ jobs:
       TF_VAR_openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
       TF_VAR_serper_api_key: ${{ secrets.SERPER_API_KEY }}
       TF_VAR_searlo_api_key: ${{ secrets.SEARLO_API_KEY }}
+      TF_VAR_jina_api_key: ${{ secrets.JINA_API_KEY }}
       TF_VAR_admin_api_key: ${{ secrets.ADMIN_API_KEY }}
       TF_VAR_stripe_secret_key: ${{ secrets.STRIPE_SECRET_KEY }}
       TF_VAR_stripe_webhook_secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
@@ -237,6 +238,7 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
           SEARLO_API_KEY: ${{ secrets.SEARLO_API_KEY }}
+          JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
@@ -265,6 +267,7 @@ jobs:
           sync_secret "openrouter-api-key-${{ env.ENVIRONMENT }}" "$OPENROUTER_API_KEY"
           sync_secret "serper-api-key-${{ env.ENVIRONMENT }}"   "$SERPER_API_KEY"
           sync_secret "searlo-api-key-${{ env.ENVIRONMENT }}"   "$SEARLO_API_KEY"
+          sync_secret "jina-api-key-${{ env.ENVIRONMENT }}"     "$JINA_API_KEY"
           sync_secret "races-api-admin-key-${{ env.ENVIRONMENT }}" "$ADMIN_API_KEY"
           sync_secret "stripe-secret-key-${{ env.ENVIRONMENT }}" "$STRIPE_SECRET_KEY"
           sync_secret "stripe-webhook-secret-${{ env.ENVIRONMENT }}" "$STRIPE_WEBHOOK_SECRET"

--- a/infra/README.md
+++ b/infra/README.md
@@ -34,6 +34,7 @@ region     = "us-central1"
 openrouter_api_key = "sk-or-your-openrouter-key"
 serper_api_key     = "your-serper-key"
 searlo_api_key     = "your-searlo-key"
+jina_api_key       = "your-jina-key"
 admin_api_key      = "long-random-admin-key"
 
 ```

--- a/infra/pipeline-job.tf
+++ b/infra/pipeline-job.tf
@@ -96,6 +96,15 @@ resource "google_cloud_run_v2_job" "pipeline" {
             }
           }
         }
+        env {
+          name = "JINA_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.jina_key.secret_id
+              version = "latest"
+            }
+          }
+        }
 
         resources {
           limits = {

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -41,6 +41,27 @@ resource "google_secret_manager_secret_version" "searlo_key" {
   }
 }
 
+resource "google_secret_manager_secret" "jina_key" {
+  project   = var.project_id
+  secret_id = "jina-api-key-${var.environment}"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "jina_key" {
+  count       = var.jina_api_key != "" ? 1 : 0
+  secret      = google_secret_manager_secret.jina_key.id
+  secret_data = var.jina_api_key
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
 # Service accounts for the same project
 resource "google_service_account" "races_api" {
   project      = var.project_id

--- a/infra/secrets.tfvars.example
+++ b/infra/secrets.tfvars.example
@@ -11,6 +11,7 @@ environment = "dev"  # dev, staging, or prod
 openrouter_api_key = "sk-or-your-openrouter-api-key"
 serper_api_key     = "your-serper-api-key"
 searlo_api_key     = "your-searlo-api-key"
+jina_api_key       = "your-jina-api-key"
 
 # Races API admin key - protects /analytics/* endpoints (leave empty to disable auth)
 admin_api_key = ""

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -38,6 +38,13 @@ variable "searlo_api_key" {
   default     = ""
 }
 
+variable "jina_api_key" {
+  description = "Jina Reader API key for authenticated page-fetch proxy quota"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # Deployment and versioning variables
 variable "app_version" {
   description = "Application version for tracking updates"


### PR DESCRIPTION
## What changed

- create the environment-scoped Jina API key in Secret Manager
- expose it to the pipeline Cloud Run job
- synchronize it from the Terraform deployment workflow
- document Terraform variable setup

## Why

The authenticated text-proxy support merged in #219 needs a deployable secret path; without this wiring production jobs would continue using anonymous quota.

## Validation

- Terraform init and validate
- recursive Terraform format check
- workflow YAML parse
- git diff whitespace check
