### PR TITLE
Deduplicate polls and reject ambiguous portraits

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -227,7 +227,9 @@ summaries are filled even when their biographical facts predate the prior run.
 Polling matchups are evaluated against their contest stage. A primary poll may
 legitimately include only candidates from one party, so `remove_poll` rejects
 attempts whose sole rationale is that the poll omits the other party or does not
-contain the full race roster. Enabled steps also clear their own prior failure
+contain the full race roster. Reports of the same sample/topline under a sponsor
+and pollster name within three days collapse to one poll, and adding a real poll
+clears any stale `No public polling found` note. Enabled steps also clear their own prior failure
 and remaining-work markers before rerunning; failures from unrelated steps are
 preserved and any failure that recurs is recorded anew.
 

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -1653,7 +1653,31 @@ def _make_editing_handlers(
         for existing in race_json.get("polling", []):
             if existing.get("pollster") == args["pollster"] and existing.get("date") == args["date"]:
                 return f"Poll from {args['pollster']} ({args['date']}) already exists — skipping duplicate."
+        for existing in race_json.get("polling", []):
+            same_topline = existing.get("matchups") == poll.get("matchups") and existing.get("sample_size") == poll.get(
+                "sample_size"
+            )
+            try:
+                date_gap = abs(
+                    (
+                        datetime.fromisoformat(str(existing.get("date"))).date() - datetime.fromisoformat(args["date"]).date()
+                    ).days
+                )
+            except (TypeError, ValueError):
+                date_gap = 999
+            if same_topline and date_gap <= 3:
+                sponsor_pattern = re.compile(r"\b(?:DCCC|DSCC|NRCC|NRSC|committee|campaign)\b", re.IGNORECASE)
+                if sponsor_pattern.search(str(existing.get("pollster") or "")) and not sponsor_pattern.search(
+                    str(args["pollster"])
+                ):
+                    existing.update(poll)
+                    if re.search(r"\bno public poll(?:ing|s)?\b", str(race_json.get("polling_note") or ""), re.I):
+                        race_json["polling_note"] = None
+                    return f"Replaced sponsor-labeled duplicate with pollster {args['pollster']} ({args['date']})."
+                return f"Equivalent poll topline already exists near {args['date']} - skipping duplicate."
         race_json.setdefault("polling", []).insert(0, poll)
+        if re.search(r"\bno public poll(?:ing|s)?\b", str(race_json.get("polling_note") or ""), re.IGNORECASE):
+            race_json["polling_note"] = None
         log("info", f"    📊 Added poll: {args['pollster']} ({args['date']})")
         return f"Added poll from {args['pollster']} ({args['date']})."
 

--- a/pipeline_client/agent/images.py
+++ b/pipeline_client/agent/images.py
@@ -84,6 +84,11 @@ def _candidate_surname_token(candidate_name: str) -> Optional[str]:
     return tokens[-1].lower() if tokens else None
 
 
+_WIKIMEDIA_NON_CANDIDATE_QUALIFIERS = frozenset(
+    {"actor", "actress", "band", "composer", "director", "footballer", "musician", "singer"}
+)
+
+
 def _is_untrusted_wikimedia_match(url: str, candidate_name: str) -> bool:
     """True if an upload.wikimedia.org filename does not match the full name.
 
@@ -99,7 +104,8 @@ def _is_untrusted_wikimedia_match(url: str, candidate_name: str) -> bool:
     candidate_tokens = _name_tokens(candidate_name)
     if not candidate_tokens:
         return False
-    return not candidate_tokens.issubset(_name_tokens(unquote(url)))
+    url_tokens = _name_tokens(unquote(url))
+    return not candidate_tokens.issubset(url_tokens) or bool(url_tokens & _WIKIMEDIA_NON_CANDIDATE_QUALIFIERS)
 
 
 # Generic Open-Graph / social-share cards served by data and reference sites

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1814,6 +1814,41 @@ def test_add_poll_allows_source_only_poll_but_rejects_incomplete_matchups():
     assert [poll["pollster"] for poll in race_json["polling"]] == ["Example Source Only Poll"]
 
 
+def test_add_poll_dedupes_sponsor_report_and_clears_stale_no_poll_note():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    matchup = [{"candidates": ["Shomari Figures", "Rhett Marques"], "percentages": [44, 45]}]
+    race_json = {
+        "candidates": [{"name": "Shomari Figures"}, {"name": "Rhett Marques"}],
+        "polling_note": "No public polling found for this race as of 2026-08-01.",
+        "polling": [
+            {
+                "pollster": "Democratic Congressional Campaign Committee (DCCC)",
+                "date": "2026-07-13",
+                "sample_size": 400,
+                "matchups": matchup,
+                "source_url": "https://dccc.example/poll",
+            }
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["add_poll"](
+        {
+            "pollster": "Impact Research",
+            "date": "2026-07-14",
+            "sample_size": 400,
+            "matchups": matchup,
+            "source_url": "https://news.example/impact-poll",
+        }
+    )
+
+    assert "Replaced sponsor-labeled duplicate" in result
+    assert len(race_json["polling"]) == 1
+    assert race_json["polling"][0]["pollster"] == "Impact Research"
+    assert race_json["polling_note"] is None
+
+
 def test_remove_candidate_deletes_malformed_entries():
     """remove_candidate physically deletes entries whose name looks like a metadata key."""
     from pipeline_client.agent.agent import _make_editing_handlers

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -368,3 +368,6 @@ def test_is_untrusted_wikimedia_match_ignores_non_wikimedia_urls():
     assert _is_untrusted_wikimedia_match(
         "https://upload.wikimedia.org/wikipedia/commons/d/d0/Dave_Matthews_Band.jpg", "David Matthews"
     )
+    assert _is_untrusted_wikimedia_match(
+        "https://upload.wikimedia.org/wikipedia/commons/9/9f/David_Matthews_composer.jpg", "David Matthews"
+    )


### PR DESCRIPTION
## Summary
- collapse sponsor/pollster reports of the same adjacent-date topline
- clear stale no-poll notes when valid polling is added
- reject Wikimedia full-name collisions carrying unrelated occupation qualifiers

## Validation
- pytest -q (1060 passed)
- git diff --check