### PR TITLE
Normalize official roster name variants

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -125,6 +125,13 @@ def _source_names_candidate(text: str, candidate_name: str) -> bool:
     return bool(name_words) and all(word in text for word in name_words)
 
 
+def _canonical_roster_name(name: str) -> str:
+    """Normalize harmless middle initials and suffixes for roster-set comparison."""
+    suffixes = {"jr", "sr", "ii", "iii", "iv"}
+    tokens = re.findall(r"[a-z0-9]+", str(name).casefold())
+    return " ".join(token for token in tokens if len(token) > 1 and token not in suffixes)
+
+
 def _source_proves_different_contest(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> bool:
     """Validate that a wrong-contest removal cites real, current, on-topic evidence.
 
@@ -1072,14 +1079,14 @@ def _make_editing_handlers(
             proposed_names = [str(spec.get("name") or "").strip() for spec in proposed_specs if isinstance(spec, dict)]
             if len(proposed_names) != len(proposed_specs) or any(not name for name in proposed_names):
                 return "ERROR: roster finalization blocked. Every proposed candidate needs a non-empty name."
-            normalized_names = [name.casefold() for name in proposed_names]
+            normalized_names = [_canonical_roster_name(name) for name in proposed_names]
             if len(set(normalized_names)) != len(normalized_names):
                 return "ERROR: roster finalization blocked. The proposed roster contains duplicate candidate names."
             extracted_names = [str(name).strip() for name in args.get("source_candidate_names") or [] if str(name).strip()]
-            if {name.casefold() for name in extracted_names} != set(normalized_names):
+            if {_canonical_roster_name(name) for name in extracted_names} != set(normalized_names):
                 return (
-                    "ERROR: roster finalization blocked. source_candidate_names must exactly match the proposed "
-                    "candidate roster extracted from the completeness evidence."
+                    "ERROR: roster finalization blocked. source_candidate_names must match the proposed candidate "
+                    "roster extracted from the completeness evidence (middle initials and suffixes may differ)."
                 )
 
             existing_by_name = {

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -403,7 +403,8 @@ FINALIZE_ROSTER_TOOL: Dict = {
                 "source_candidate_names": {
                     "type": "array",
                     "description": (
-                        "Every candidate name extracted from the completeness evidence; must exactly match candidates."
+                        "Every candidate name extracted from the completeness evidence; must match candidates. "
+                        "Middle initials and suffixes may differ."
                     ),
                     "items": {"type": "string"},
                 },
@@ -431,7 +432,7 @@ FINALIZE_ROSTER_TOOL: Dict = {
                             "evidence_tier": {"type": "integer", "enum": [1, 2, 3]},
                             "retrieval_status": {"type": "string", "enum": ["content", "snippet"]},
                         },
-                        "required": ["url", "title"],
+                        "required": ["url", "title", "evidence"],
                     },
                 },
             },

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1060,8 +1060,47 @@ def test_finalize_roster_atomic_submission_requires_extracted_name_match():
         }
     )
 
-    assert "source_candidate_names must exactly match" in result
+    assert "source_candidate_names must match" in result
     assert [candidate["name"] for candidate in race_json["candidates"]] == ["Old Entry"]
+
+
+def test_finalize_roster_allows_middle_initial_in_extracted_source_name():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    source_url = "https://aldemocrats.org/2026-primary-election-qualified-candidates"
+    source = {
+        "url": source_url,
+        "title": "2026 Primary Election - Qualified Candidates",
+        "evidence": (
+            "Qualified candidate for the August 11, 2026 special primary for "
+            "U.S. House Congressional District 2: Shomari C. Figures"
+        ),
+    }
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House",
+                "contest_stage": "pre_primary",
+                "primary_status": "Special Primary Election on August 11, 2026",
+                "election_date": "2026-08-11",
+            }
+        },
+        "candidates": [],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["finalize_roster"](
+        {
+            "summary": "Official qualified candidate list.",
+            "candidates": [{"name": "Shomari Figures", "party": "Democratic", "incumbent": True}],
+            "source_candidate_names": ["Shomari C. Figures"],
+            "completeness_sources": [source],
+            "_research_trace": {"researched_urls": [source_url], "fetched_urls": [source_url]},
+        }
+    )
+
+    assert result == "Roster finalized with 1 evidence-backed active candidate(s)."
 
 
 def test_add_candidate_blocks_primary_loser_after_nominee_is_known():


### PR DESCRIPTION
Live AL-02 debug follow-up: accept harmless middle initials/suffixes when comparing names extracted from official completeness evidence to canonical candidate names, while preserving first/last-name identity. Also require the forced final completeness payload to include its evidence excerpt so the final retry cannot drop accumulated proof. Focused roster/agent suite: 154 passed.