### PR TITLE
Finalize race metadata from sourced research

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -204,6 +204,23 @@ persists this audit under `pipeline_state.roster_research`. If the gate does not
 pass, the run stops before images, polling, and forecast work and keeps `discovery`
 visibly incomplete for a retry.
 
+Update discovery applies race metadata with the same end-of-phase discipline.
+Its last turn is reserved for a stronger synthesis model and forced to call
+`finalize_metadata` with the complete active roster, a substantive race
+description, and a sourced 2-3 sentence biography for every candidate. The
+handler verifies that every cited URL appeared in the run's actual search/fetch
+trace and applies the payload atomically, then records the audit under
+`pipeline_state.metadata_research`. This prevents useful research from being
+lost merely because the exploratory turns reached their limit. Missing or thin
+summaries are filled even when their biographical facts predate the prior run.
+
+Polling matchups are evaluated against their contest stage. A primary poll may
+legitimately include only candidates from one party, so `remove_poll` rejects
+attempts whose sole rationale is that the poll omits the other party or does not
+contain the full race roster. Enabled steps also clear their own prior failure
+and remaining-work markers before rerunning; failures from unrelated steps are
+preserved and any failure that recurs is recorded anew.
+
 Roster authority order is: official election authority/certified ballot or
 result; official party qualification list when the party administers primary
 qualification; FEC corroboration for federal candidates; then a current

--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from shared.pipeline_config import DEFAULT_UPDATE_PIPELINE_STEPS, PIPELINE_STEP_IDS, REVIEW_PROVIDERS, PipelineRuntimeConfig
+from shared.run_health import clear_step_failures
 
 from .ballotpedia import default_ballotpedia_race_url
 from .cost import _cost_ctx, estimate_cost
@@ -58,6 +59,7 @@ from .tools import (  # noqa: F401 - re-exported for tests
     BALLOTPEDIA_TOOL,
     CANDIDATE_TOOLS,
     FETCH_TOOL,
+    FINALIZE_METADATA_TOOL,
     FORECAST_TOOLS,
     ISSUE_TOOLS,
     RACE_TOOLS,
@@ -705,6 +707,11 @@ async def run_agent(
     if existing_data and enabled_steps is None:
         _enabled = set(DEFAULT_UPDATE_PIPELINE_STEPS)
         log("info", "Using low-cost update steps; issue research and review are opt-in")
+
+    if isinstance(existing_data, dict):
+        # Health is an assessment of the latest attempt. Retain unrelated failures,
+        # but let every enabled phase prove itself again from a clean slate.
+        clear_step_failures(existing_data, _enabled)
 
     if existing_data:
         log("info", f"Update mode for {race_id} (profile={profile}, model={model}, small_model={small_model})")

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -201,6 +201,23 @@ def _normalize_source(source: Any, *, default_type: str = "finance") -> Dict[str
     return normalized
 
 
+def _normalize_observed_sources(sources: Any, research_trace: Any, *, default_type: str = "website") -> list[Dict[str, Any]]:
+    """Keep generic sources only when their URL was observed by this agent loop."""
+    normalized = [
+        source for source in (_normalize_source(item, default_type=default_type) for item in sources or []) if source
+    ]
+    if not isinstance(research_trace, dict):
+        return normalized
+
+    def url_key(raw_url: Any) -> str:
+        parsed = urlparse(str(raw_url or "").strip())
+        path = parsed.path.rstrip("/") or "/"
+        return f"{parsed.scheme.casefold()}://{parsed.netloc.casefold()}{path}?{parsed.query}".rstrip("?")
+
+    observed = {url_key(url) for key in ("researched_urls", "fetched_urls") for url in research_trace.get(key) or []}
+    return [source for source in normalized if url_key(source.get("url")) in observed]
+
+
 def _classify_roster_source_type(raw_type: Any, *, title: str | None, url: str | None, host: str) -> str:
     """Map a free-form roster source label onto a known roster source class.
 
@@ -1095,6 +1112,54 @@ def _make_editing_handlers(
         log("info", f"    Updated summary for {name}")
         return f"Updated summary for '{name}'."
 
+    def finalize_metadata(args: Dict[str, Any]) -> str:
+        """Apply the complete metadata payload only after all entries validate."""
+        active_candidates = [
+            candidate
+            for candidate in race_json.get("candidates", [])
+            if isinstance(candidate, dict) and candidate.get("name") and candidate.get("withdrawn") is not True
+        ]
+        proposed = args.get("candidates")
+        if not isinstance(proposed, list) or not proposed:
+            return "ERROR: metadata finalization requires every active candidate."
+        active_names = {str(candidate["name"]).strip().casefold() for candidate in active_candidates}
+        proposed_names = {str(item.get("name") or "").strip().casefold() for item in proposed if isinstance(item, dict)}
+        if len(proposed_names) != len(proposed) or proposed_names != active_names:
+            return "ERROR: metadata candidates must exactly match the complete active roster."
+
+        description = str(args.get("description") or "").strip()
+        description_sources = _normalize_observed_sources(
+            args.get("description_sources"), args.get("_research_trace"), default_type="news"
+        )
+        if len(description) < 100 or not description_sources:
+            return "ERROR: provide a substantive race description and at least one source observed during this research."
+
+        validated: Dict[str, tuple[str, list[Dict[str, Any]]]] = {}
+        for item in proposed:
+            name = str(item.get("name") or "").strip()
+            summary = str(item.get("summary") or "").strip()
+            sources = _normalize_observed_sources(item.get("sources"), args.get("_research_trace"), default_type="website")
+            if len(summary) < 80:
+                return f"ERROR: summary for '{name}' is too thin; provide a factual 2-3 sentence biography."
+            if not sources:
+                return f"ERROR: summary for '{name}' needs a source URL observed during this research."
+            validated[name.casefold()] = (summary, sources)
+
+        # Atomic application: no mutation occurs until the entire submission passes.
+        race_json["description"] = description
+        for candidate in active_candidates:
+            summary, sources = validated[str(candidate["name"]).strip().casefold()]
+            candidate["summary"] = summary
+            candidate["summary_sources"] = sources
+        race_json.setdefault("pipeline_state", {})["metadata_research"] = {
+            "finalized_at": datetime.now(timezone.utc).isoformat(),
+            "active_candidate_count": len(active_candidates),
+            "description_sources": description_sources,
+            "candidate_sources": {item["name"]: validated[item["name"].strip().casefold()][1] for item in proposed},
+        }
+        log("info", f"    Finalized description and {len(active_candidates)} candidate summaries")
+        return f"Metadata finalized for all {len(active_candidates)} active candidates."
+
     # --- Issue handler ---
 
     def set_issue_stance(args: Dict[str, Any]) -> str:
@@ -1422,6 +1487,17 @@ def _make_editing_handlers(
         pollster = args["pollster"]
         date = args.get("date")
         reason = args.get("reason", "")
+        if re.search(
+            r"\b(?:roster alignment|did not include|does not include|missing from (?:the )?matchup|"
+            r"subset of (?:the )?(?:full )?roster)\b",
+            str(reason),
+            re.IGNORECASE,
+        ):
+            return (
+                "ERROR: Poll removal blocked. A primary or partial-matchup poll is valid when every named person "
+                "belongs to the roster; it must not include every candidate or the other party. Remove only a "
+                "duplicate, malformed record, non-poll result, or poll proven to concern a different contest."
+            )
         polling = race_json.get("polling", [])
         orig_len = len(polling)
         if date:
@@ -1637,6 +1713,7 @@ def _make_editing_handlers(
         "finalize_roster": finalize_roster,
         "set_candidate_field": set_candidate_field,
         "set_candidate_summary": set_candidate_summary,
+        "finalize_metadata": finalize_metadata,
         "set_issue_stance": set_issue_stance,
         "set_donor_summary": set_donor_summary,
         "set_voting_summary": set_voting_summary,

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -17,7 +17,15 @@ from ..prompts import (
 )
 from ..run_budget import RunBudget, RunBudgetExceeded
 from ..selection import _scale_iterations, _select_target_candidates
-from ..tools import CANDIDATE_TOOLS, DESCRIPTION_TOOLS, READ_PROFILE_TOOL, RECORD_TOOLS, REMOVE_CANDIDATE_TOOL, ROSTER_TOOLS
+from ..tools import (
+    CANDIDATE_TOOLS,
+    DESCRIPTION_TOOLS,
+    FINALIZE_METADATA_TOOL,
+    READ_PROFILE_TOOL,
+    RECORD_TOOLS,
+    REMOVE_CANDIDATE_TOOL,
+    ROSTER_TOOLS,
+)
 from ..utils import make_logger
 from ._common import (
     RunFailureReason,
@@ -282,10 +290,22 @@ async def _run_update(
                     max_iterations=meta_iters,
                     phase_name="update-meta",
                     max_tokens=16384,
-                    extra_tools=DESCRIPTION_TOOLS + CANDIDATE_TOOLS + RECORD_TOOLS + [READ_PROFILE_TOOL],
+                    extra_tools=DESCRIPTION_TOOLS
+                    + CANDIDATE_TOOLS
+                    + RECORD_TOOLS
+                    + [READ_PROFILE_TOOL, FINALIZE_METADATA_TOOL],
                     extra_tool_handlers=handlers,
                     tools_mode=True,
                     run_budget=run_budget,
+                    tool_error_escalation_model=NEMOTRON_ULTRA_MODEL,
+                    required_final_tool_name="finalize_metadata",
+                    required_final_instruction=(
+                        "Research is over. Synthesize the evidence already collected into a substantive race "
+                        "description and a factual 2-3 sentence biography for EVERY active candidate. Call "
+                        "finalize_metadata once with the complete candidate array and only source URLs you actually "
+                        "searched or fetched. Do not leave findings only in prose and do not perform more research."
+                    ),
+                    return_tool_trace=True,
                 )
             except RunBudgetExceeded:
                 raise

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -315,6 +315,12 @@ Search for NEW information since {last_updated}:
 2. Updated or corrected candidate summaries (keep them 2-3 sentences, nonpartisan).
 3. Updated race description (office context, why it matters, key contrasts).
 
+Completeness takes priority over recency: if any active candidate has an empty,
+placeholder, or thin summary, research and write a sourced 2-3 sentence biography
+even when the underlying facts predate {last_updated}. Your final action must be one
+finalize_metadata call containing the race description and every active candidate;
+this atomically preserves the research you found.
+
 WHAT COUNTS AS "NEW" — be precise:
 - A development is new if it appears in articles published AFTER {last_updated}:
   new endorsements, policy announcements, primary results, candidate debates,
@@ -328,8 +334,8 @@ WHAT COUNTS AS "NEW" — be precise:
   future result.
 
 WHEN TO MAKE NO CHANGES:
-- If nothing meaningful has changed since {last_updated}, reply exactly:
-  "No changes needed."
+- Existing substantive text may be retained, but it must still be included with
+  supporting sources in finalize_metadata. Do not exit with findings only in prose.
 - Do not rephrase existing summaries without a substantive new reason.
 
 When you do find improvements, use your editing tools to record them:
@@ -361,6 +367,10 @@ Find recent public polls from primary poll releases, reputable aggregators, or
 news coverage linking to the underlying poll. Add at most five useful recent
 polls. Every matchup candidate name must exactly match the roster above and the
 percentages array must align with the candidate array. If a source confirms a
+poll for a party primary, include only the candidates measured in that primary;
+it is valid and expected for that matchup to omit the other party's candidate(s)
+and any unmeasured candidates. Never remove a genuine primary poll merely because
+its matchup is a subset of the full cross-party race roster. If a source confirms a
 poll but does not name the polling organization, do not invent a placeholder
 pollster. Election returns, primary results, vote totals, and candidate vote
 shares are not opinion polls and must never be added to polling.

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -453,6 +453,69 @@ SET_CANDIDATE_SUMMARY_TOOL: Dict = {
     },
 }
 
+FINALIZE_METADATA_TOOL: Dict = {
+    "type": "function",
+    "function": {
+        "name": "finalize_metadata",
+        "description": (
+            "Atomically submit the race description and a sourced biographical summary for every active candidate. "
+            "Use this after research so findings cannot be lost when the phase reaches its turn limit."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "A sourced, nonpartisan 3-4 sentence description of this exact race.",
+                },
+                "description_sources": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                            "type": {"type": "string"},
+                            "title": {"type": "string"},
+                        },
+                        "required": ["url"],
+                    },
+                },
+                "candidates": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 8,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "summary": {
+                                "type": "string",
+                                "description": "A factual, nonpartisan 2-3 sentence biography.",
+                            },
+                            "sources": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {"type": "string"},
+                                        "type": {"type": "string"},
+                                        "title": {"type": "string"},
+                                    },
+                                    "required": ["url"],
+                                },
+                            },
+                        },
+                        "required": ["name", "summary", "sources"],
+                    },
+                },
+            },
+            "required": ["description", "description_sources", "candidates"],
+        },
+    },
+}
+
 CANDIDATE_TOOLS: List[Dict] = [SET_CANDIDATE_FIELD_TOOL, SET_CANDIDATE_SUMMARY_TOOL]
 
 # ---------------------------------------------------------------------------

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -227,6 +227,10 @@ FIELD_TYPE_OVERRIDES: Dict[tuple, str] = {
     # Dict keyed by CanonicalIssue, but IssueKey (a superset including legacy
     # names) + Partial is the deliberately more tolerant TS rendering.
     ("Candidate", "issues"): "Partial<Record<IssueKey, IssueStance>>",
+    # Research audits intentionally retain provider/tool-specific JSON details;
+    # the frontend treats their values as unknown until a consumer narrows them.
+    ("PipelineState", "roster_research"): "Record<string, unknown>",
+    ("PipelineState", "metadata_research"): "Record<string, unknown>",
 }
 
 # Fields checked by a bespoke function below instead of the generic matcher

--- a/shared/models.py
+++ b/shared/models.py
@@ -464,6 +464,8 @@ class PipelineState(BaseModel):
     step_failures: List[StepFailure] = Field(default_factory=list)
     deterministic_cleanup: Dict[str, int] = Field(default_factory=dict)
     race_identity: Optional[RaceIdentityBrief] = None
+    roster_research: Optional[Dict[str, Any]] = None
+    metadata_research: Optional[Dict[str, Any]] = None
 
 
 class RaceJSON(BaseModel):

--- a/shared/run_health.py
+++ b/shared/run_health.py
@@ -173,6 +173,28 @@ def record_step_failure(
     failures.append(entry)
 
 
+def clear_step_failures(race_json: Dict[str, Any], steps: Iterable[str]) -> None:
+    """Clear stale failure and remaining-work markers for steps being rerun.
+
+    A rerun starts a fresh health assessment for its enabled steps. Any failure
+    encountered again is recorded by that step, while unrelated failures remain.
+    """
+    if not isinstance(race_json, dict):
+        return
+    pipeline_state = race_json.get("pipeline_state")
+    if not isinstance(pipeline_state, dict):
+        return
+    selected = {str(step) for step in steps}
+    failures = pipeline_state.get("step_failures")
+    if isinstance(failures, list):
+        pipeline_state["step_failures"] = [
+            entry for entry in failures if not isinstance(entry, dict) or str(entry.get("step")) not in selected
+        ]
+    remaining = pipeline_state.get("remaining_steps")
+    if isinstance(remaining, list):
+        pipeline_state["remaining_steps"] = [step for step in remaining if str(step) not in selected]
+
+
 def get_step_failures(race_json: Dict[str, Any]) -> List[StepFailure]:
     """Parse the raw step-failure dicts back into typed models, tolerating garbage entries."""
     if not isinstance(race_json, dict):

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -34,6 +34,7 @@ def test_editing_tool_schemas_exist():
         ADD_LINK_TOOL,
         ADD_POLL_TOOL,
         CANDIDATE_TOOLS,
+        FINALIZE_METADATA_TOOL,
         ISSUE_TOOLS,
         RACE_TOOLS,
         READ_PROFILE_TOOL,
@@ -61,6 +62,7 @@ def test_editing_tool_schemas_exist():
     assert SET_CANDIDATE_ROSTER_SOURCES_TOOL["function"]["name"] == "set_candidate_roster_sources"
     assert SET_RACE_IDENTITY_TOOL["function"]["name"] == "set_race_identity"
     assert READ_PROFILE_TOOL["function"]["name"] == "read_profile"
+    assert FINALIZE_METADATA_TOOL["function"]["name"] == "finalize_metadata"
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +87,7 @@ def test_make_editing_handlers():
         "finalize_roster",
         "set_candidate_field",
         "set_candidate_summary",
+        "finalize_metadata",
         "set_issue_stance",
         "set_donor_summary",
         "set_voting_summary",
@@ -1278,6 +1281,98 @@ def test_remove_poll_handler():
     # Remove by pollster only
     handlers["remove_poll"]({"pollster": "Emerson", "reason": "null data"})
     assert race_json["polling"] == []
+
+
+def test_finalize_metadata_atomically_requires_complete_sourced_roster():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {
+        "id": "al-house-02-2026",
+        "description": "Old description",
+        "candidates": [
+            {"name": "Alice Example", "summary": "", "summary_sources": []},
+            {"name": "Bob Example", "summary": "", "summary_sources": []},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+    source = {"url": "https://example.com/race", "type": "news", "title": "Race guide"}
+    trace = {"researched_urls": [source["url"]], "fetched_urls": []}
+
+    incomplete = handlers["finalize_metadata"](
+        {
+            "description": "This is a substantive description of the exact election and its broader context. "
+            "It explains the office, timing, field, and major contrasts without advocating for a candidate.",
+            "description_sources": [source],
+            "candidates": [
+                {
+                    "name": "Alice Example",
+                    "summary": "Alice Example is a candidate with relevant public service and professional experience. "
+                    "Her biography describes that background in neutral language for voters.",
+                    "sources": [source],
+                }
+            ],
+            "_research_trace": trace,
+        }
+    )
+    assert incomplete.startswith("ERROR:")
+    assert race_json["description"] == "Old description"
+
+    complete = handlers["finalize_metadata"](
+        {
+            "description": "This is a substantive description of the exact election and its broader context. "
+            "It explains the office, timing, field, and major contrasts without advocating for a candidate.",
+            "description_sources": [source],
+            "candidates": [
+                {
+                    "name": "Alice Example",
+                    "summary": "Alice Example is a candidate with relevant public service and professional experience. "
+                    "Her biography describes that background in neutral language for voters.",
+                    "sources": [source],
+                },
+                {
+                    "name": "Bob Example",
+                    "summary": "Bob Example is a candidate with relevant community leadership and professional experience. "
+                    "His biography describes that background in neutral language for voters.",
+                    "sources": [source],
+                },
+            ],
+            "_research_trace": trace,
+        }
+    )
+    assert complete.startswith("Metadata finalized")
+    assert all(candidate["summary"] for candidate in race_json["candidates"])
+    assert race_json["pipeline_state"]["metadata_research"]["active_candidate_count"] == 2
+
+
+def test_remove_poll_blocks_full_roster_alignment_for_primary_matchup():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    poll = {
+        "pollster": "Peak Insights",
+        "date": "2026-06-09",
+        "matchups": [{"candidates": ["Rhett Marques", "Hampton Harris"], "percentages": [30, 4]}],
+        "source_url": "https://example.com/republican-primary-poll",
+    }
+    race_json = {
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic"},
+            {"name": "Rhett Marques", "party": "Republican"},
+            {"name": "Hampton Harris", "party": "Republican"},
+        ],
+        "polling": [poll],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["remove_poll"](
+        {
+            "pollster": "Peak Insights",
+            "date": "2026-06-09",
+            "reason": "Roster alignment: poll did not include Shomari Figures.",
+        }
+    )
+
+    assert result.startswith("ERROR: Poll removal blocked")
+    assert race_json["polling"] == [poll]
 
 
 def test_add_poll_requires_exact_roster_names():

--- a/tests/test_run_health.py
+++ b/tests/test_run_health.py
@@ -156,6 +156,25 @@ def test_get_step_failures_empty_when_missing():
     assert get_step_failures({"pipeline_state": {"step_failures": "not-a-list"}}) == []
 
 
+def test_clear_step_failures_only_resets_steps_being_rerun():
+    from shared.run_health import clear_step_failures
+
+    race = {
+        "pipeline_state": {
+            "step_failures": [
+                {"step": "forecast", "reason": "step_no_data", "detail": None},
+                {"step": "finance", "reason": "step_no_data", "detail": None},
+            ],
+            "remaining_steps": ["forecast", "finance", "review"],
+        }
+    }
+
+    clear_step_failures(race, {"forecast"})
+
+    assert race["pipeline_state"]["step_failures"] == [{"step": "finance", "reason": "step_no_data", "detail": None}]
+    assert race["pipeline_state"]["remaining_steps"] == ["finance", "review"]
+
+
 # ---------------------------------------------------------------------------
 # Empty finance output detection (silent failure #1)
 # ---------------------------------------------------------------------------

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -247,6 +247,8 @@ export interface PipelineState {
   step_failures: StepFailure[];
   deterministic_cleanup: Record<string, number>;
   race_identity?: RaceIdentityBrief;
+  roster_research?: Record<string, unknown>;
+  metadata_research?: Record<string, unknown>;
 }
 
 export interface IssueResearchAudit {


### PR DESCRIPTION
## Summary
- atomically finalize sourced race descriptions and every active candidate biography
- bind metadata sources to the actual research trace
- preserve valid primary polling subsets and reset stale health markers on reruns
- document the updated pipeline behavior

## Validation
- python -m pytest tests/test_agent_loop.py tests/test_editing_tools.py tests/test_prompts.py tests/test_run_agent.py tests/test_run_health.py -q (258 passed)