### PR TITLE
Match dead citations by URL instead of parsing prose

### DIFF
--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -326,7 +326,12 @@ def _is_permanent_link_failure(exc: Exception) -> bool:
     if isinstance(exc, ValueError):
         return True  # malformed / disallowed URL
     text = str(exc).casefold()
-    return any(marker in text for marker in _PERMANENT_DNS_FAILURE_MARKERS)
+    if any(marker in text for marker in _PERMANENT_DNS_FAILURE_MARKERS):
+        return True
+    # A certificate that does not validate makes the address unusable as a
+    # citation until someone fixes the host, which is not something a rerun can
+    # resolve. Common on "www." variants of state election sites.
+    return "certificate_verify_failed" in text or "certificate verify failed" in text
 
 
 async def _verify_url(client: httpx.AsyncClient, url: str) -> Optional[tuple[str, bool]]:
@@ -412,8 +417,12 @@ async def check_profile_links(
                     "suggestion": "Verify the URL, find a replacement source, and update the stance.",
                     "severity": "warning",
                     # Machine-readable so deterministic cleanup does not have to
-                    # parse this sentence back out of prose.
+                    # parse these back out of prose. Recovering the URL by regex
+                    # truncated any address containing parentheses — which covers
+                    # every Ballotpedia/Wikipedia disambiguation link — so those
+                    # citations could never be matched and removed.
                     "permanent_failure": permanent,
+                    "url": url,
                 }
             )
 
@@ -452,9 +461,16 @@ def _remove_confirmed_dead_candidate_sources(race_json: Dict[str, Any], link_rev
         if not permanent:
             continue
         field_match = re.match(r"candidates\[(\d+)\]", str(flag.get("field") or ""))
-        url_match = re.search(r"Cited source URL \((https?://[^)]+)\)", concern)
-        if field_match and url_match:
-            removals.setdefault(int(field_match.group(1)), set()).add(url_match.group(1))
+        if not field_match:
+            continue
+        url = str(flag.get("url") or "").strip()
+        if not url:
+            # Reviews stored before the flag carried its URL. The regex truncates
+            # any address containing parentheses, so it is a fallback only.
+            url_match = re.search(r"Cited source URL \((https?://[^)]+)\)", concern)
+            url = url_match.group(1) if url_match else ""
+        if url:
+            removals.setdefault(int(field_match.group(1)), set()).add(url)
 
     removed = 0
     candidates = race_json.get("candidates") or []

--- a/tests/test_models_review.py
+++ b/tests/test_models_review.py
@@ -765,3 +765,58 @@ def test_research_audit_survives_schema_roundtrip():
 
     assert stance.research_audit is not None
     assert stance.model_dump()["research_audit"]["search_calls"] == 2
+
+
+def test_dead_source_removal_handles_urls_containing_parentheses():
+    """Ballotpedia/Wikipedia disambiguation URLs contain parentheses.
+
+    Regression: the URL was recovered from the flag's prose with a regex that
+    stopped at the first ')', producing a truncated address that never matched
+    the stored citation, so those dead links could never be auto-removed.
+    """
+    from pipeline_client.agent.review import _remove_confirmed_dead_candidate_sources
+
+    dead = "https://www.ballotpedia.org/Alabama%27s_2nd_Congressional_District_election,_2026_(August_11_Republican_primary)"
+    race_json = {
+        "candidates": [
+            {
+                "name": "David Matthews",
+                "issues": {
+                    "Election Policy": {
+                        "stance": "Supports voter ID.",
+                        "sources": [{"url": dead}, {"url": "https://al.com/politics/story"}],
+                    }
+                },
+            }
+        ]
+    }
+    link_review = {
+        "flags": [
+            {
+                "field": "candidates[0].issues.Election Policy.sources[0].url",
+                "concern": f"Cited source URL ({dead}) returned a dead link: Request failed: [Errno -2] Name or service not known.",
+                "permanent_failure": True,
+                "url": dead,
+            }
+        ]
+    }
+
+    assert _remove_confirmed_dead_candidate_sources(race_json, link_review) == 1
+    remaining = [s["url"] for s in race_json["candidates"][0]["issues"]["Election Policy"]["sources"]]
+    assert dead not in remaining
+    assert "https://al.com/politics/story" in remaining
+
+
+@pytest.mark.asyncio
+async def test_verify_url_marks_tls_failure_permanent():
+    """A host whose certificate will not validate is not a usable citation."""
+    import httpx
+
+    from pipeline_client.agent.review import _verify_url
+
+    exc = httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer")
+
+    with patch("pipeline_client.agent.review._get_validated", new_callable=AsyncMock, side_effect=exc):
+        _reason, permanent = await _verify_url(AsyncMock(), "https://www.sos.alabama.gov/doc.pdf")
+
+    assert permanent is True


### PR DESCRIPTION
## What changed

- The link-validator flag carries the offending `url` as a field; cleanup matches on it
- TLS verification failures are classified permanent alongside 404/410 and DNS failures

## Why

`_remove_confirmed_dead_candidate_sources` recovered the address from the flag's sentence with:

```python
re.search(r"Cited source URL \((https?://[^)]+)\)", concern)
```

That stops at the first `)`. For a URL that itself contains parentheses the captured value is truncated and never matches the stored citation, so the source cannot be removed:

```
https://www.ballotpedia.org/..._election,_2026_(August_11_Republican_primary)
                                              ^ capture ends here
```

This covers **every Ballotpedia and Wikipedia disambiguation link**, which are among the most commonly cited sources in the corpus. `al-house-02-2026` carried one through repeated review passes; each pass re-flagged it, capped validation at 79, and blocked publication.

Same principle as `permanent_failure` in #240 — the flag should carry structured data rather than have the consumer re-parse an English sentence. The regex stays as a fallback for reviews stored before this change.

**TLS:** `https://www.sos.alabama.gov/...` fails certificate verification. That is not transient — the host stays unusable as a citation until someone fixes it, and a rerun cannot. Several state election sites are in this state on their `www.` variants.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 952 passed
- New tests: a parenthesised URL is now matched and removed while a valid sibling source is kept; a TLS failure is classified permanent

🤖 Generated with [Claude Code](https://claude.com/claude-code)