### PR TITLE
Deduplicate persisted polling globally

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -277,12 +277,61 @@ def _sanitize_polling(race_json: Dict[str, Any], log: Any | None = None) -> None
             continue
         kept_polls.append(poll)
 
-    if len(kept_polls) != len(polling):
-        race_json["polling"] = kept_polls
+    sponsor_pattern = re.compile(r"\b(?:DCCC|DSCC|NRCC|NRSC|committee|campaign)\b", re.IGNORECASE)
+    deduplicated_polls: List[Dict[str, Any]] = []
+    removed_duplicate_labels: List[str] = []
+    for poll in kept_polls:
+        duplicate_index = None
+        for index, existing in enumerate(deduplicated_polls):
+            if existing.get("matchups") != poll.get("matchups") or existing.get("sample_size") != poll.get("sample_size"):
+                continue
+            try:
+                date_gap = abs(
+                    (
+                        datetime.fromisoformat(str(existing.get("date"))).date()
+                        - datetime.fromisoformat(str(poll.get("date"))).date()
+                    ).days
+                )
+            except (TypeError, ValueError):
+                continue
+            if date_gap <= 3:
+                duplicate_index = index
+                break
+
+        if duplicate_index is None:
+            deduplicated_polls.append(poll)
+            continue
+
+        existing = deduplicated_polls[duplicate_index]
+        existing_is_sponsor = bool(sponsor_pattern.search(str(existing.get("pollster") or "")))
+        poll_is_sponsor = bool(sponsor_pattern.search(str(poll.get("pollster") or "")))
+        if existing_is_sponsor and not poll_is_sponsor:
+            removed_duplicate_labels.append(str(existing.get("pollster") or ""))
+            deduplicated_polls[duplicate_index] = poll
+        else:
+            removed_duplicate_labels.append(str(poll.get("pollster") or ""))
+
+    total_dropped = dropped_polls + len(kept_polls) - len(deduplicated_polls)
+    if removed_duplicate_labels:
+        note = str(race_json.get("polling_note") or "")
+        removed_sponsor = any(sponsor_pattern.search(label) for label in removed_duplicate_labels)
+        if any(label and label.casefold() in note.casefold() for label in removed_duplicate_labels) or (
+            removed_sponsor and sponsor_pattern.search(note)
+        ):
+            race_json["polling_note"] = None
         if log:
             log(
                 "warning",
-                f"Dropped {dropped_polls} malformed or placeholder polling entr{'y' if dropped_polls == 1 else 'ies'}",
+                "Removed equivalent near-date polling duplicate(s): " + ", ".join(removed_duplicate_labels),
+            )
+
+    if deduplicated_polls != polling:
+        race_json["polling"] = deduplicated_polls
+        if log:
+            log(
+                "warning",
+                f"Dropped {total_dropped} malformed, placeholder, or duplicate polling "
+                f"entr{'y' if total_dropped == 1 else 'ies'}",
             )
 
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1531,6 +1531,58 @@ def test_sanitize_polling_keeps_source_only_polls_without_numeric_percentages():
     assert race_json["polling"][0]["matchups"] == []
 
 
+def test_sanitize_polling_dedupes_sponsor_copy_and_clears_contradictory_note():
+    matchup = [{"candidates": ["Alice Smith", "Bob Jones"], "percentages": [44, 45]}]
+    race_json = {
+        "candidates": [{"name": "Alice Smith"}, {"name": "Bob Jones"}],
+        "polling_note": "Impact Research and DCCC both show Alice 44 and Bob 45.",
+        "polling": [
+            {
+                "pollster": "Impact Research",
+                "date": "2026-07-14",
+                "sample_size": 400,
+                "matchups": copy.deepcopy(matchup),
+            },
+            {
+                "pollster": "Democratic Congressional Campaign Committee (DCCC)",
+                "date": "2026-07-13",
+                "sample_size": 400,
+                "matchups": copy.deepcopy(matchup),
+            },
+        ],
+    }
+
+    _sanitize_polling(race_json)
+
+    assert [poll["pollster"] for poll in race_json["polling"]] == ["Impact Research"]
+    assert race_json["polling_note"] is None
+
+
+def test_sanitize_polling_prefers_pollster_when_sponsor_copy_comes_first():
+    matchup = [{"candidates": ["Alice Smith", "Bob Jones"], "percentages": [44, 45]}]
+    race_json = {
+        "candidates": [{"name": "Alice Smith"}, {"name": "Bob Jones"}],
+        "polling": [
+            {
+                "pollster": "DCCC",
+                "date": "2026-07-13",
+                "sample_size": 400,
+                "matchups": copy.deepcopy(matchup),
+            },
+            {
+                "pollster": "Impact Research",
+                "date": "2026-07-14",
+                "sample_size": 400,
+                "matchups": copy.deepcopy(matchup),
+            },
+        ],
+    }
+
+    _sanitize_polling(race_json)
+
+    assert [poll["pollster"] for poll in race_json["polling"]] == ["Impact Research"]
+
+
 @pytest.mark.asyncio
 async def test_polling_step_runs_without_issue_finance_or_refinement():
     reviews = [


### PR DESCRIPTION
Summary: normalize equivalent near-date polls across the full persisted collection; prefer named pollsters over sponsor-labeled copies; clear notes that reference removed duplicates. Validation: targeted 152-test suite, Black, and diff check all pass.