### PR TITLE
Let continuations finish bounded research

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -721,6 +721,7 @@ async def run_agent(
 
     # Initialise a fresh cost accumulator for this run
     prior_agent_metrics = prior_agent_metrics or {}
+    prior_phase_breakdown = copy.deepcopy(prior_agent_metrics.get("phase_breakdown", {}))
     _acc: Dict[str, Any] = {
         "prompt_tokens": int(prior_agent_metrics.get("prompt_tokens", 0) or 0),
         "completion_tokens": int(prior_agent_metrics.get("completion_tokens", 0) or 0),
@@ -743,7 +744,19 @@ async def run_agent(
         "retry_provider_failures": int(prior_agent_metrics.get("retry_provider_failures", 0) or 0),
         "retry_deadline_exits": int(prior_agent_metrics.get("retry_deadline_exits", 0) or 0),
         "model_breakdown": copy.deepcopy(prior_agent_metrics.get("model_breakdown", {})),
-        "phase_breakdown": copy.deepcopy(prior_agent_metrics.get("phase_breakdown", {})),
+        "phase_breakdown": prior_phase_breakdown,
+        # Per-phase ceilings bound one physical invocation. A continuation gets
+        # a fresh phase allowance while the logical-run totals below remain
+        # cumulative, so it can finish untouched work without losing cost caps.
+        "_phase_budget_baselines": {
+            phase: {
+                "prompt_tokens": int(metrics.get("prompt_tokens", 0) or 0),
+                "completion_tokens": int(metrics.get("completion_tokens", 0) or 0),
+                "search_calls": int(metrics.get("search_calls", 0) or 0),
+            }
+            for phase, metrics in prior_phase_breakdown.items()
+            if isinstance(metrics, dict)
+        },
         "page_fetches": int(prior_agent_metrics.get("page_fetches", 0) or 0),
         "fetched_chars": int(prior_agent_metrics.get("fetched_chars", 0) or 0),
         "page_budget_blocked": int(prior_agent_metrics.get("page_budget_blocked", 0) or 0),

--- a/pipeline_client/agent/cost.py
+++ b/pipeline_client/agent/cost.py
@@ -60,6 +60,12 @@ def _phase_entry(acc: Dict[str, Any]) -> Dict[str, Any]:
     )
 
 
+def _phase_budget_baseline(acc: Dict[str, Any]) -> Dict[str, int]:
+    """Return metrics already spent before this physical continuation pass."""
+    baseline = acc.get("_phase_budget_baselines", {}).get(_phase_ctx.get(), {})
+    return baseline if isinstance(baseline, dict) else {}
+
+
 def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> float:
     """Return estimated USD cost for a single model call."""
     spec = MODEL_CATALOG.get(normalize_model_id(model) or model)
@@ -150,7 +156,9 @@ def reserve_search_call(provider: str) -> bool:
     config = PipelineRuntimeConfig.from_env()
     used = int(acc.get("serper_calls", 0) or 0) + int(acc.get("searlo_calls", 0) or 0)
     phase = _phase_entry(acc)
-    if used >= config.max_search_calls or int(phase.get("search_calls", 0)) >= config.max_phase_search_calls:
+    baseline = _phase_budget_baseline(acc)
+    phase_used = int(phase.get("search_calls", 0)) - int(baseline.get("search_calls", 0))
+    if used >= config.max_search_calls or phase_used >= config.max_phase_search_calls:
         acc["search_budget_blocked"] = int(acc.get("search_budget_blocked", 0) or 0) + 1
         phase["search_budget_blocked"] = int(phase.get("search_budget_blocked", 0) or 0) + 1
         return False
@@ -196,7 +204,13 @@ def total_token_budget_reached() -> bool:
     used = int(acc.get("prompt_tokens", 0) or 0) + int(acc.get("completion_tokens", 0) or 0)
     config = PipelineRuntimeConfig.from_env()
     phase = _phase_entry(acc)
-    phase_used = int(phase.get("prompt_tokens", 0) or 0) + int(phase.get("completion_tokens", 0) or 0)
+    baseline = _phase_budget_baseline(acc)
+    phase_used = (
+        int(phase.get("prompt_tokens", 0) or 0)
+        + int(phase.get("completion_tokens", 0) or 0)
+        - int(baseline.get("prompt_tokens", 0) or 0)
+        - int(baseline.get("completion_tokens", 0) or 0)
+    )
     return used >= config.max_total_tokens or phase_used >= config.max_phase_tokens
 
 

--- a/shared/pipeline_config.py
+++ b/shared/pipeline_config.py
@@ -96,8 +96,8 @@ class PipelineRuntimeConfig:
     iteration_min_iterations: int = 14
     quality_critical_issue_stances: int = CANONICAL_ISSUE_COUNT // 2
     quality_warning_issue_stances: int = (CANONICAL_ISSUE_COUNT * 2) // 3
-    max_search_calls: int = 240
-    max_total_tokens: int = 2_500_000
+    max_search_calls: int = 480
+    max_total_tokens: int = 5_000_000
     max_phase_search_calls: int = 120
     max_phase_tokens: int = 1_250_000
     max_page_fetches: int = 300
@@ -119,8 +119,8 @@ class PipelineRuntimeConfig:
             iteration_min_iterations=_env_int("PIPELINE_ITERATION_MIN_ITERATIONS", 14, 1, None),
             quality_critical_issue_stances=critical,
             quality_warning_issue_stances=warning,
-            max_search_calls=_env_int("PIPELINE_MAX_SEARCH_CALLS", 240, 1, 5000),
-            max_total_tokens=_env_int("PIPELINE_MAX_TOTAL_TOKENS", 2_500_000, 10_000, 50_000_000),
+            max_search_calls=_env_int("PIPELINE_MAX_SEARCH_CALLS", 480, 1, 5000),
+            max_total_tokens=_env_int("PIPELINE_MAX_TOTAL_TOKENS", 5_000_000, 10_000, 50_000_000),
             max_phase_search_calls=_env_int("PIPELINE_MAX_PHASE_SEARCH_CALLS", 120, 1, 5000),
             max_phase_tokens=_env_int("PIPELINE_MAX_PHASE_TOKENS", 1_250_000, 10_000, 50_000_000),
             max_page_fetches=_env_int("PIPELINE_MAX_PAGE_FETCHES", 300, 1, 5000),

--- a/shared/race_cleanup.py
+++ b/shared/race_cleanup.py
@@ -84,6 +84,15 @@ def cleanup_race_data(race_data: Dict[str, Any]) -> Dict[str, int]:
             race_data[field] = after
             text_changes += 1
 
+    description = str(race_data.get("description") or "")
+    jurisdiction = str(race_data.get("jurisdiction") or "").strip()
+    district_match = re.search(r"\b\d+(?:st|nd|rd|th) Congressional District race\b", description, re.IGNORECASE)
+    if jurisdiction and district_match:
+        damaged_prefix = description[: district_match.start()]
+        if damaged_prefix.count("'s") >= 4 or any(ord(char) > 127 for char in damaged_prefix):
+            race_data["description"] = f"{jurisdiction} race{description[district_match.end():]}"
+            text_changes += 1
+
     for candidate in race_data.get("candidates", []):
         if not isinstance(candidate, dict):
             continue

--- a/tests/test_agent_cost.py
+++ b/tests/test_agent_cost.py
@@ -195,3 +195,25 @@ def test_phase_search_and_page_budgets_are_enforced(cost_accumulator, monkeypatc
     assert reserve_page_fetch() is True
     assert reserve_page_fetch() is False
     assert cost_accumulator["page_budget_blocked"] == 1
+
+
+def test_continuation_phase_budget_ignores_prior_phase_spend_but_keeps_logical_total(cost_accumulator, monkeypatch):
+    monkeypatch.setenv("PIPELINE_MAX_PHASE_SEARCH_CALLS", "2")
+    monkeypatch.setenv("PIPELINE_MAX_SEARCH_CALLS", "10")
+    monkeypatch.setenv("PIPELINE_MAX_PHASE_TOKENS", "10000")
+    monkeypatch.setenv("PIPELINE_MAX_TOTAL_TOKENS", "50000")
+    set_current_phase("issues")
+    cost_accumulator.update(
+        {
+            "prompt_tokens": 12000,
+            "completion_tokens": 3000,
+            "serper_calls": 2,
+            "searlo_calls": 0,
+            "phase_breakdown": {"issues": {"prompt_tokens": 12000, "completion_tokens": 3000, "search_calls": 2}},
+            "_phase_budget_baselines": {"issues": {"prompt_tokens": 12000, "completion_tokens": 3000, "search_calls": 2}},
+        }
+    )
+
+    assert total_token_budget_reached() is False
+    assert reserve_search_call("serper") is True
+    assert cost_accumulator["serper_calls"] == 3

--- a/tests/test_race_cleanup.py
+++ b/tests/test_race_cleanup.py
@@ -61,6 +61,21 @@ def test_forecast_evidence_gate_records_degraded_step_failure():
     ]
 
 
+def test_cleanup_repairs_pathological_repeated_district_description_prefix():
+    race = {
+        "jurisdiction": "Alabama's 2nd Congressional District",
+        "description": (
+            "Alabama's 202020202's2's2's2's2's2's2\u0d82\u0b3e's 2nd Congressional District race "
+            "is shaped by ongoing redistricting litigation."
+        ),
+    }
+
+    report = cleanup_race_data(race)
+
+    assert race["description"] == ("Alabama's 2nd Congressional District race is shaped by ongoing redistricting litigation.")
+    assert report["text_changes"] == 1
+
+
 def test_forecast_evidence_gate_requires_named_rating_source():
     race = {
         "pipeline_state": {},


### PR DESCRIPTION
Summary: reset per-phase budget accounting at physical continuation boundaries while preserving logical-run totals and exact costs; enlarge the bounded default envelope for crowded all-issue runs; repair pathological repeated district-description prefixes deterministically. The AL-02 debug run demonstrated the old continuation began synthesis-only with zero research actions. Validation: 33 focused tests pass, Black and diff checks pass.