### PR TITLE
Guard filtered polling and resolved portraits

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -229,7 +229,9 @@ legitimately include only candidates from one party, so `remove_poll` rejects
 attempts whose sole rationale is that the poll omits the other party or does not
 contain the full race roster. Reports of the same sample/topline under a sponsor
 and pollster name within three days collapse to one poll, and adding a real poll
-clears any stale `No public polling found` note. Enabled steps also clear their own prior failure
+clears any stale `No public polling found` note. An explicit `roster mismatch`
+rationale is also blocked, preventing a candidate-filtered turn from mistaking
+its narrow view for the complete race. Enabled steps also clear their own prior failure
 and remaining-work markers before rerunning; failures from unrelated steps are
 preserved and any failure that recurs is recorded anew.
 

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -1686,7 +1686,7 @@ def _make_editing_handlers(
         date = args.get("date")
         reason = args.get("reason", "")
         if re.search(
-            r"\b(?:roster alignment|did not include|does not include|missing from (?:the )?matchup|"
+            r"\b(?:roster alignment|roster mismatch|did not include|does not include|missing from (?:the )?matchup|"
             r"subset of (?:the )?(?:full )?roster)\b",
             str(reason),
             re.IGNORECASE,

--- a/pipeline_client/agent/images.py
+++ b/pipeline_client/agent/images.py
@@ -412,7 +412,20 @@ async def _lookup_wikipedia_image(candidate_name: str, context: str = "") -> Opt
                     data = img_resp.json()
                     for page in data.get("query", {}).get("pages", {}).values():
                         thumb = page.get("thumbnail", {}).get("source", "")
-                        if thumb and "upload.wikimedia.org" in thumb:
+                        resolved_title = str(page.get("title") or title)
+                        if candidate_tokens and (
+                            not candidate_tokens.issubset(_name_tokens(resolved_title))
+                            or _name_tokens(resolved_title) & _WIKIMEDIA_NON_CANDIDATE_QUALIFIERS
+                        ):
+                            logger.debug(
+                                "Rejected resolved Wikipedia title %r for candidate %r", resolved_title, candidate_name
+                            )
+                            continue
+                        if (
+                            thumb
+                            and urlparse(thumb).netloc.casefold() == "upload.wikimedia.org"
+                            and not _is_untrusted_wikimedia_match(thumb, candidate_name)
+                        ):
                             return thumb
                 return None
 

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1742,6 +1742,12 @@ def test_remove_poll_blocks_full_roster_alignment_for_primary_matchup():
     assert result.startswith("ERROR: Poll removal blocked")
     assert race_json["polling"] == [poll]
 
+    mismatch = handlers["remove_poll"](
+        {"pollster": "Peak Insights", "date": "2026-06-09", "reason": "malformed poll (roster mismatch)"}
+    )
+    assert mismatch.startswith("ERROR: Poll removal blocked")
+    assert race_json["polling"] == [poll]
+
 
 def test_add_poll_requires_exact_roster_names():
     from pipeline_client.agent.agent import _make_editing_handlers

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -318,6 +318,19 @@ async def test_lookup_wikipedia_image_rejects_same_surname_unrelated_entity(monk
 
 
 @pytest.mark.asyncio
+async def test_lookup_wikipedia_image_rejects_exact_name_composer_thumbnail(monkeypatch):
+    fake_client = _FakeWikipediaClient(
+        opensearch_titles={"David Matthews": ["David Matthews"]},
+        thumbnails={"David Matthews": "https://upload.wikimedia.org/wikipedia/commons/9/9f/David_Matthews_composer.jpg"},
+    )
+    monkeypatch.setattr("pipeline_client.agent.images.httpx.AsyncClient", fake_client)
+
+    result = await _lookup_wikipedia_image("David Matthews")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_resolve_single_image_discards_stale_mismatched_wikimedia_url(monkeypatch):
     # A prior run can persist a mismatched Wikimedia URL onto image_url (e.g. from
     # the opensearch fuzzy-match bug before it was fixed). The existing-URL fast


### PR DESCRIPTION
## Summary
- validate resolved Wikipedia titles and thumbnails, not only initial search titles
- reject poll removals justified by roster mismatch in candidate-filtered runs
- add live-failure regressions and operational documentation

## Validation
- pytest -q (1068 passed)
- git diff --check