### PR TITLE
Expose safe partial pipeline resume

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -103,6 +103,9 @@ Use an update when the existing race is generally good:
   when the correction goal justifies their cost
 - explicit `enabled_steps` always override the update default
 - pass `candidate_names` for candidate-specific repair
+- pass `resume_partial=true` only when `baseline_source=latest` points to a
+  trusted pipeline checkpoint or draft whose completed work-unit markers must
+  be preserved; ordinary issue refreshes deliberately research enabled units again
 - use `review` after material issue or narrative changes and `iteration` only
   when model-assisted correction is appropriate
 

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -715,7 +715,7 @@ class AgentHandler:
                 target_no_info=options.get("target_no_info", False),
                 candidate_names=options.get("candidate_names"),
                 goal=options.get("goal"),
-                resume_partial=bool(options.get("is_continuation")),
+                resume_partial=bool(options.get("is_continuation") or options.get("resume_partial")),
                 continue_incomplete_work=True,
                 reject_empty_candidates=True,
                 prior_agent_metrics=options.get("prior_agent_metrics"),

--- a/shared/pipeline_options.py
+++ b/shared/pipeline_options.py
@@ -23,6 +23,7 @@ class PipelineRunOptions(BaseModel):
     goal: Optional[str] = None
     force_fresh: Optional[bool] = None
     baseline_source: Optional[Literal["latest", "published"]] = None
+    resume_partial: Optional[bool] = None
     research_model: Optional[str] = None
     claude_model: Optional[str] = None
     gemini_model: Optional[str] = None
@@ -86,4 +87,5 @@ class ResolvedPipelineRunOptions(PipelineRunOptions):
     save_artifact: bool = True
     force_fresh: bool = False
     baseline_source: Literal["latest", "published"] = "latest"
+    resume_partial: bool = False
     target_no_info: bool = False

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -534,6 +534,7 @@ async def queue_races(
     cheap_mode: bool | None = True,
     force_fresh: bool | None = None,
     baseline_source: Literal["latest", "published"] | None = None,
+    resume_partial: bool | None = None,
     save_artifact: bool | None = None,
     enabled_steps: List[str] | None = None,
     research_model: str | None = None,
@@ -560,12 +561,15 @@ async def queue_races(
     Expensive default/quality/custom model profiles require explicitly passing
     cheap_mode=False. Set baseline_source="published" for a targeted repair
     that must ignore any existing draft; the default "latest" behavior prefers
-    a draft and falls back to published data.
+    a draft and falls back to published data. Set resume_partial=True only when
+    the latest draft is a trusted pipeline checkpoint whose completed work-unit
+    markers should be preserved instead of deliberately refreshed.
     """
     options = _pipeline_options(
         cheap_mode=cheap_mode,
         force_fresh=force_fresh,
         baseline_source=baseline_source,
+        resume_partial=resume_partial,
         save_artifact=save_artifact,
         enabled_steps=enabled_steps,
         research_model=research_model,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -105,6 +105,7 @@ async def test_v2_handler_passes_enabled_steps():
                 "cheap_mode": True,
                 "enabled_steps": ["discovery", "images", "issues"],
                 "candidate_names": ["Jeff Wadlin"],
+                "resume_partial": True,
             },
         )
 
@@ -112,6 +113,7 @@ async def test_v2_handler_passes_enabled_steps():
     call_kwargs = mock_agent.call_args
     assert call_kwargs.kwargs["enabled_steps"] == ["discovery", "images", "issues"]
     assert call_kwargs.kwargs["candidate_names"] == ["Jeff Wadlin"]
+    assert call_kwargs.kwargs["resume_partial"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline_options.py
+++ b/tests/test_pipeline_options.py
@@ -18,6 +18,11 @@ from shared.pipeline_options import PipelineRunOptions, ResolvedPipelineRunOptio
 # ---------------------------------------------------------------------------
 
 
+def test_resume_partial_defaults_false_and_is_explicitly_available():
+    assert ResolvedPipelineRunOptions().resume_partial is False
+    assert ResolvedPipelineRunOptions(resume_partial=True).resume_partial is True
+
+
 def test_normalize_pipeline_steps_none_passthrough():
     assert normalize_pipeline_steps(None) is None
 

--- a/tests/test_smartervote_mcp_client.py
+++ b/tests/test_smartervote_mcp_client.py
@@ -657,6 +657,10 @@ def test_mcp_pipeline_options_default_to_cheap_mode():
         "cheap_mode": True,
         "baseline_source": "published",
     }
+    assert _pipeline_options(resume_partial=True) == {
+        "cheap_mode": True,
+        "resume_partial": True,
+    }
 
 
 def test_mcp_pipeline_options_require_explicit_false_for_quality_profile():

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -468,10 +468,11 @@ export interface RunOptions {
     review_grok?: string;
   };
   force_fresh?: boolean;
-  // baseline_source/runner are power-user options (set via admin tooling/MCP,
+  // baseline_source/resume_partial/runner are power-user options (set via admin tooling/MCP,
   // not the standard queue form) but are still valid wire-level fields on
   // shared.pipeline_options.PipelineRunOptions — kept here for completeness.
   baseline_source?: "latest" | "published";
+  resume_partial?: boolean;
   runner?: "cloud_run" | "local";
   research_model?: string;
   claude_model?: string;


### PR DESCRIPTION
Summary: add an explicit resume_partial run option across the API, worker, and MCP; preserve trusted completed work-unit markers without using internal continuation flags; document that it is only for trusted latest drafts/checkpoints. This closes the recovery gap exposed by AL-02. Validation: 71 focused tests, Black, and diff checks pass.