### PR TITLE
Enforce exact no-position issue marker

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -188,8 +188,11 @@ as durable evidence, infers only recognizable source classes, and still applies
 current-cycle and exact-contest checks. In production agent loops, the handler
 also cross-checks each cited URL against the loop's actual search/fetch trace;
 model-supplied retrieval metadata cannot promote a URL the run never observed,
-and completeness evidence must have been fetched as page content. A blocked/error tool result is surfaced
-to the model as a failure. After two consecutive blocked edits, roster sync
+and completeness evidence must have been fetched as page content. A refresh may
+reuse an exact URL's already-persisted tier-1/2 content evidence; it reuses the
+stored source object, never the model's new claims about an unfetched page. A
+blocked/error tool result and its bounded reason are recorded in debug logs and
+surfaced to the model as a failure. After two consecutive blocked edits, roster sync
 keeps the accumulated research but escalates subsequent synthesis to the
 stronger roster fallback and directs it to obtain higher-priority evidence
 instead of repeating the same invalid payload.
@@ -244,7 +247,9 @@ Removals have three paths, chosen by what the evidence actually supports:
 - **`not_on_roster=true`** — nothing supports the candidacy and the best roster
   listing for this exact race omits them. The listing must name at least two
   other candidates on the profile (proving it loaded and enumerates the field)
-  and must not name the candidate being removed. It cannot remove the incumbent.
+  and cannot affirmatively list the candidate being removed. Evidence may name
+  that person only when it explicitly describes the omission, withdrawal, or
+  disqualification. It cannot remove the incumbent.
 
 Absence is only evidence when it comes from a source that demonstrably has the
 roster. A page that failed to load, returned nothing, or was truncated is not
@@ -264,8 +269,12 @@ are documented in `.env.example`.
 For an issue unit, a ceiling ends further searching but does not manufacture a
 result. The last turn escalates from an economy model when a stronger configured
 fallback exists, receives the accumulated evidence, and is forced to call
-`set_issue_stance`. Its terminal result must be either a sourced factual stance
-or exactly `No public position found`. The latter is accepted only when the
+`set_issue_stance`. A documented absence is always stored as the exact marker
+`No public position found` with low confidence, including when a later review
+model tries to append its research explanation to the stance field. The
+per-issue research audit records whether the required search actually occurred.
+The terminal result must be either a sourced factual stance or that exact
+marker. The latter is accepted only when the
 durable `pipeline_state.issue_research` audit records at least two search/fetch
 actions. Retry exhaustion leaves the unit incomplete and visible to review;
 it is never converted into a no-position finding.

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -183,13 +183,19 @@ def _source_omits_candidate_from_roster(
     if not _source_is_current_cycle(source, race_id=race_id, text=text):
         return False
 
-    # Deliberately no "the candidate must not appear in the evidence text" check.
-    # The evidence field holds the model's account of the listing, and the natural
-    # way to describe an omission names the person omitted ("enumerates the field
-    # without Justin Maldonado", "listed under withdrawn candidates"). Scanning it
-    # for the name rejects exactly the well-reasoned removals this path exists to
-    # allow. The structural guarantee comes from the corroboration count below:
-    # the listing must independently name candidates who are still on the roster.
+    # A model may mention the target while accurately narrating an omission, but
+    # a source that simply lists the target is affirmative roster evidence and
+    # must never be accepted as proof of absence. If the target appears, require
+    # explicit omission/withdrawal language tied to that account of the listing.
+    if _source_names_candidate(text, candidate_name) and not re.search(
+        r"\b(?:without|omit(?:s|ted)?|absent|not\s+(?:listed|included|named)|"
+        r"does\s+not\s+(?:list|include|name)|withdr(?:ew|awn)|disqualified)\b",
+        text,
+    ):
+        return False
+
+    # The structural guarantee below still requires the listing to independently
+    # name multiple candidates who remain on the roster.
 
     corroborating = 0
     for other in other_roster_names:
@@ -1333,14 +1339,20 @@ def _make_editing_handlers(
                 "Provide sources, or record a documented absence with "
                 "'No public position found'."
             )
+        # Keep the catalog marker machine-readable and consistent across issue
+        # research and later review/iteration passes. Models often append their
+        # search narrative to this field despite being told to use the exact
+        # marker; the research audit is the proper place for that evidence.
+        stored_stance = "No public position found" if is_documented_absence else args["stance"]
+        stored_confidence = "low" if is_documented_absence else args["confidence"]
         stance_data: Dict[str, Any] = {
-            "stance": args["stance"],
-            "confidence": args["confidence"],
+            "stance": stored_stance,
+            "confidence": stored_confidence,
             "sources": merged_sources,
         }
         c.setdefault("issues", {})[issue] = stance_data
-        log("info", f"    {name} / {issue} [{args['confidence']}]")
-        return f"Set {name}'s {issue} stance (confidence: {args['confidence']})."
+        log("info", f"    {name} / {issue} [{stored_confidence}]")
+        return f"Set {name}'s {issue} stance (confidence: {stored_confidence})."
 
     # --- Career, education, social media handlers ---
 

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -801,7 +801,8 @@ async def _agent_loop(
                             tool_trace["required_final_tool_succeeded"] = True
                         if _tool_result_is_error(handler_result):
                             consecutive_tool_errors += 1
-                            log("warning", f"    🔧 {fn.name} → BLOCKED")
+                            blocked_detail = " ".join(str(handler_result).split())[:1200]
+                            log("warning", f"    🔧 {fn.name} → BLOCKED: {blocked_detail}")
                         else:
                             consecutive_tool_errors = 0
                             log("info", f"    🔧 {fn.name} → OK")

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1323,9 +1323,30 @@ def test_set_issue_stance_rejects_placeholder_variants():
         }
     )
     assert "ERROR" not in ok
-    assert race_json["candidates"][0]["issues"]["Healthcare"]["stance"] == (
-        "No public position found after repeated research attempts."
+    assert race_json["candidates"][0]["issues"]["Healthcare"]["stance"] == "No public position found"
+
+
+def test_set_issue_stance_normalizes_review_elaboration_to_exact_absence_marker():
+    """Later review passes cannot turn the canonical marker back into prose."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {"candidates": [{"name": "Alice", "issues": {}}]}
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    result = handlers["set_issue_stance"](
+        {
+            "candidate_name": "Alice",
+            "issue": "Climate/Energy",
+            "stance": "No public position found. The campaign site mentions energy only in passing.",
+            "confidence": "high",
+            "sources": [{"url": "https://example.com/platform", "title": "Campaign platform"}],
+        }
     )
+
+    assert "ERROR" not in result
+    issue = race_json["candidates"][0]["issues"]["Climate/Energy"]
+    assert issue["stance"] == "No public position found"
+    assert issue["confidence"] == "low"
 
 
 def test_is_missing_stance_text_catches_placeholder_variants_not_just_exact_markers():
@@ -1994,6 +2015,31 @@ def test_not_on_roster_allows_evidence_that_narrates_the_omission():
 
     assert "unlisted" in result
     assert "Justin Maldonado" not in [candidate["name"] for candidate in race_json["candidates"]]
+
+
+def test_not_on_roster_rejects_listing_that_affirmatively_names_target():
+    """A model's contradictory reason cannot turn roster proof into absence proof."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = _nj_roster_race()
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+    listing = _nj_roster_listing()
+    listing["text"] = (
+        "Official candidate list for United States Senate New Jersey, 2026: Cory Booker, "
+        "Justin Maldonado, Justin Murphy, and Veronica Fernandez."
+    )
+
+    result = handlers["remove_candidate"](
+        {
+            "name": "Justin Maldonado",
+            "reason": "The official list does not include this candidate.",
+            "not_on_roster": True,
+            "sources": [listing],
+        }
+    )
+
+    assert "blocked" in result.lower()
+    assert "Justin Maldonado" in [candidate["name"] for candidate in race_json["candidates"]]
 
 
 def test_not_on_roster_still_requires_two_corroborating_roster_names():


### PR DESCRIPTION
## Summary
- normalize every documented absence to the exact catalog marker
- force low confidence even when review or iteration elaborates it
- preserve research evidence in sources/audit rather than the stance text

## Validation
- pytest -q (1056 passed)
- git diff --check