### PR TITLE
Reuse verified roster evidence across refreshes

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -188,8 +188,11 @@ as durable evidence, infers only recognizable source classes, and still applies
 current-cycle and exact-contest checks. In production agent loops, the handler
 also cross-checks each cited URL against the loop's actual search/fetch trace;
 model-supplied retrieval metadata cannot promote a URL the run never observed,
-and completeness evidence must have been fetched as page content. A blocked/error tool result is surfaced
-to the model as a failure. After two consecutive blocked edits, roster sync
+and completeness evidence must have been fetched as page content. A refresh may
+reuse an exact URL's already-persisted tier-1/2 content evidence; it reuses the
+stored source object, never the model's new claims about an unfetched page. A
+blocked/error tool result and its bounded reason are recorded in debug logs and
+surfaced to the model as a failure. After two consecutive blocked edits, roster sync
 keeps the accumulated research but escalates subsequent synthesis to the
 stronger roster fallback and directs it to obtain higher-priority evidence
 instead of repeating the same invalid payload.
@@ -244,7 +247,9 @@ Removals have three paths, chosen by what the evidence actually supports:
 - **`not_on_roster=true`** — nothing supports the candidacy and the best roster
   listing for this exact race omits them. The listing must name at least two
   other candidates on the profile (proving it loaded and enumerates the field)
-  and must not name the candidate being removed. It cannot remove the incumbent.
+  and cannot affirmatively list the candidate being removed. Evidence may name
+  that person only when it explicitly describes the omission, withdrawal, or
+  disqualification. It cannot remove the incumbent.
 
 Absence is only evidence when it comes from a source that demonstrably has the
 roster. A page that failed to load, returned nothing, or was truncated is not

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -183,13 +183,19 @@ def _source_omits_candidate_from_roster(
     if not _source_is_current_cycle(source, race_id=race_id, text=text):
         return False
 
-    # Deliberately no "the candidate must not appear in the evidence text" check.
-    # The evidence field holds the model's account of the listing, and the natural
-    # way to describe an omission names the person omitted ("enumerates the field
-    # without Justin Maldonado", "listed under withdrawn candidates"). Scanning it
-    # for the name rejects exactly the well-reasoned removals this path exists to
-    # allow. The structural guarantee comes from the corroboration count below:
-    # the listing must independently name candidates who are still on the roster.
+    # A model may mention the target while accurately narrating an omission, but
+    # a source that simply lists the target is affirmative roster evidence and
+    # must never be accepted as proof of absence. If the target appears, require
+    # explicit omission/withdrawal language tied to that account of the listing.
+    if _source_names_candidate(text, candidate_name) and not re.search(
+        r"\b(?:without|omit(?:s|ted)?|absent|not\s+(?:listed|included|named)|"
+        r"does\s+not\s+(?:list|include|name)|withdr(?:ew|awn)|disqualified)\b",
+        text,
+    ):
+        return False
+
+    # The structural guarantee below still requires the listing to independently
+    # name multiple candidates who remain on the roster.
 
     corroborating = 0
     for other in other_roster_names:
@@ -626,6 +632,25 @@ def _make_editing_handlers(
         "contest_stage",
     }
 
+    # Snapshot durable evidence before this loop can edit the roster. A refresh
+    # may reuse a previously retrieved official document without fetching it
+    # again; the stored object, not newly model-authored text, is authoritative.
+    persisted_roster_sources: Dict[str, Dict[str, Any]] = {}
+    for existing_candidate in race_json.get("candidates", []):
+        if not isinstance(existing_candidate, dict):
+            continue
+        for existing_source in existing_candidate.get("roster_sources") or []:
+            if not isinstance(existing_source, dict):
+                continue
+            url = str(existing_source.get("url") or "").strip()
+            if (
+                url
+                and existing_source.get("retrieval_status") == "content"
+                and existing_source.get("evidence_tier") in {1, 2}
+                and existing_source.get("evidence")
+            ):
+                persisted_roster_sources[url.rstrip("/").casefold()] = dict(existing_source)
+
     def _find_candidate(name: str) -> Optional[Dict[str, Any]]:
         for c in race_json.get("candidates", []):
             if isinstance(c, dict) and c.get("name") == name:
@@ -1052,6 +1077,15 @@ def _make_editing_handlers(
             require_fetch=True,
             infer_fetched_news=True,
         )
+        observed_urls = {str(source.get("url") or "").rstrip("/").casefold() for source in completeness_sources}
+        for submitted in args.get("completeness_sources") or []:
+            if not isinstance(submitted, dict):
+                continue
+            url_key = str(submitted.get("url") or "").strip().rstrip("/").casefold()
+            trusted = persisted_roster_sources.get(url_key)
+            if trusted and url_key not in observed_urls:
+                completeness_sources.append(dict(trusted))
+                observed_urls.add(url_key)
         completeness_rejections = [
             reason
             for source in completeness_sources

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -801,7 +801,8 @@ async def _agent_loop(
                             tool_trace["required_final_tool_succeeded"] = True
                         if _tool_result_is_error(handler_result):
                             consecutive_tool_errors += 1
-                            log("warning", f"    🔧 {fn.name} → BLOCKED")
+                            blocked_detail = " ".join(str(handler_result).split())[:1200]
+                            log("warning", f"    🔧 {fn.name} → BLOCKED: {blocked_detail}")
                         else:
                             consecutive_tool_errors = 0
                             log("info", f"    🔧 {fn.name} → OK")

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1103,6 +1103,58 @@ def test_finalize_roster_allows_middle_initial_in_extracted_source_name():
     assert result == "Roster finalized with 1 evidence-backed active candidate(s)."
 
 
+def test_finalize_roster_reuses_persisted_content_evidence_by_url():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    source_url = "https://www.sos.alabama.gov/2026/district-2-certified.pdf"
+    trusted_source = {
+        "url": source_url,
+        "type": "official",
+        "title": "State Certification of Candidates",
+        "evidence": (
+            "Certified and complete qualified candidate list for the August 11, 2026 Special Primary Election "
+            "for U.S. House Congressional District 2: Shomari Figures and Hampton Harris"
+        ),
+        "race_id": "al-house-02-2026",
+        "published_at": "2026-05-22",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House",
+                "contest_stage": "pre_primary",
+                "primary_status": "Special Primary Election on August 11, 2026",
+                "election_date": "2026-08-11",
+            }
+        },
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic", "roster_sources": [trusted_source]},
+            {"name": "Hampton Harris", "party": "Republican", "roster_sources": [trusted_source]},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["finalize_roster"](
+        {
+            "summary": "Reused official certification from the prior verified run.",
+            "candidates": [
+                {"name": "Shomari Figures", "party": "Democratic"},
+                {"name": "Hampton Harris", "party": "Republican"},
+            ],
+            "source_candidate_names": ["Shomari Figures", "Hampton Harris"],
+            "completeness_sources": [{"url": source_url, "title": "State Certification", "evidence": "model-provided claim"}],
+            "_research_trace": {"researched_urls": [], "fetched_urls": []},
+        }
+    )
+
+    assert result == "Roster finalized with 2 evidence-backed active candidate(s)."
+    stored = race_json["pipeline_state"]["roster_research"]["completeness_sources"][0]
+    assert stored["evidence"] == trusted_source["evidence"]
+
+
 def test_add_candidate_blocks_primary_loser_after_nominee_is_known():
     from pipeline_client.agent.agent import _make_editing_handlers
 
@@ -1942,6 +1994,31 @@ def test_not_on_roster_allows_evidence_that_narrates_the_omission():
 
     assert "unlisted" in result
     assert "Justin Maldonado" not in [candidate["name"] for candidate in race_json["candidates"]]
+
+
+def test_not_on_roster_rejects_listing_that_affirmatively_names_target():
+    """A model's contradictory reason cannot turn roster proof into absence proof."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    listing = _nj_roster_listing()
+    listing["text"] = (
+        "Official candidate list for United States Senate New Jersey, 2026: Cory Booker, "
+        "Justin Maldonado, Justin Murphy, and Veronica Fernandez."
+    )
+
+    result = handlers["remove_candidate"](
+        {
+            "name": "Justin Maldonado",
+            "reason": "The official list does not include this candidate.",
+            "not_on_roster": True,
+            "sources": [listing],
+        }
+    )
+
+    assert "blocked" in result.lower()
+    assert "Justin Maldonado" in [candidate["name"] for candidate in race_json["candidates"]]
 
 
 def test_not_on_roster_still_requires_two_corroborating_roster_names():


### PR DESCRIPTION
## Summary
- safely reuse previously persisted tier-1/2 roster content by exact URL during atomic finalization
- expose bounded blocked-tool reasons in debug logs
- reject roster-absence removals when the cited listing affirmatively names the candidate
- document the refresh and debugging behavior

## Validation
- pytest -q (1056 passed)
- git diff --check