### PR TITLE
Accept fetched unlabeled roster news

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -302,7 +302,11 @@ def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any
 
 
 def _apply_roster_research_provenance(
-    source: Dict[str, Any], research_trace: Any, *, require_fetch: bool = False
+    source: Dict[str, Any],
+    research_trace: Any,
+    *,
+    require_fetch: bool = False,
+    infer_fetched_news: bool = False,
 ) -> Dict[str, Any] | None:
     """Grade evidence from URLs the current agent loop actually observed.
 
@@ -324,6 +328,12 @@ def _apply_roster_research_provenance(
     researched = {url_key(item) for item in research_trace.get("researched_urls") or []}
     fetched = {url_key(item) for item in research_trace.get("fetched_urls") or []}
     if url in fetched:
+        # Models sometimes omit the optional source-type label even after they
+        # successfully fetched a conventional news article. Do not discard that
+        # real content on a labeling technicality. This promotion is deliberately
+        # limited to fetched sources and never grants official/FEC authority.
+        if infer_fetched_news and source.get("type") == "other":
+            source["type"] = "news"
         source["retrieval_status"] = "content"
         source["evidence_tier"] = 1 if source.get("type") in {"official", "fec"} else 2
         return source
@@ -335,13 +345,25 @@ def _apply_roster_research_provenance(
 
 
 def _normalize_observed_roster_sources(
-    sources: Any, *, race_id: str, research_trace: Any, require_fetch: bool = False
+    sources: Any,
+    *,
+    race_id: str,
+    research_trace: Any,
+    require_fetch: bool = False,
+    infer_fetched_news: bool = False,
 ) -> list[Dict[str, Any]]:
     normalized = [source for source in (_normalize_roster_source(item, race_id=race_id) for item in sources or []) if source]
     return [
         observed
         for source in normalized
-        if (observed := _apply_roster_research_provenance(source, research_trace, require_fetch=require_fetch))
+        if (
+            observed := _apply_roster_research_provenance(
+                source,
+                research_trace,
+                require_fetch=require_fetch,
+                infer_fetched_news=infer_fetched_news,
+            )
+        )
     ]
 
 
@@ -1021,6 +1043,7 @@ def _make_editing_handlers(
             race_id=race_id,
             research_trace=args.get("_research_trace"),
             require_fetch=True,
+            infer_fetched_news=True,
         )
         completeness_rejections = [
             reason

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -943,6 +943,80 @@ def test_finalize_roster_atomically_applies_complete_proposed_roster():
     assert all(candidate["roster_sources"][0]["retrieval_status"] == "content" for candidate in race_json["candidates"])
 
 
+def test_finalize_roster_infers_news_for_fetched_unlabeled_completeness_source():
+    """Regression for the live AL-02 final synthesis payload."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    source_url = (
+        "https://alabamareflector.com/2026/05/22/"
+        "as-litigation-continues-21-candidates-qualify-for-august-alabama-congressional-primaries/"
+    )
+    source = {
+        "url": source_url,
+        "title": "Candidates qualify for August Alabama congressional primaries",
+        "evidence": (
+            "For the August 11, 2026 special primary in Alabama's 2nd Congressional District, "
+            "Shomari Figures qualified with Republican candidates Rhett Marques, Hampton Harris, "
+            "Christian Horn, David Matthews, Joshua McKee, and James Richardson."
+        ),
+        "published_at": "2026-05-22",
+    }
+    names = [
+        "Shomari Figures",
+        "Rhett Marques",
+        "Hampton Harris",
+        "Christian Horn",
+        "David Matthews",
+        "Joshua McKee",
+        "James Richardson",
+    ]
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House",
+                "contest_stage": "pre_primary",
+                "primary_status": "Special Primary Election on August 11, 2026",
+                "election_date": "2026-08-11",
+            }
+        },
+        "candidates": [],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["finalize_roster"](
+        {
+            "summary": "Complete special-primary field reported by Alabama Reflector.",
+            "candidates": [
+                {"name": name, "party": "Democratic" if name == "Shomari Figures" else "Republican"} for name in names
+            ],
+            "source_candidate_names": names,
+            "completeness_sources": [source],
+            "_research_trace": {"researched_urls": [source_url], "fetched_urls": [source_url]},
+        }
+    )
+
+    assert result == "Roster finalized with 7 evidence-backed active candidate(s)."
+    audit_source = race_json["pipeline_state"]["roster_research"]["completeness_sources"][0]
+    assert audit_source["type"] == "news"
+    assert audit_source["retrieval_status"] == "content"
+    assert audit_source["evidence_tier"] == 2
+
+
+def test_fetched_unlabeled_candidate_source_does_not_gain_news_classification():
+    from pipeline_client.agent.handlers import _normalize_observed_roster_sources
+
+    source_url = "https://example.com/candidate-claim"
+    sources = _normalize_observed_roster_sources(
+        [{"url": source_url, "title": "Candidate claim", "evidence": "Alice Example is running in 2026."}],
+        race_id="example-race-2026",
+        research_trace={"researched_urls": [source_url], "fetched_urls": [source_url]},
+    )
+
+    assert sources[0]["type"] == "other"
+    assert sources[0]["retrieval_status"] == "content"
+
+
 def test_exact_contest_accepts_statewide_certification_table_row_wording():
     from pipeline_client.agent.handlers import _source_supports_exact_contest
 


### PR DESCRIPTION
Live AL-02 debug regression: the forced final roster synthesis supplied a fetched exact-contest Alabama Reflector article but omitted its optional source type, so valid completeness evidence was classified as other and rejected. Promote only actually fetched unlabeled sources to news (never official/FEC authority), with the full seven-candidate payload covered by a regression test.