### PR TITLE
Store blank URL fields as null

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -1259,6 +1259,11 @@ def _make_editing_handlers(
         c = _find_candidate(name)
         if not c:
             return f"Candidate '{name}' not found."
+        # A blank string carries no information and is not a valid URL, so several
+        # of these fields (website, image_url) fail RaceJSON validation when one is
+        # stored. Clearing a field means null, not "".
+        if isinstance(value, str) and not value.strip():
+            value = None
         if field == "image_url" and value is not None and not _is_valid_image_url(value):
             log("warning", f"    Rejected non-image URL for {name}: {value!r}")
             return f"ERROR: {value!r} is not a direct image URL. " "Use a URL for an image file or set image_url to null."

--- a/pipeline_client/agent/roster.py
+++ b/pipeline_client/agent/roster.py
@@ -30,6 +30,13 @@ def normalize_candidate_entries(race_json: Dict[str, Any], log: Any | None = Non
             dropped += 1
             continue
         candidate["name"] = name
+        # A blank string is not a valid URL. One stored in website/image_url fails
+        # RaceJSON validation for the whole race, so a single cleared field blocks
+        # publication of an otherwise complete profile. Clearing means null.
+        for url_field in ("website", "image_url", "voting_source_url", "donor_source_url"):
+            value = candidate.get(url_field)
+            if isinstance(value, str) and not value.strip():
+                candidate[url_field] = None
         kept.append(candidate)
     if dropped:
         race_json["candidates"] = kept

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -2378,3 +2378,31 @@ def test_scoped_issue_reset_clears_only_targeted_candidates():
     kept = {u for u in units if not (u.startswith("issues:") and belongs_to_scope(u))}
 
     assert kept == {"issues:Justin Murphy:Economy", "discovery.roster_sync"}
+
+
+def test_blank_url_field_is_stored_as_null():
+    """A blank string fails RaceJSON's HttpUrl validation and blocks the whole race."""
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    race_json = {"id": "nj-senate-2026", "candidates": [{"name": "Joanne Kuniansky"}]}
+    handlers = _make_editing_handlers(race_json, lambda _level, _message: None)
+
+    handlers["set_candidate_field"]({"candidate_name": "Joanne Kuniansky", "field": "website", "value": "   "})
+
+    assert race_json["candidates"][0]["website"] is None
+
+
+def test_roster_sanitizer_repairs_existing_blank_urls():
+    """Drafts already damaged must self-heal rather than need a model to fix them."""
+    from pipeline_client.agent.roster import normalize_candidate_entries
+
+    race_json = {
+        "candidates": [
+            {"name": "Joanne Kuniansky", "website": "", "image_url": "https://example.com/a.jpg"},
+        ]
+    }
+
+    normalize_candidate_entries(race_json)
+
+    assert race_json["candidates"][0]["website"] is None
+    assert race_json["candidates"][0]["image_url"] == "https://example.com/a.jpg"


### PR DESCRIPTION
## What changed

- `set_candidate_field` treats a blank string as `null`
- The roster sanitizer repairs already-damaged drafts

## Why

A cleared `website` was stored as `""`, which is not a valid URL, so `RaceJSON` validation failed for the **entire race**:

```
RaceJSON schema validation failed: 1 validation error for RaceJSON
candidates.3.website
  Input should be a valid URL
```

On `nj-senate-2026` that single field blocked publication of a profile that was otherwise complete — 4 verified candidates, 48/48 sourced issue slots, finance and forecast done. Clearing a field means null, not empty string.

The sanitizer half matters because drafts already carrying `""` would otherwise stay unpublishable until a model happened to notice and rewrite the field, which is not something to leave to chance.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 950 passed
- New tests: a blank value stores as `None`; the sanitizer repairs an existing blank while leaving valid URLs alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)