### PR TITLE
Reject unrelated candidate image matches

### DIFF
--- a/pipeline_client/agent/images.py
+++ b/pipeline_client/agent/images.py
@@ -85,8 +85,7 @@ def _candidate_surname_token(candidate_name: str) -> Optional[str]:
 
 
 def _is_untrusted_wikimedia_match(url: str, candidate_name: str) -> bool:
-    """True if an upload.wikimedia.org URL's filename doesn't contain the
-    candidate's surname.
+    """True if an upload.wikimedia.org filename does not match the full name.
 
     Guards against the same fuzzy-match risk as Wikipedia's opensearch API
     (e.g. "Sam Mead" resolving to "Sam Mendes"), but for a URL that was
@@ -97,10 +96,10 @@ def _is_untrusted_wikimedia_match(url: str, candidate_name: str) -> bool:
     """
     if "upload.wikimedia.org" not in url:
         return False
-    surname_token = _candidate_surname_token(candidate_name)
-    if not surname_token:
+    candidate_tokens = _name_tokens(candidate_name)
+    if not candidate_tokens:
         return False
-    return surname_token not in _name_tokens(unquote(url))
+    return not candidate_tokens.issubset(_name_tokens(unquote(url)))
 
 
 # Generic Open-Graph / social-share cards served by data and reference sites
@@ -363,9 +362,10 @@ async def _lookup_wikipedia_image(candidate_name: str, context: str = "") -> Opt
     # opensearch is a fuzzy/autocomplete match, not an exact lookup — for a name
     # with no Wikipedia page (common for down-ballot candidates) it can return a
     # similarly-spelled but unrelated person (e.g. "Sam Mead" -> "Sam Mendes").
-    # Require the candidate's surname to actually appear in the matched title
-    # before trusting its image.
-    surname_token = _candidate_surname_token(candidate_name)
+    # Require the candidate's full normalized name to appear in the matched
+    # title before trusting its image. Surname-only matching accepted unrelated
+    # entities such as "Dave Matthews Band" for candidate David Matthews.
+    candidate_tokens = _name_tokens(candidate_name)
 
     try:
         async with httpx.AsyncClient(timeout=10, follow_redirects=True) as client:
@@ -385,9 +385,9 @@ async def _lookup_wikipedia_image(candidate_name: str, context: str = "") -> Opt
                 search_data = search_resp.json()
                 titles = search_data[1] if len(search_data) > 1 else []
                 for title in titles:
-                    if surname_token and surname_token not in _name_tokens(title):
+                    if candidate_tokens and not candidate_tokens.issubset(_name_tokens(title)):
                         logger.debug(
-                            "Rejected Wikipedia match %r for candidate %r — surname not present", title, candidate_name
+                            "Rejected Wikipedia match %r for candidate %r — full name not present", title, candidate_name
                         )
                         continue
                     img_resp = await client.get(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -304,6 +304,20 @@ async def test_lookup_wikipedia_image_accepts_matching_surname(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_lookup_wikipedia_image_rejects_same_surname_unrelated_entity(monkeypatch):
+    fake_client = _FakeWikipediaClient(
+        opensearch_titles={"David Matthews": ["Dave Matthews Band"]},
+        thumbnails={"Dave Matthews Band": "https://upload.wikimedia.org/wikipedia/commons/dave_matthews_band.jpg"},
+    )
+    monkeypatch.setattr("pipeline_client.agent.images.httpx.AsyncClient", fake_client)
+
+    result = await _lookup_wikipedia_image("David Matthews")
+
+    assert result is None
+    assert all(call.get("action") != "query" for call in fake_client.calls)
+
+
+@pytest.mark.asyncio
 async def test_resolve_single_image_discards_stale_mismatched_wikimedia_url(monkeypatch):
     # A prior run can persist a mismatched Wikimedia URL onto image_url (e.g. from
     # the opensearch fuzzy-match bug before it was fixed). The existing-URL fast
@@ -350,4 +364,7 @@ def test_is_untrusted_wikimedia_match_ignores_non_wikimedia_urls():
     )
     assert not _is_untrusted_wikimedia_match(
         "https://upload.wikimedia.org/wikipedia/commons/f/fe/Sam_Mead_2026.jpg", "Sam Mead"
+    )
+    assert _is_untrusted_wikimedia_match(
+        "https://upload.wikimedia.org/wikipedia/commons/d/d0/Dave_Matthews_Band.jpg", "David Matthews"
     )


### PR DESCRIPTION
## Summary
- require all normalized candidate name tokens in Wikipedia matches
- reject stale Wikimedia URLs whose filenames match only a surname
- add regression coverage for unrelated same-surname entities

## Validation
- python -m pytest tests/test_images.py -q (18 passed)