### PR TITLE
Bind roster evidence to research trace

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -182,10 +182,13 @@ forecast evidence lineage, and pipeline/validation health. Use
 thumbnail quality matters; presence alone is not treated as verification.
 
 Roster editing tools accept both normalized evidence fields and the native
-`web_search`/model result aliases (`text`, `context`, or `snippet`, plus
+`web_search`/model result aliases (`evidence_text`, `text`, `context`, or `snippet`, plus
 `retrieved` and `date`). The handler preserves those
 as durable evidence, infers only recognizable source classes, and still applies
-current-cycle and exact-contest checks. A blocked/error tool result is surfaced
+current-cycle and exact-contest checks. In production agent loops, the handler
+also cross-checks each cited URL against the loop's actual search/fetch trace;
+model-supplied retrieval metadata cannot promote a URL the run never observed,
+and completeness evidence must have been fetched as page content. A blocked/error tool result is surfaced
 to the model as a failure. After two consecutive blocked edits, roster sync
 keeps the accumulated research but escalates subsequent synthesis to the
 stronger roster fallback and directs it to obtain higher-priority evidence

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -247,7 +247,14 @@ def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any
     url = str(source.get("url") or "").strip() or None
     title = str(source.get("title") or "").strip() or None
     evidence = (
-        str(source.get("evidence") or source.get("text") or source.get("context") or source.get("snippet") or "").strip()
+        str(
+            source.get("evidence")
+            or source.get("evidence_text")
+            or source.get("text")
+            or source.get("context")
+            or source.get("snippet")
+            or ""
+        ).strip()
         or None
     )
     host = urlparse(url or "").netloc.casefold()
@@ -271,6 +278,50 @@ def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any
         normalized["evidence_tier"] = 3
         normalized["retrieval_status"] = "snippet"
     return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _apply_roster_research_provenance(
+    source: Dict[str, Any], research_trace: Any, *, require_fetch: bool = False
+) -> Dict[str, Any] | None:
+    """Grade evidence from URLs the current agent loop actually observed.
+
+    Model-provided ``retrieved`` and tier fields are claims, not provenance. The
+    loop injects its real search/fetch URL trace into editing calls so fabricated
+    citations copied from the goal cannot masquerade as retrieved evidence.
+    Direct handler callers that do not provide a trace retain legacy behavior;
+    production agent loops always provide one.
+    """
+    if not isinstance(research_trace, dict):
+        return source
+
+    def url_key(raw_url: Any) -> str:
+        parsed = urlparse(str(raw_url or "").strip())
+        path = parsed.path.rstrip("/") or "/"
+        return f"{parsed.scheme.casefold()}://{parsed.netloc.casefold()}{path}?{parsed.query}".rstrip("?")
+
+    url = url_key(source.get("url"))
+    researched = {url_key(item) for item in research_trace.get("researched_urls") or []}
+    fetched = {url_key(item) for item in research_trace.get("fetched_urls") or []}
+    if url in fetched:
+        source["retrieval_status"] = "content"
+        source["evidence_tier"] = 1 if source.get("type") in {"official", "fec"} else 2
+        return source
+    if require_fetch or url not in researched:
+        return None
+    source["retrieval_status"] = "snippet"
+    source["evidence_tier"] = 3
+    return source
+
+
+def _normalize_observed_roster_sources(
+    sources: Any, *, race_id: str, research_trace: Any, require_fetch: bool = False
+) -> list[Dict[str, Any]]:
+    normalized = [source for source in (_normalize_roster_source(item, race_id=race_id) for item in sources or []) if source]
+    return [
+        observed
+        for source in normalized
+        if (observed := _apply_roster_research_provenance(source, research_trace, require_fetch=require_fetch))
+    ]
 
 
 def _roster_source_rejection_reason(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> str | None:
@@ -565,11 +616,17 @@ def _make_editing_handlers(
                     f"another race in {state} for this election cycle. A candidate cannot run in multiple concurrent "
                     "statewide or federal contests. Verify the office, district, and candidate name."
                 )
-        roster_sources = _qualifying_candidate_addition_sources(
-            args.get("roster_sources"), candidate_name=name, race_id=race_id
+        supplied_sources = _normalize_observed_roster_sources(
+            args.get("roster_sources"),
+            race_id=race_id,
+            research_trace=args.get("_research_trace"),
         )
+        roster_sources = _qualifying_candidate_addition_sources(supplied_sources, candidate_name=name, race_id=race_id)
         if not roster_sources:
-            detail = _roster_source_rejection_summary(args.get("roster_sources"), candidate_name=name, race_id=race_id)
+            if isinstance(args.get("_research_trace"), dict) and not supplied_sources:
+                detail = "none of the cited URLs appeared in this run's actual search/fetch trace"
+            else:
+                detail = _roster_source_rejection_summary(supplied_sources, candidate_name=name, race_id=race_id)
             log("warning", f"    add_candidate('{name}') BLOCKED: {detail}")
             return (
                 f"Blocked adding '{name}': {detail}. "
@@ -628,11 +685,9 @@ def _make_editing_handlers(
         if args.get("wrong_contest") is True or args.get("not_on_roster") is True:
             race_id = str(race_json.get("id") or "").strip()
             not_on_roster = args.get("not_on_roster") is True and args.get("wrong_contest") is not True
-            normalized_sources = [
-                source
-                for source in (_normalize_roster_source(item, race_id=race_id) for item in args.get("sources") or [])
-                if source
-            ]
+            normalized_sources = _normalize_observed_roster_sources(
+                args.get("sources"), race_id=race_id, research_trace=args.get("_research_trace")
+            )
 
             if not_on_roster:
                 target = _find_candidate(name)
@@ -779,10 +834,12 @@ def _make_editing_handlers(
         # this candidate, that citation is the stronger signal — accept it and let
         # the reason text be prose rather than an incantation.
         cited_race_id = str(race_json.get("id") or "").strip()
+        observed_cited_sources = _normalize_observed_roster_sources(
+            args.get("sources"), race_id=cited_race_id, research_trace=args.get("_research_trace")
+        )
         has_cited_evidence = any(
             _source_proves_different_contest(source, candidate_name=name, race_id=cited_race_id)
-            for source in (_normalize_roster_source(item, race_id=cited_race_id) for item in args.get("sources") or [])
-            if source
+            for source in observed_cited_sources
         )
         has_withdrawal_signal = (
             has_cited_evidence
@@ -871,11 +928,17 @@ def _make_editing_handlers(
         # This candidate is already on the roster, so the corroboration rule that
         # guards *adding* one does not apply — a single valid source is enough to
         # attach evidence to an existing entry.
+        supplied_sources = _normalize_observed_roster_sources(
+            args.get("sources"), race_id=race_id, research_trace=args.get("_research_trace")
+        )
         sources = _qualifying_candidate_addition_sources(
-            args.get("sources"), candidate_name=name, race_id=race_id, require_corroboration=False
+            supplied_sources, candidate_name=name, race_id=race_id, require_corroboration=False
         )
         if not sources:
-            detail = _roster_source_rejection_summary(args.get("sources"), candidate_name=name, race_id=race_id)
+            if isinstance(args.get("_research_trace"), dict) and not supplied_sources:
+                detail = "none of the cited URLs appeared in this run's actual search/fetch trace"
+            else:
+                detail = _roster_source_rejection_summary(supplied_sources, candidate_name=name, race_id=race_id)
             log("warning", f"    set_candidate_roster_sources('{name}') BLOCKED: {detail}")
             return f"ERROR: no usable roster source for '{name}': {detail}."
         c["roster_sources"] = sources
@@ -947,13 +1010,12 @@ def _make_editing_handlers(
         if not isinstance(identity, dict) or not identity.get("office") or not identity.get("contest_stage"):
             return "ERROR: roster finalization blocked. Lock the exact office and contest stage with set_race_identity."
 
-        completeness_sources = [
-            source
-            for source in (
-                _normalize_roster_source(raw_source, race_id=race_id) for raw_source in args.get("completeness_sources") or []
-            )
-            if source
-        ]
+        completeness_sources = _normalize_observed_roster_sources(
+            args.get("completeness_sources"),
+            race_id=race_id,
+            research_trace=args.get("_research_trace"),
+            require_fetch=True,
+        )
         completeness_rejections = [
             reason
             for source in completeness_sources

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -480,6 +480,8 @@ async def _agent_loop(
     required_final_tool_succeeded = False
     consecutive_tool_errors = 0
     tool_errors_escalated = False
+    researched_urls: set[str] = set()
+    fetched_urls: set[str] = set()
     tool_trace = {
         "search_calls": 0,
         "page_fetches": 0,
@@ -674,6 +676,11 @@ async def _agent_loop(
                         timeout_result=[],
                     )
                     log("debug", f"    🔍 got {len(search_results)} results")
+                    for search_result in search_results:
+                        if isinstance(search_result, dict):
+                            result_url = str(search_result.get("url") or search_result.get("link") or "").strip()
+                            if result_url:
+                                researched_urls.add(result_url)
                     messages.append(
                         {
                             "role": "tool",
@@ -718,6 +725,9 @@ async def _agent_loop(
                         timeout_result="[Page fetch timed out; use another source.]",
                     )
                     log("debug", f"    📄 got {len(page_text)} chars")
+                    if page_text and len(page_text) >= 100 and not page_text.lstrip().startswith("["):
+                        fetched_urls.add(url)
+                        researched_urls.add(url)
                     fetch_hint = _page_fetch_log_hint(url, page_text)
                     if fetch_hint:
                         log("warning", f"    📄 {fetch_hint}")
@@ -774,6 +784,10 @@ async def _agent_loop(
                         tool_trace["editing_calls"] += 1
                     args = json.loads(fn.arguments)
                     log("info", f"    🔧 {fn.name}({', '.join(f'{k}={v!r}' for k, v in args.items())})")
+                    args["_research_trace"] = {
+                        "researched_urls": sorted(researched_urls),
+                        "fetched_urls": sorted(fetched_urls),
+                    }
                     try:
                         if fn.name == "read_profile" and context_budget.narrow_phase and args.get("section", "full") == "full":
                             handler_result = (

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -158,6 +158,7 @@ ADD_CANDIDATE_TOOL: Dict = {
                             },
                             "title": {"type": "string"},
                             "evidence": {"type": "string", "description": "Short note explaining what the source confirms."},
+                            "evidence_text": {"type": "string", "description": "Alias for evidence."},
                             "text": {"type": "string", "description": "Search-result evidence text; alias for evidence."},
                             "snippet": {"type": "string", "description": "Search-result snippet; alias for evidence."},
                             "context": {
@@ -225,6 +226,7 @@ REMOVE_CANDIDATE_TOOL: Dict = {
                             "type": {"type": "string", "enum": ["official", "ballotpedia", "fec", "news", "campaign"]},
                             "title": {"type": "string"},
                             "evidence": {"type": "string"},
+                            "evidence_text": {"type": "string", "description": "Alias for evidence."},
                             "text": {"type": "string", "description": "Search-result evidence text; alias for evidence."},
                             "snippet": {"type": "string", "description": "Search-result snippet; alias for evidence."},
                             "context": {
@@ -283,6 +285,7 @@ SET_CANDIDATE_ROSTER_SOURCES_TOOL: Dict = {
                             },
                             "title": {"type": "string"},
                             "evidence": {"type": "string"},
+                            "evidence_text": {"type": "string", "description": "Alias for evidence."},
                             "text": {"type": "string", "description": "Search-result evidence text; alias for evidence."},
                             "snippet": {"type": "string", "description": "Search-result snippet; alias for evidence."},
                             "context": {
@@ -368,6 +371,7 @@ FINALIZE_ROSTER_TOOL: Dict = {
                             "type": {"type": "string"},
                             "title": {"type": "string"},
                             "evidence": {"type": "string"},
+                            "evidence_text": {"type": "string", "description": "Alias for evidence."},
                             "text": {"type": "string"},
                             "snippet": {"type": "string"},
                             "context": {"type": "string"},

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -773,6 +773,51 @@ async def test_agent_loop_reserves_strong_edit_turn_before_forced_finalization()
 
 
 @pytest.mark.asyncio
+async def test_agent_loop_injects_actual_search_and_fetch_urls_into_editing_calls():
+    source_url = "https://elections.example.gov/qualified-candidates"
+    searched = _mock_openai_response(
+        tool_calls=[{"id": "search", "function": {"name": "web_search", "arguments": json.dumps({"query": "roster"})}}]
+    )
+    fetched = _mock_openai_response(
+        tool_calls=[{"id": "fetch", "function": {"name": "fetch_page", "arguments": json.dumps({"url": source_url})}}]
+    )
+    edited = _mock_openai_response(
+        tool_calls=[{"id": "edit", "function": {"name": "set_sources", "arguments": json.dumps({"name": "Alice"})}}]
+    )
+    stopped = _mock_openai_response(content="Done")
+    handler = MagicMock(return_value="OK")
+    edit_tool = {
+        "type": "function",
+        "function": {"name": "set_sources", "description": "Set", "parameters": {"type": "object"}},
+    }
+
+    with (
+        patch("pipeline_client.agent.llm._call_openrouter", new_callable=AsyncMock) as call,
+        patch(
+            "pipeline_client.agent.llm._serper_search",
+            new_callable=AsyncMock,
+            return_value=[{"url": source_url, "title": "Official roster"}],
+        ),
+        patch("pipeline_client.agent.llm._fetch_page", new_callable=AsyncMock, return_value="Official roster " * 20),
+    ):
+        call.side_effect = [searched, fetched, edited, stopped]
+        await _agent_loop(
+            "system",
+            "user",
+            model="google/gemini-2.5-flash",
+            phase_name="roster-provenance",
+            max_iterations=5,
+            tools_mode=True,
+            extra_tools=[edit_tool],
+            extra_tool_handlers={"set_sources": handler},
+        )
+
+    trace = handler.call_args.args[0]["_research_trace"]
+    assert trace["researched_urls"] == [source_url]
+    assert trace["fetched_urls"] == [source_url]
+
+
+@pytest.mark.asyncio
 async def test_agent_loop_escalates_after_repeated_blocked_edits():
     from pipeline_client.agent.model_registry import CHEAP_MODEL, NEMOTRON_ULTRA_MODEL
 

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -740,6 +740,46 @@ def test_add_candidate_accepts_native_search_snippet_alias():
     assert race_json["candidates"][0]["roster_sources"][0]["evidence"].startswith("US Representative")
 
 
+def test_add_candidate_accepts_evidence_text_but_requires_observed_url_in_agent_loop():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {"id": "al-house-02-2026", "state": "Alabama", "candidates": []}
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    source = {
+        "url": "https://algop.org/special-congressional-election-qualified-candidates/",
+        "title": "Special Congressional Election Qualified Candidates",
+        "evidence_text": "2026 U.S. Congress Congressional District 2 qualified candidate Rhett Marques",
+        "retrieved": "2026-08-01",
+    }
+
+    blocked = handlers["add_candidate"](
+        {
+            "name": "Rhett Marques",
+            "party": "Republican",
+            "roster_sources": [source],
+            "_research_trace": {"researched_urls": [], "fetched_urls": []},
+        }
+    )
+    assert "actual search/fetch trace" in blocked
+
+    added = handlers["add_candidate"](
+        {
+            "name": "Rhett Marques",
+            "party": "Republican",
+            "roster_sources": [source],
+            "_research_trace": {
+                "researched_urls": [source["url"].rstrip("/")],
+                "fetched_urls": [],
+            },
+        }
+    )
+    assert added == "Added candidate 'Rhett Marques'."
+    saved = race_json["candidates"][0]["roster_sources"][0]
+    assert saved["evidence"] == source["evidence_text"]
+    assert saved["retrieval_status"] == "snippet"
+    assert saved["evidence_tier"] == 3
+
+
 def test_finalize_roster_requires_evidence_for_every_active_candidate():
     from pipeline_client.agent.agent import _make_editing_handlers
 
@@ -829,8 +869,23 @@ def test_finalize_roster_requires_exact_special_election_completeness_source():
             "published_at": "2026-05-22",
         }
     )
+    searched_only = handlers["finalize_roster"](
+        {
+            "summary": "August special primary list",
+            "completeness_sources": [special_source],
+            "_research_trace": {"researched_urls": [special_source["url"]], "fetched_urls": []},
+        }
+    )
+    assert "no sources were supplied" in searched_only
     finalized = handlers["finalize_roster"](
-        {"summary": "August special primary list", "completeness_sources": [special_source]}
+        {
+            "summary": "August special primary list",
+            "completeness_sources": [special_source],
+            "_research_trace": {
+                "researched_urls": [special_source["url"]],
+                "fetched_urls": [special_source["url"]],
+            },
+        }
     )
     assert finalized == "Roster finalized with 1 evidence-backed active candidate(s)."
 


### PR DESCRIPTION
## Summary
- accept the native evidence_text alias used by roster models
- inject actual searched and fetched URLs into editing calls
- prevent model-authored retrieval metadata from promoting unseen citations
- require fetched content for whole-roster completeness evidence

## Validation
- python -m pytest tests -q (1001 passed)
- black/isort checks for touched Python files