### PR TITLE
Handle persisted special-primary roster evidence

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -191,6 +191,10 @@ model-supplied retrieval metadata cannot promote a URL the run never observed,
 and completeness evidence must have been fetched as page content. A refresh may
 reuse an exact URL's already-persisted tier-1/2 content evidence; it reuses the
 stored source object, never the model's new claims about an unfetched page. A
+trusted persisted source is considered automatically during finalization, so a
+low-cost refresh does not depend on the synthesis model repeating its URL.
+For a special primary, completeness matching uses the primary date stated in
+`primary_status`, not the later general-election date stored on the profile. A
 blocked/error tool result and its bounded reason are recorded in debug logs and
 surfaced to the model as a failure. After two consecutive blocked edits, roster sync
 keeps the accumulated research but escalates subsequent synthesis to the

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -522,9 +522,24 @@ def _roster_completeness_source_rejection_reason(
     if "special" in primary_status.casefold():
         if "special" not in text:
             return "race identity is a special election, but the source does not identify the special contest"
-        election_date = str(identity.get("election_date") or "")
+        # The profile election_date is normally the November general election,
+        # while a roster source may certify an earlier special primary. Prefer
+        # the explicit date embedded in primary_status for this gate.
+        parsed_date = None
+        iso_match = re.search(r"\b((?:19|20)\d{2}-\d{2}-\d{2})\b", primary_status)
+        named_match = re.search(
+            r"\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+"
+            r"(\d{1,2})(?:st|nd|rd|th)?[,]?\s+((?:19|20)\d{2})\b",
+            primary_status,
+            re.IGNORECASE,
+        )
         try:
-            parsed_date = datetime.fromisoformat(election_date).date()
+            if iso_match:
+                parsed_date = datetime.fromisoformat(iso_match.group(1)).date()
+            elif named_match:
+                parsed_date = datetime.strptime(" ".join(named_match.groups()), "%B %d %Y").date()
+            else:
+                parsed_date = datetime.fromisoformat(str(identity.get("election_date") or "")).date()
         except ValueError:
             parsed_date = None
         if parsed_date:
@@ -1084,6 +1099,14 @@ def _make_editing_handlers(
             url_key = str(submitted.get("url") or "").strip().rstrip("/").casefold()
             trusted = persisted_roster_sources.get(url_key)
             if trusted and url_key not in observed_urls:
+                completeness_sources.append(dict(trusted))
+                observed_urls.add(url_key)
+        # Durable tier-1/2 evidence is part of the profile's verified state and
+        # should remain available to a cheap refresh even when the final model
+        # neglects to repeat its URL. The handler evaluates the stored objects
+        # against the new proposed roster; it never trusts new unfetched claims.
+        for url_key, trusted in persisted_roster_sources.items():
+            if url_key not in observed_urls:
                 completeness_sources.append(dict(trusted))
                 observed_urls.add(url_key)
         completeness_rejections = [

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -879,7 +879,7 @@ def test_finalize_roster_requires_exact_special_election_completeness_source():
             "_research_trace": {"researched_urls": [special_source["url"]], "fetched_urls": []},
         }
     )
-    assert "no sources were supplied" in searched_only
+    assert "roster finalization blocked" in searched_only
     finalized = handlers["finalize_roster"](
         {
             "summary": "August special primary list",
@@ -891,6 +891,41 @@ def test_finalize_roster_requires_exact_special_election_completeness_source():
         }
     )
     assert finalized == "Roster finalized with 1 evidence-backed active candidate(s)."
+
+
+def test_special_primary_uses_primary_status_date_not_general_election_date():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    source = {
+        "url": "https://elections.example.gov/special-primary-certified.pdf",
+        "type": "official",
+        "title": "Special Primary Certified Candidate List",
+        "evidence": (
+            "Certified candidates for the August 11, 2026 Special Primary Election for U.S. House "
+            "Congressional District 2: Hampton Harris"
+        ),
+        "race_id": "al-house-02-2026",
+        "published_at": "2026-06-03",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House",
+                "contest_stage": "pre_primary",
+                "primary_status": "Special Primary Election on August 11, 2026",
+                "election_date": "2026-11-03",
+            }
+        },
+        "candidates": [{"name": "Hampton Harris", "party": "Republican", "roster_sources": [source]}],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["finalize_roster"]({"summary": "Official special-primary list", "completeness_sources": [source]})
+
+    assert result == "Roster finalized with 1 evidence-backed active candidate(s)."
 
 
 def test_finalize_roster_atomically_applies_complete_proposed_roster():
@@ -1153,6 +1188,56 @@ def test_finalize_roster_reuses_persisted_content_evidence_by_url():
     assert result == "Roster finalized with 2 evidence-backed active candidate(s)."
     stored = race_json["pipeline_state"]["roster_research"]["completeness_sources"][0]
     assert stored["evidence"] == trusted_source["evidence"]
+
+
+def test_finalize_roster_automatically_considers_persisted_completeness_evidence():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    source_url = "https://www.sos.alabama.gov/2026/district-2-certified.pdf"
+    trusted_source = {
+        "url": source_url,
+        "type": "official",
+        "title": "State Certification of Candidates",
+        "evidence": (
+            "Certified candidate list for the August 11, 2026 Special Primary Election for U.S. House "
+            "Congressional District 2: Shomari Figures and Hampton Harris"
+        ),
+        "race_id": "al-house-02-2026",
+        "published_at": "2026-06-03",
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House",
+                "contest_stage": "pre_primary",
+                "primary_status": "Special Primary Election on August 11, 2026",
+                "election_date": "2026-11-03",
+            }
+        },
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic", "roster_sources": [trusted_source]},
+            {"name": "Hampton Harris", "party": "Republican", "roster_sources": [trusted_source]},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["finalize_roster"](
+        {
+            "summary": "Prior official certification remains current.",
+            "candidates": [
+                {"name": "Shomari Figures", "party": "Democratic"},
+                {"name": "Hampton Harris", "party": "Republican"},
+            ],
+            "source_candidate_names": ["Shomari Figures", "Hampton Harris"],
+            "completeness_sources": [],
+            "_research_trace": {"researched_urls": [], "fetched_urls": []},
+        }
+    )
+
+    assert result == "Roster finalized with 2 evidence-backed active candidate(s)."
 
 
 def test_add_candidate_blocks_primary_loser_after_nominee_is_known():


### PR DESCRIPTION
## Summary
- validate special-primary roster sources against the primary date instead of the later general date
- automatically consider trusted persisted tier-1/2 sources during atomic finalization
- add regressions for both live Alabama failure modes

## Validation
- pytest -q (1059 passed)
- git diff --check