### PR TITLE
Reuse verified roster evidence across refreshes

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -626,6 +626,25 @@ def _make_editing_handlers(
         "contest_stage",
     }
 
+    # Snapshot durable evidence before this loop can edit the roster. A refresh
+    # may reuse a previously retrieved official document without fetching it
+    # again; the stored object, not newly model-authored text, is authoritative.
+    persisted_roster_sources: Dict[str, Dict[str, Any]] = {}
+    for existing_candidate in race_json.get("candidates", []):
+        if not isinstance(existing_candidate, dict):
+            continue
+        for existing_source in existing_candidate.get("roster_sources") or []:
+            if not isinstance(existing_source, dict):
+                continue
+            url = str(existing_source.get("url") or "").strip()
+            if (
+                url
+                and existing_source.get("retrieval_status") == "content"
+                and existing_source.get("evidence_tier") in {1, 2}
+                and existing_source.get("evidence")
+            ):
+                persisted_roster_sources[url.rstrip("/").casefold()] = dict(existing_source)
+
     def _find_candidate(name: str) -> Optional[Dict[str, Any]]:
         for c in race_json.get("candidates", []):
             if isinstance(c, dict) and c.get("name") == name:
@@ -1052,6 +1071,15 @@ def _make_editing_handlers(
             require_fetch=True,
             infer_fetched_news=True,
         )
+        observed_urls = {str(source.get("url") or "").rstrip("/").casefold() for source in completeness_sources}
+        for submitted in args.get("completeness_sources") or []:
+            if not isinstance(submitted, dict):
+                continue
+            url_key = str(submitted.get("url") or "").strip().rstrip("/").casefold()
+            trusted = persisted_roster_sources.get(url_key)
+            if trusted and url_key not in observed_urls:
+                completeness_sources.append(dict(trusted))
+                observed_urls.add(url_key)
         completeness_rejections = [
             reason
             for source in completeness_sources

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1103,6 +1103,58 @@ def test_finalize_roster_allows_middle_initial_in_extracted_source_name():
     assert result == "Roster finalized with 1 evidence-backed active candidate(s)."
 
 
+def test_finalize_roster_reuses_persisted_content_evidence_by_url():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    source_url = "https://www.sos.alabama.gov/2026/district-2-certified.pdf"
+    trusted_source = {
+        "url": source_url,
+        "type": "official",
+        "title": "State Certification of Candidates",
+        "evidence": (
+            "Certified and complete qualified candidate list for the August 11, 2026 Special Primary Election "
+            "for U.S. House Congressional District 2: Shomari Figures and Hampton Harris"
+        ),
+        "race_id": "al-house-02-2026",
+        "published_at": "2026-05-22",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House",
+                "contest_stage": "pre_primary",
+                "primary_status": "Special Primary Election on August 11, 2026",
+                "election_date": "2026-08-11",
+            }
+        },
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic", "roster_sources": [trusted_source]},
+            {"name": "Hampton Harris", "party": "Republican", "roster_sources": [trusted_source]},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["finalize_roster"](
+        {
+            "summary": "Reused official certification from the prior verified run.",
+            "candidates": [
+                {"name": "Shomari Figures", "party": "Democratic"},
+                {"name": "Hampton Harris", "party": "Republican"},
+            ],
+            "source_candidate_names": ["Shomari Figures", "Hampton Harris"],
+            "completeness_sources": [{"url": source_url, "title": "State Certification", "evidence": "model-provided claim"}],
+            "_research_trace": {"researched_urls": [], "fetched_urls": []},
+        }
+    )
+
+    assert result == "Roster finalized with 2 evidence-backed active candidate(s)."
+    stored = race_json["pipeline_state"]["roster_research"]["completeness_sources"][0]
+    assert stored["evidence"] == trusted_source["evidence"]
+
+
 def test_add_candidate_blocks_primary_loser_after_nominee_is_known():
     from pipeline_client.agent.agent import _make_editing_handlers
 


### PR DESCRIPTION
## Summary
- snapshot durable roster evidence before refresh edits
- allow finalization to reuse the exact previously verified source object by URL
- prevent model-authored replacement text from overriding persisted evidence

## Validation
- python -m pytest tests/test_editing_tools.py -q (78 passed)