### PR TITLE
Stop targeted issue runs from wiping other candidates' audits

### DIFF
--- a/pipeline_client/agent/phases/issues.py
+++ b/pipeline_client/agent/phases/issues.py
@@ -389,10 +389,22 @@ async def run_issues_phase(
         issue_research = {}
         race_json["pipeline_state"]["issue_research"] = issue_research
     if not resume_partial:
-        completed_units = {unit for unit in completed_units if not unit.startswith("issues:")}
+        # Reset only the candidates this run will actually research. Clearing
+        # race-wide destroyed the research audit for everyone else, and review
+        # flags a "No public position found" stance whose audit is missing — so a
+        # targeted candidate_names repair re-broke every candidate it skipped and
+        # no sequence of targeted runs could ever converge.
+        scoped_names = {str(name) for name in candidate_names}
+
+        def _belongs_to_scope(unit: str) -> bool:
+            parts = unit.split(":")
+            return len(parts) >= 2 and parts[1] in scoped_names
+
+        completed_units = {unit for unit in completed_units if not (unit.startswith("issues:") and _belongs_to_scope(unit))}
         race_json["pipeline_state"]["completed_units"] = sorted(completed_units)
-        issue_attempts.clear()
-        issue_research.clear()
+        for tracker in (issue_attempts, issue_research):
+            for unit_id in [key for key in tracker if key.startswith("issues:") and _belongs_to_scope(key)]:
+                del tracker[unit_id]
     else:
         candidates_by_name = {
             str(candidate.get("name")): candidate

--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -309,8 +309,31 @@ async def _run_single_review(
         return None
 
 
-async def _verify_url(client: httpx.AsyncClient, url: str) -> Optional[str]:
-    """Check whether a URL is reachable through the SSRF-safe fetch path."""
+# Failures that will not resolve themselves on a retry, so the citation can be
+# dropped deterministically instead of being handed back to a model. A host that
+# does not resolve is at least as dead as a 404.
+_PERMANENT_DNS_FAILURE_MARKERS = (
+    "name or service not known",
+    "nodename nor servname provided",
+    "getaddrinfo failed",
+    "no address associated with hostname",
+    "name does not resolve",
+)
+
+
+def _is_permanent_link_failure(exc: Exception) -> bool:
+    """True when a fetch failure means the URL is gone, not merely unreachable now."""
+    if isinstance(exc, ValueError):
+        return True  # malformed / disallowed URL
+    text = str(exc).casefold()
+    return any(marker in text for marker in _PERMANENT_DNS_FAILURE_MARKERS)
+
+
+async def _verify_url(client: httpx.AsyncClient, url: str) -> Optional[tuple[str, bool]]:
+    """Check a URL through the SSRF-safe fetch path.
+
+    Returns ``None`` when healthy, otherwise ``(reason, permanent)``.
+    """
     try:
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
@@ -319,12 +342,12 @@ async def _verify_url(client: httpx.AsyncClient, url: str) -> Optional[str]:
         if _is_access_restricted_response(url, resp.status_code):
             return None
         if resp.status_code >= 400:
-            return f"HTTP error {resp.status_code}"
+            return f"HTTP error {resp.status_code}", resp.status_code in {404, 410}
         return None
     except (httpx.HTTPError, ValueError) as exc:
-        return f"Request failed: {exc}"
+        return f"Request failed: {exc}", _is_permanent_link_failure(exc)
     except Exception as exc:
-        return f"Error: {exc}"
+        return f"Error: {exc}", False
 
 
 async def check_profile_links(
@@ -381,12 +404,16 @@ async def check_profile_links(
     flags = []
     for url, path, err in check_results:
         if err:
+            reason, permanent = err
             flags.append(
                 {
                     "field": path,
-                    "concern": f"Cited source URL ({url}) returned a dead link: {err}.",
+                    "concern": f"Cited source URL ({url}) returned a dead link: {reason}.",
                     "suggestion": "Verify the URL, find a replacement source, and update the stance.",
                     "severity": "warning",
+                    # Machine-readable so deterministic cleanup does not have to
+                    # parse this sentence back out of prose.
+                    "permanent_failure": permanent,
                 }
             )
 
@@ -405,7 +432,12 @@ async def check_profile_links(
 
 
 def _remove_confirmed_dead_candidate_sources(race_json: Dict[str, Any], link_review: Dict[str, Any]) -> int:
-    """Remove candidate URLs that the link validator confirmed as HTTP 404/410."""
+    """Remove candidate URLs the link validator confirmed are permanently gone.
+
+    Covers HTTP 404/410 and unresolvable hosts. A DNS failure used to fall through
+    to the model, which then had to remove the citation by hand — in practice it
+    never did, and the unfixable flag blocked publication indefinitely.
+    """
     if not isinstance(link_review, dict):
         return 0
     removals: Dict[int, set[str]] = {}
@@ -413,7 +445,11 @@ def _remove_confirmed_dead_candidate_sources(race_json: Dict[str, Any], link_rev
         if not isinstance(flag, dict):
             continue
         concern = str(flag.get("concern") or "")
-        if "HTTP error 404" not in concern and "HTTP error 410" not in concern:
+        permanent = flag.get("permanent_failure")
+        if permanent is None:
+            # Reviews stored before permanent_failure existed.
+            permanent = "HTTP error 404" in concern or "HTTP error 410" in concern
+        if not permanent:
             continue
         field_match = re.match(r"candidates\[(\d+)\]", str(flag.get("field") or ""))
         url_match = re.search(r"Cited source URL \((https?://[^)]+)\)", concern)

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -2307,3 +2307,74 @@ def test_completeness_gate_still_rejects_single_candidate_evidence():
     assert _roster_completeness_source_rejection_reason(
         source, race_id="nj-senate-2026", identity={"office": "U.S. Senate", "contest_stage": "post_primary_general"}
     )
+
+
+@pytest.mark.asyncio
+async def test_targeted_issue_run_preserves_other_candidates_audits():
+    """Regression: a scoped candidate_names run used to wipe the whole race's audit.
+
+    Review flags any "No public position found" stance whose research audit is
+    missing, so clearing race-wide meant every targeted repair re-broke the
+    candidates it skipped and no sequence of runs could converge.
+    """
+    from pipeline_client.agent.phases.issues import run_issues_phase
+
+    race_json = {
+        "id": "nj-senate-2026",
+        "candidates": [
+            {"name": "Justin Murphy", "issues": {}},
+            {"name": "Veronica Fernandez", "issues": {}},
+        ],
+        "pipeline_state": {
+            "completed_units": ["issues:Justin Murphy:Economy", "issues:Veronica Fernandez:Economy"],
+            "issue_attempts": {"issues:Justin Murphy:Economy": 1, "issues:Veronica Fernandez:Economy": 1},
+            "issue_research": {
+                "issues:Justin Murphy:Economy": {"status": "completed", "search_calls": 2, "page_fetches": 1},
+                "issues:Veronica Fernandez:Economy": {"status": "completed", "search_calls": 2, "page_fetches": 1},
+            },
+        },
+    }
+
+    await run_issues_phase(
+        race_json,
+        "nj-senate-2026",
+        candidate_names=["Veronica Fernandez"],
+        small_model="test-model",
+        on_log=None,
+        max_iterations=1,
+        step_enabled=lambda _step: False,  # stop before doing real research
+        track=lambda *_a, **_kw: None,
+        max_candidates=None,
+        target_no_info=False,
+        is_update=True,
+        last_updated="",
+        log=lambda *_a, **_kw: None,
+        prefix="Test Phase",
+        resume_partial=False,
+        continue_incomplete_work=False,
+        run_budget=None,
+    )
+
+    research = race_json["pipeline_state"]["issue_research"]
+    assert "issues:Justin Murphy:Economy" in research, "skipped candidate's audit must survive"
+
+
+def test_scoped_issue_reset_clears_only_targeted_candidates():
+    """Directly exercise the scoping rule the phase applies to its trackers."""
+    from pipeline_client.agent.phases.issues import run_issues_phase  # noqa: F401  (import guard)
+
+    scoped_names = {"Veronica Fernandez"}
+
+    def belongs_to_scope(unit):
+        parts = unit.split(":")
+        return len(parts) >= 2 and parts[1] in scoped_names
+
+    units = {
+        "issues:Justin Murphy:Economy",
+        "issues:Veronica Fernandez:Economy",
+        "issues:Veronica Fernandez:Healthcare",
+        "discovery.roster_sync",
+    }
+    kept = {u for u in units if not (u.startswith("issues:") and belongs_to_scope(u))}
+
+    assert kept == {"issues:Justin Murphy:Economy", "discovery.roster_sync"}

--- a/tests/test_models_review.py
+++ b/tests/test_models_review.py
@@ -549,7 +549,8 @@ async def test_verify_url_still_flags_non_facebook_400():
     response = httpx.Response(400, request=httpx.Request("GET", url))
 
     with patch("pipeline_client.agent.review._get_validated", new_callable=AsyncMock, return_value=response):
-        assert await _verify_url(AsyncMock(), url) == "HTTP error 400"
+        # 400 is a real failure but not permanent, so it must not be auto-removed.
+        assert await _verify_url(AsyncMock(), url) == ("HTTP error 400", False)
 
 
 def test_profile_quality_flags_title_like_description():
@@ -601,3 +602,90 @@ def test_profile_quality_flags_duplicate_stale_and_unsourced_claims():
     assert any("Duplicate source URL" in concern for concern in concerns)
     assert any("more than one year old" in concern for concern in concerns)
     assert any("Substantive issue stance has no supporting sources" in concern for concern in concerns)
+
+
+@pytest.mark.asyncio
+async def test_verify_url_marks_unresolvable_host_permanent():
+    """A host that does not resolve is at least as dead as a 404."""
+    import httpx
+
+    from pipeline_client.agent.review import _verify_url
+
+    url = "https://www.ballotpedia.org/Joanne_Kuniansky"
+    exc = httpx.ConnectError("[Errno -2] Name or service not known")
+
+    with patch("pipeline_client.agent.review._get_validated", new_callable=AsyncMock, side_effect=exc):
+        reason, permanent = await _verify_url(AsyncMock(), url)
+
+    assert permanent is True
+    assert "Name or service not known" in reason
+
+
+@pytest.mark.asyncio
+async def test_verify_url_keeps_timeouts_transient():
+    import httpx
+
+    from pipeline_client.agent.review import _verify_url
+
+    with patch(
+        "pipeline_client.agent.review._get_validated",
+        new_callable=AsyncMock,
+        side_effect=httpx.ReadTimeout("timed out"),
+    ):
+        _reason, permanent = await _verify_url(AsyncMock(), "https://example.com/slow")
+
+    assert permanent is False
+
+
+def test_dead_source_removal_covers_unresolvable_hosts():
+    """Regression: a DNS-dead citation blocked publication across five runs."""
+    from pipeline_client.agent.review import _remove_confirmed_dead_candidate_sources
+
+    dead = "https://www.ballotpedia.org/Joanne_Kuniansky"
+    race_json = {
+        "candidates": [
+            {
+                "name": "Joanne Kuniansky",
+                "issues": {
+                    "Economy": {
+                        "stance": "Supports a public works program.",
+                        "sources": [{"url": dead}, {"url": "https://themilitant.com/2026/swp-campaign"}],
+                    }
+                },
+            }
+        ]
+    }
+    link_review = {
+        "flags": [
+            {
+                "field": "candidates[0].issues.Economy.sources[0].url",
+                "concern": f"Cited source URL ({dead}) returned a dead link: Request failed: [Errno -2] Name or service not known.",
+                "permanent_failure": True,
+            }
+        ]
+    }
+
+    removed = _remove_confirmed_dead_candidate_sources(race_json, link_review)
+
+    assert removed == 1
+    remaining = [s["url"] for s in race_json["candidates"][0]["issues"]["Economy"]["sources"]]
+    assert dead not in remaining
+    assert "https://themilitant.com/2026/swp-campaign" in remaining
+
+
+def test_dead_source_removal_leaves_transient_failures_alone():
+    from pipeline_client.agent.review import _remove_confirmed_dead_candidate_sources
+
+    url = "https://example.com/slow"
+    race_json = {"candidates": [{"name": "A", "issues": {"Economy": {"stance": "x", "sources": [{"url": url}]}}}]}
+    link_review = {
+        "flags": [
+            {
+                "field": "candidates[0].issues.Economy.sources[0].url",
+                "concern": f"Cited source URL ({url}) returned a dead link: Request failed: timed out.",
+                "permanent_failure": False,
+            }
+        ]
+    }
+
+    assert _remove_confirmed_dead_candidate_sources(race_json, link_review) == 0


### PR DESCRIPTION
## What changed

- Scoped the issues-phase reset of `issue_attempts` / `issue_research` / `completed_units` to the candidates the run actually researches
- Classified link failures as permanent vs transient at the source, and extended deterministic dead-source cleanup to unresolvable hosts

## Why

Both found driving `nj-senate-2026` to publication. Together they made the race unpublishable by any sequence of runs.

**Audit scope.** `run_issues_phase` cleared `issue_attempts` and `issue_research` race-wide on every non-resume run, then only repopulated the candidates in `candidate_names`. Review flags a `"No public position found"` stance whose audit is missing, so each targeted repair re-broke every candidate it skipped:

| run scoped to | outcome |
| --- | --- |
| Murphy, Kuniansky | Murphy's 4 flags cleared → Fernandez's 3 appear |
| Fernandez, Kuniansky | Fernandez's 3 cleared → Murphy's Tech & AI returns |

This silently penalises the targeted `candidate_names` repair that `plan_repairs` and the runbook recommend, and it presents as "the model didn't search hard enough" rather than "the record was deleted."

**Dead links.** `_remove_confirmed_dead_candidate_sources` matched the strings `"HTTP error 404"` / `"HTTP error 410"` in the flag prose. `https://www.ballotpedia.org/Joanne_Kuniansky` fails DNS (`[Errno -2] Name or service not known`), so it had no HTTP status, was never auto-removed, and was left to the model — which across five runs never removed it and instead appended sources, pushing the dead URL from index 4 to 5 to 9. The flag blocked publication the whole time.

`_verify_url` now returns `(reason, permanent)` and the flag carries `permanent_failure`, so cleanup reads a field instead of parsing a sentence. Permanent: 404/410, unresolvable host, malformed URL. Transient (still flagged, never auto-removed): timeouts, 5xx, connection refused.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 945 passed
- New tests: a scoped run preserves a skipped candidate's audit; DNS failure is permanent and gets removed while a timeout does not; `_verify_url` returns the new tuple shape
- Black, isort, pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)