### PR TITLE
Require roster completeness evidence

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -192,9 +192,14 @@ stronger roster fallback and directs it to obtain higher-priority evidence
 instead of repeating the same invalid payload.
 Roster sync receives the run goal and cannot end successfully until it calls
 `finalize_roster`; that gate requires a locked contest identity plus qualifying
-current-cycle exact-contest evidence for every active candidate. If the gate
-does not pass, the run stops before images, polling, and forecast work and keeps
-`discovery` visibly incomplete for a retry.
+current-cycle exact-contest evidence for every active candidate. It separately
+requires retrieved completeness evidence quoting a qualified, certified, or
+official-ballot list that names every active candidate; candidate-by-candidate
+proof alone cannot establish that nobody was omitted. Special-election evidence
+must identify the special contest and its verified date. Successful finalization
+persists this audit under `pipeline_state.roster_research`. If the gate does not
+pass, the run stops before images, polling, and forecast work and keeps `discovery`
+visibly incomplete for a retry.
 
 Roster authority order is: official election authority/certified ballot or
 result; official party qualification list when the party administers primary

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -380,6 +380,52 @@ def _roster_source_rejection_summary(sources: Any, *, candidate_name: str, race_
     return "; ".join(reasons)
 
 
+def _roster_completeness_source_rejection_reason(
+    source: Dict[str, Any], *, race_id: str, identity: Dict[str, Any]
+) -> str | None:
+    """Validate evidence that describes the roster as a whole, not one member."""
+    if source.get("type") not in {"official", "news"}:
+        return "completeness evidence must be an official roster/ballot or retrieved news report"
+    parsed_url = urlparse(str(source.get("url") or ""))
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        return "source needs an absolute http(s) url"
+    if source.get("race_id") != race_id:
+        return f"source race_id {str(source.get('race_id'))!r} does not match this race ({race_id!r})"
+    if not source.get("title") or not source.get("evidence"):
+        return "source needs a title and evidence quoting the complete candidate list"
+    if not _source_supports_exact_contest(source, race_id=race_id):
+        return "evidence does not name this exact contest and district"
+    if source.get("retrieval_status") != "content" or source.get("evidence_tier") not in {1, 2}:
+        return "completeness evidence must come from retrieved page content, not a search snippet"
+
+    text = _roster_source_text(source)
+    if not re.search(r"\b(?:qualified|certified|official ballot|candidate list|candidates? running|vote for one)\b", text):
+        return "evidence does not identify itself as a qualified, certified, ballot, or complete candidate list"
+
+    primary_status = str(identity.get("primary_status") or "")
+    if "special" in primary_status.casefold():
+        if "special" not in text:
+            return "race identity is a special election, but the source does not identify the special contest"
+        election_date = str(identity.get("election_date") or "")
+        try:
+            parsed_date = datetime.fromisoformat(election_date).date()
+        except ValueError:
+            parsed_date = None
+        if parsed_date:
+            month = parsed_date.strftime("%B").casefold()
+            numeric_dates = {
+                parsed_date.isoformat(),
+                f"{parsed_date.month}/{parsed_date.day}/{parsed_date.year}",
+                f"{parsed_date.month:02d}/{parsed_date.day:02d}/{parsed_date.year}",
+            }
+            has_date = any(value in text for value in numeric_dates) or bool(
+                re.search(rf"\b{month}\s+{parsed_date.day}(?:st|nd|rd|th)?[,]?\s+{parsed_date.year}\b", text)
+            )
+            if not has_date:
+                return f"source does not identify the special-election date {parsed_date.isoformat()}"
+    return None
+
+
 def _get_other_state_candidates(race_id: str, state: str | None) -> set[str]:
     """Retrieve candidate names from other races in the same state/cycle to detect contamination."""
     other_names = set()
@@ -901,7 +947,52 @@ def _make_editing_handlers(
         if not isinstance(identity, dict) or not identity.get("office") or not identity.get("contest_stage"):
             return "ERROR: roster finalization blocked. Lock the exact office and contest stage with set_race_identity."
 
+        completeness_sources = [
+            source
+            for source in (
+                _normalize_roster_source(raw_source, race_id=race_id) for raw_source in args.get("completeness_sources") or []
+            )
+            if source
+        ]
+        completeness_rejections = [
+            reason
+            for source in completeness_sources
+            if (reason := _roster_completeness_source_rejection_reason(source, race_id=race_id, identity=identity))
+        ]
+        qualifying_completeness = [
+            source
+            for source in completeness_sources
+            if _roster_completeness_source_rejection_reason(source, race_id=race_id, identity=identity) is None
+        ]
+        if not qualifying_completeness:
+            detail = "; ".join(completeness_rejections) if completeness_rejections else "no sources were supplied"
+            return (
+                "ERROR: roster finalization blocked. Candidate-level evidence proves membership, not completeness. "
+                "Provide retrieved completeness_sources quoting the authoritative qualified/certified/ballot list "
+                f"for this exact contest ({detail})."
+            )
+
+        combined_evidence = " ".join(_roster_source_text(source) for source in qualifying_completeness)
+        uncovered_names = []
+        for candidate in active_candidates:
+            name = str(candidate.get("name") or "").strip()
+            name_words = re.findall(r"[a-z0-9]+", name.casefold())
+            if not name_words or not all(word in combined_evidence for word in name_words):
+                uncovered_names.append(name)
+        if uncovered_names:
+            return (
+                "ERROR: roster finalization blocked. Completeness evidence does not name every active candidate: "
+                f"{', '.join(uncovered_names)}. Quote the full authoritative list, not candidate-only excerpts."
+            )
+
         summary = str(args.get("summary") or "").strip()
+        pipeline_state = race_json.setdefault("pipeline_state", {})
+        pipeline_state["roster_research"] = {
+            "finalized_at": datetime.now(timezone.utc).isoformat(),
+            "summary": summary,
+            "active_candidate_count": len(active_candidates),
+            "completeness_sources": completeness_sources,
+        }
         log("info", f"    Finalized roster with {len(active_candidates)} active candidate(s): {summary}")
         return f"Roster finalized with {len(active_candidates)} evidence-backed active candidate(s)."
 

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -139,7 +139,9 @@ async def _run_update(
                     required_final_tool_name="finalize_roster",
                     required_final_instruction=(
                         "Do not stop yet. Finish the authoritative exact-contest roster, ensure every active "
-                        "candidate has durable qualifying roster_sources, then call finalize_roster."
+                        "candidate has durable qualifying roster_sources, and provide retrieved completeness_sources "
+                        "that quote the full qualified/certified/ballot list (including the exact date for a special "
+                        "election), then call finalize_roster."
                     ),
                     return_tool_trace=True,
                 )

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -1204,8 +1204,12 @@ official ballot). Never assume a race is uncontested without at least one additi
 search verifying the other party's candidate status.
 
 When you have made all necessary corrections (or confirmed no changes are needed),
-call finalize_roster. It will reject incomplete or weakly sourced rosters and tell
-you exactly which candidate evidence remains to fix. You may stop only after
+call finalize_roster with `completeness_sources` quoting the full qualified,
+certified, or official-ballot list for this exact contest. Candidate-specific
+sources prove that listed people belong; they do not prove nobody was omitted.
+For a special election, the completeness evidence must explicitly identify the
+special contest and its verified date. The tool will reject incomplete or weakly
+sourced rosters and tell you exactly which evidence remains to fix. You may stop only after
 finalize_roster succeeds. Do NOT produce any text reply or JSON.
 Do NOT modify any other data (issues, summaries, polls, etc.)."""
 

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -344,8 +344,9 @@ FINALIZE_ROSTER_TOOL: Dict = {
     "function": {
         "name": "finalize_roster",
         "description": (
-            "Finish roster sync only after every active candidate has durable current-cycle exact-contest evidence. "
-            "The handler validates the roster and returns specific missing evidence to fix."
+            "Finish roster sync only after every active candidate has durable current-cycle exact-contest evidence "
+            "and retrieved authoritative evidence proves the roster itself is complete. The handler validates both "
+            "membership and completeness and returns specific evidence gaps to fix."
         ),
         "parameters": {
             "type": "object",
@@ -353,9 +354,35 @@ FINALIZE_ROSTER_TOOL: Dict = {
                 "summary": {
                     "type": "string",
                     "description": "Brief description of the authoritative roster and contest stage used.",
-                }
+                },
+                "completeness_sources": {
+                    "type": "array",
+                    "description": (
+                        "Retrieved official roster/ballot sources (or retrieved reputable news reports) whose evidence "
+                        "quotes the complete qualified candidate list for this exact contest and names every active candidate."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                            "type": {"type": "string"},
+                            "title": {"type": "string"},
+                            "evidence": {"type": "string"},
+                            "text": {"type": "string"},
+                            "snippet": {"type": "string"},
+                            "context": {"type": "string"},
+                            "retrieved": {"type": "string"},
+                            "date": {"type": "string"},
+                            "published_at": {"type": "string"},
+                            "race_id": {"type": "string"},
+                            "evidence_tier": {"type": "integer", "enum": [1, 2, 3]},
+                            "retrieval_status": {"type": "string", "enum": ["content", "snippet"]},
+                        },
+                        "required": ["url", "title"],
+                    },
+                },
             },
-            "required": ["summary"],
+            "required": ["summary", "completeness_sources"],
         },
     },
 }

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -768,10 +768,70 @@ def test_finalize_roster_requires_evidence_for_every_active_candidate():
     }
     handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
 
-    blocked = handlers["finalize_roster"]({"summary": "Official party lists"})
+    completeness_source = {
+        "url": "https://aldemocrats.org/2026-qualified-candidates",
+        "type": "official",
+        "title": "2026 Qualified Candidates",
+        "evidence": "Qualified candidates for U.S. Representative, 2nd Congressional District: Shomari Figures",
+        "race_id": "al-house-02-2026",
+        "published_at": "2026-02-01",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+
+    blocked = handlers["finalize_roster"]({"summary": "Official party lists", "completeness_sources": [completeness_source]})
     assert "Unverified Candidate" in blocked
     race_json["candidates"].pop()
-    finalized = handlers["finalize_roster"]({"summary": "Official party list"})
+    finalized = handlers["finalize_roster"]({"summary": "Official party list", "completeness_sources": [completeness_source]})
+    assert finalized == "Roster finalized with 1 evidence-backed active candidate(s)."
+    assert race_json["pipeline_state"]["roster_research"]["active_candidate_count"] == 1
+
+
+def test_finalize_roster_requires_exact_special_election_completeness_source():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    candidate_source = {
+        "url": "https://algop.org/qualified-2026-republican-candidates/",
+        "type": "official",
+        "title": "Qualified 2026 Republican Candidates",
+        "evidence": "U.S. Congress Congressional District 2 Hampton Harris",
+        "race_id": "al-house-02-2026",
+        "published_at": "2026-02-01",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House",
+                "contest_stage": "pre_primary",
+                "primary_status": "Special Primary Election on August 11, 2026",
+                "election_date": "2026-08-11",
+            }
+        },
+        "candidates": [{"name": "Hampton Harris", "party": "Republican", "roster_sources": [candidate_source]}],
+    }
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    ordinary = handlers["finalize_roster"]({"summary": "Regular primary list", "completeness_sources": [candidate_source]})
+    assert "special election" in ordinary
+
+    special_source = dict(candidate_source)
+    special_source.update(
+        {
+            "url": "https://algop.org/special-congressional-election-qualified-candidates/",
+            "title": "Special Congressional Election Qualified Candidates",
+            "evidence": (
+                "Qualified candidates for the August 11, 2026 Special Primary Election, U.S. Congress "
+                "Congressional District 2: Hampton Harris"
+            ),
+            "published_at": "2026-05-22",
+        }
+    )
+    finalized = handlers["finalize_roster"](
+        {"summary": "August special primary list", "completeness_sources": [special_source]}
+    )
     assert finalized == "Roster finalized with 1 evidence-backed active candidate(s)."
 
 


### PR DESCRIPTION
## Summary
- distinguish candidate membership evidence from whole-roster completeness evidence
- require exact special-election/date evidence before roster finalization
- persist the successful completeness audit in pipeline state

## Validation
- python -m pytest tests -q (989 passed)
- black/isort checks for touched Python files