### PR TITLE
Budget per unit of work instead of per phase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,12 +88,16 @@ SKIP_AUTH=true
 # Max execution time before a run is considered timed-out, in seconds (default: 86400 = 24h)
 # WORKER_DEADLINE_SECONDS=86400
 
-# Logical-run and phase ceilings. Cached search/page hits do not consume the
-# external-call ceilings.
-# PIPELINE_MAX_SEARCH_CALLS=240
-# PIPELINE_MAX_TOTAL_TOKENS=2500000
-# PIPELINE_MAX_PHASE_SEARCH_CALLS=120
-# PIPELINE_MAX_PHASE_TOKENS=1250000
+# Budget ceilings. Cached search/page hits do not consume them.
+#
+# The binding constraint is PER UNIT of work — one candidate/issue pair, one
+# roster sync, one review pass. The run-wide numbers are runaway guards, not the
+# working budget: a shared per-phase allowance meant a large roster starved
+# whichever candidate the fan-out researched last into empty verdicts.
+# PIPELINE_MAX_UNIT_SEARCH_CALLS=40
+# PIPELINE_MAX_UNIT_TOKENS=400000
+# PIPELINE_MAX_SEARCH_CALLS=2400
+# PIPELINE_MAX_TOTAL_TOKENS=20000000
 # PIPELINE_MAX_PAGE_FETCHES=300
 # PIPELINE_MAX_FETCHED_CHARS=3000000
 

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -103,9 +103,6 @@ Use an update when the existing race is generally good:
   when the correction goal justifies their cost
 - explicit `enabled_steps` always override the update default
 - pass `candidate_names` for candidate-specific repair
-- pass `resume_partial=true` only when `baseline_source=latest` points to a
-  trusted pipeline checkpoint or draft whose completed work-unit markers must
-  be preserved; ordinary issue refreshes deliberately research enabled units again
 - use `review` after material issue or narrative changes and `iteration` only
   when model-assisted correction is appropriate
 
@@ -272,9 +269,14 @@ and low, and once spent it answers 403 for every host, which silently strands al
 roster evidence at snippet (tier 3). A run whose proxy fetches all fail logs a
 single explicit outage warning rather than one indistinguishable error per URL.
 
-Logical runs enforce both global and phase search/token ceilings. They also cap
-uncached page fetches and fetched characters, and persist per-phase
-token/provider/search/page attribution across continuation handoffs. Defaults
+Budget ceilings bind per unit of work — one candidate/issue pair, one roster
+sync, one review pass — not per phase. A phase-wide allowance is shared by every
+unit in a fan-out, so a large roster exhausted it partway and whichever candidate
+was researched last recorded empty verdicts that then failed review as
+undocumented absences. Run-wide search/token ceilings remain as runaway guards.
+Runs also cap uncached page fetches and fetched characters, and persist per-phase
+token/provider/search/page attribution across continuation handoffs. Cost
+attribution still rolls up by phase family; only budgeting is per unit. Defaults
 are documented in `.env.example`.
 
 For an issue unit, a ceiling ends further searching but does not manufacture a

--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -745,18 +745,6 @@ async def run_agent(
         "retry_deadline_exits": int(prior_agent_metrics.get("retry_deadline_exits", 0) or 0),
         "model_breakdown": copy.deepcopy(prior_agent_metrics.get("model_breakdown", {})),
         "phase_breakdown": prior_phase_breakdown,
-        # Per-phase ceilings bound one physical invocation. A continuation gets
-        # a fresh phase allowance while the logical-run totals below remain
-        # cumulative, so it can finish untouched work without losing cost caps.
-        "_phase_budget_baselines": {
-            phase: {
-                "prompt_tokens": int(metrics.get("prompt_tokens", 0) or 0),
-                "completion_tokens": int(metrics.get("completion_tokens", 0) or 0),
-                "search_calls": int(metrics.get("search_calls", 0) or 0),
-            }
-            for phase, metrics in prior_phase_breakdown.items()
-            if isinstance(metrics, dict)
-        },
         "page_fetches": int(prior_agent_metrics.get("page_fetches", 0) or 0),
         "fetched_chars": int(prior_agent_metrics.get("fetched_chars", 0) or 0),
         "page_budget_blocked": int(prior_agent_metrics.get("page_budget_blocked", 0) or 0),
@@ -1131,8 +1119,8 @@ async def run_agent(
         "page_budget_blocked": _acc.get("page_budget_blocked", 0),
         "max_search_calls": PipelineRuntimeConfig.from_env().max_search_calls,
         "max_total_tokens": PipelineRuntimeConfig.from_env().max_total_tokens,
-        "max_phase_search_calls": PipelineRuntimeConfig.from_env().max_phase_search_calls,
-        "max_phase_tokens": PipelineRuntimeConfig.from_env().max_phase_tokens,
+        "max_unit_search_calls": PipelineRuntimeConfig.from_env().max_unit_search_calls,
+        "max_unit_tokens": PipelineRuntimeConfig.from_env().max_unit_tokens,
         "max_page_fetches": PipelineRuntimeConfig.from_env().max_page_fetches,
         "max_fetched_chars": PipelineRuntimeConfig.from_env().max_fetched_chars,
         "context_requests": _acc.get("context_requests", 0),

--- a/pipeline_client/agent/cost.py
+++ b/pipeline_client/agent/cost.py
@@ -14,6 +14,12 @@ from .model_registry import MODEL_CATALOG, normalize_model_id
 #          "model_breakdown": {model: {"prompt_tokens": int, "completion_tokens": int}}}
 _cost_ctx: ContextVar[Optional[Dict[str, Any]]] = ContextVar("_cost_ctx", default=None)
 _phase_ctx: ContextVar[str] = ContextVar("_phase_ctx", default="unattributed")
+# Cost *attribution* buckets by phase family; cost *budgeting* keys on the
+# unabbreviated label, which is unique per unit of work. Each issue unit runs in
+# its own asyncio task, so the ContextVar copy is already unit-scoped — budgeting
+# by family made all 84 candidate/issue pairs in a large House race share one
+# allowance, and whichever candidate ran last was starved into empty verdicts.
+_unit_ctx: ContextVar[str] = ContextVar("_unit_ctx", default="unattributed")
 
 _DEFAULT_INPUT_PER_M = 2.50
 _DEFAULT_OUTPUT_PER_M = 10.00
@@ -43,6 +49,15 @@ def phase_family(phase: str) -> str:
 
 def set_current_phase(phase: str) -> None:
     _phase_ctx.set(phase_family(phase))
+    _unit_ctx.set(str(phase or "unattributed").strip().lower() or "unattributed")
+
+
+def _unit_entry(acc: Dict[str, Any]) -> Dict[str, int]:
+    """Return the budget counters for the current unit of work."""
+    return acc.setdefault("unit_budget", {}).setdefault(
+        _unit_ctx.get(),
+        {"search_calls": 0, "prompt_tokens": 0, "completion_tokens": 0},
+    )
 
 
 def _phase_entry(acc: Dict[str, Any]) -> Dict[str, Any]:
@@ -58,12 +73,6 @@ def _phase_entry(acc: Dict[str, Any]) -> Dict[str, Any]:
             "fetched_chars": 0,
         },
     )
-
-
-def _phase_budget_baseline(acc: Dict[str, Any]) -> Dict[str, int]:
-    """Return metrics already spent before this physical continuation pass."""
-    baseline = acc.get("_phase_budget_baselines", {}).get(_phase_ctx.get(), {})
-    return baseline if isinstance(baseline, dict) else {}
 
 
 def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> float:
@@ -86,11 +95,14 @@ def accumulate(
     if acc is None:
         return
     phase = _phase_entry(acc)
+    unit = _unit_entry(acc)
     acc["prompt_tokens"] += prompt_tokens
     acc["completion_tokens"] += completion_tokens
     phase["prompt_tokens"] += prompt_tokens
     phase["completion_tokens"] += completion_tokens
     phase["llm_calls"] += 1
+    unit["prompt_tokens"] = int(unit.get("prompt_tokens", 0)) + prompt_tokens
+    unit["completion_tokens"] = int(unit.get("completion_tokens", 0)) + completion_tokens
     if cost_usd is None:
         acc["unpriced_calls"] = acc.get("unpriced_calls", 0) + 1
     else:
@@ -156,15 +168,15 @@ def reserve_search_call(provider: str) -> bool:
     config = PipelineRuntimeConfig.from_env()
     used = int(acc.get("serper_calls", 0) or 0) + int(acc.get("searlo_calls", 0) or 0)
     phase = _phase_entry(acc)
-    baseline = _phase_budget_baseline(acc)
-    phase_used = int(phase.get("search_calls", 0)) - int(baseline.get("search_calls", 0))
-    if used >= config.max_search_calls or phase_used >= config.max_phase_search_calls:
+    unit = _unit_entry(acc)
+    if used >= config.max_search_calls or int(unit["search_calls"]) >= config.max_unit_search_calls:
         acc["search_budget_blocked"] = int(acc.get("search_budget_blocked", 0) or 0) + 1
         phase["search_budget_blocked"] = int(phase.get("search_budget_blocked", 0) or 0) + 1
         return False
     key = f"{provider}_calls"
     acc[key] = int(acc.get(key, 0) or 0) + 1
     phase["search_calls"] += 1
+    unit["search_calls"] = int(unit["search_calls"]) + 1
     return True
 
 
@@ -203,15 +215,9 @@ def total_token_budget_reached() -> bool:
         return False
     used = int(acc.get("prompt_tokens", 0) or 0) + int(acc.get("completion_tokens", 0) or 0)
     config = PipelineRuntimeConfig.from_env()
-    phase = _phase_entry(acc)
-    baseline = _phase_budget_baseline(acc)
-    phase_used = (
-        int(phase.get("prompt_tokens", 0) or 0)
-        + int(phase.get("completion_tokens", 0) or 0)
-        - int(baseline.get("prompt_tokens", 0) or 0)
-        - int(baseline.get("completion_tokens", 0) or 0)
-    )
-    return used >= config.max_total_tokens or phase_used >= config.max_phase_tokens
+    unit = _unit_entry(acc)
+    unit_used = int(unit.get("prompt_tokens", 0) or 0) + int(unit.get("completion_tokens", 0) or 0)
+    return used >= config.max_total_tokens or unit_used >= config.max_unit_tokens
 
 
 def record_token_budget_nudge() -> None:

--- a/shared/pipeline_config.py
+++ b/shared/pipeline_config.py
@@ -96,10 +96,14 @@ class PipelineRuntimeConfig:
     iteration_min_iterations: int = 14
     quality_critical_issue_stances: int = CANONICAL_ISSUE_COUNT // 2
     quality_warning_issue_stances: int = (CANONICAL_ISSUE_COUNT * 2) // 3
-    max_search_calls: int = 480
-    max_total_tokens: int = 5_000_000
-    max_phase_search_calls: int = 120
-    max_phase_tokens: int = 1_250_000
+    # Run-wide ceilings are runaway guards, not the working budget. The binding
+    # constraint is per unit of work (one candidate/issue pair, one roster sync,
+    # one review pass), so a large roster cannot starve whichever candidate the
+    # fan-out happens to research last.
+    max_search_calls: int = 2_400
+    max_total_tokens: int = 20_000_000
+    max_unit_search_calls: int = 40
+    max_unit_tokens: int = 400_000
     max_page_fetches: int = 300
     max_fetched_chars: int = 3_000_000
 
@@ -119,10 +123,10 @@ class PipelineRuntimeConfig:
             iteration_min_iterations=_env_int("PIPELINE_ITERATION_MIN_ITERATIONS", 14, 1, None),
             quality_critical_issue_stances=critical,
             quality_warning_issue_stances=warning,
-            max_search_calls=_env_int("PIPELINE_MAX_SEARCH_CALLS", 480, 1, 5000),
-            max_total_tokens=_env_int("PIPELINE_MAX_TOTAL_TOKENS", 5_000_000, 10_000, 50_000_000),
-            max_phase_search_calls=_env_int("PIPELINE_MAX_PHASE_SEARCH_CALLS", 120, 1, 5000),
-            max_phase_tokens=_env_int("PIPELINE_MAX_PHASE_TOKENS", 1_250_000, 10_000, 50_000_000),
+            max_search_calls=_env_int("PIPELINE_MAX_SEARCH_CALLS", 2_400, 1, 20_000),
+            max_total_tokens=_env_int("PIPELINE_MAX_TOTAL_TOKENS", 20_000_000, 10_000, 200_000_000),
+            max_unit_search_calls=_env_int("PIPELINE_MAX_UNIT_SEARCH_CALLS", 40, 1, 1000),
+            max_unit_tokens=_env_int("PIPELINE_MAX_UNIT_TOKENS", 400_000, 10_000, 20_000_000),
             max_page_fetches=_env_int("PIPELINE_MAX_PAGE_FETCHES", 300, 1, 5000),
             max_fetched_chars=_env_int("PIPELINE_MAX_FETCHED_CHARS", 3_000_000, 10_000, 100_000_000),
         )

--- a/tests/test_agent_cost.py
+++ b/tests/test_agent_cost.py
@@ -185,8 +185,8 @@ def test_phase_breakdown_attributes_tokens_cost_search_and_pages(cost_accumulato
     assert phase["fetched_chars"] == 250
 
 
-def test_phase_search_and_page_budgets_are_enforced(cost_accumulator, monkeypatch):
-    monkeypatch.setenv("PIPELINE_MAX_PHASE_SEARCH_CALLS", "1")
+def test_unit_search_and_page_budgets_are_enforced(cost_accumulator, monkeypatch):
+    monkeypatch.setenv("PIPELINE_MAX_UNIT_SEARCH_CALLS", "1")
     monkeypatch.setenv("PIPELINE_MAX_PAGE_FETCHES", "1")
     set_current_phase("images-Alice")
 
@@ -197,10 +197,64 @@ def test_phase_search_and_page_budgets_are_enforced(cost_accumulator, monkeypatc
     assert cost_accumulator["page_budget_blocked"] == 1
 
 
-def test_continuation_phase_budget_ignores_prior_phase_spend_but_keeps_logical_total(cost_accumulator, monkeypatch):
-    monkeypatch.setenv("PIPELINE_MAX_PHASE_SEARCH_CALLS", "2")
+def test_one_exhausted_unit_does_not_starve_the_next(cost_accumulator, monkeypatch):
+    """The whole point: a fan-out phase must not spend one shared allowance.
+
+    Budgeting by phase family gave every candidate/issue pair in a race one
+    pooled ceiling, so whichever candidate the fan-out reached last was denied
+    every search and produced empty verdicts.
+    """
+    monkeypatch.setenv("PIPELINE_MAX_UNIT_SEARCH_CALLS", "2")
+    monkeypatch.setenv("PIPELINE_MAX_SEARCH_CALLS", "100")
+
+    set_current_phase("issue-Alice Example-Healthcare")
+    assert reserve_search_call("serper") is True
+    assert reserve_search_call("serper") is True
+    assert reserve_search_call("serper") is False, "unit ceiling should bind"
+
+    # A different candidate/issue pair in the same phase family starts fresh.
+    set_current_phase("issue-Bob Example-Healthcare")
+    assert reserve_search_call("serper") is True
+    assert reserve_search_call("serper") is True
+
+    # Attribution still rolls up to the family.
+    assert cost_accumulator["phase_breakdown"]["issues"]["search_calls"] == 4
+
+
+def test_run_wide_search_ceiling_still_bounds_runaway(cost_accumulator, monkeypatch):
+    monkeypatch.setenv("PIPELINE_MAX_UNIT_SEARCH_CALLS", "50")
+    monkeypatch.setenv("PIPELINE_MAX_SEARCH_CALLS", "3")
+
+    for index in range(3):
+        set_current_phase(f"issue-Candidate {index}-Healthcare")
+        assert reserve_search_call("serper") is True
+
+    set_current_phase("issue-Candidate 9-Healthcare")
+    assert reserve_search_call("serper") is False
+
+
+def test_unit_token_ceiling_is_scoped_per_unit(cost_accumulator, monkeypatch):
+    # 10_000 is the configured floor for this ceiling.
+    monkeypatch.setenv("PIPELINE_MAX_UNIT_TOKENS", "10000")
+    monkeypatch.setenv("PIPELINE_MAX_TOTAL_TOKENS", "500000")
+
+    set_current_phase("issue-Alice Example-Economy")
+    accumulate(9_000, 2_000, "test-model")
+    assert total_token_budget_reached() is True
+
+    set_current_phase("issue-Bob Example-Economy")
+    assert total_token_budget_reached() is False
+
+
+def test_continuation_starts_units_fresh_but_keeps_logical_total(cost_accumulator, monkeypatch):
+    """A resumed unit gets its own allowance; run-wide totals stay cumulative.
+
+    Per-unit budgets replace the continuation baseline that used to exempt a
+    phase from spend carried over by an earlier physical pass.
+    """
+    monkeypatch.setenv("PIPELINE_MAX_UNIT_SEARCH_CALLS", "2")
     monkeypatch.setenv("PIPELINE_MAX_SEARCH_CALLS", "10")
-    monkeypatch.setenv("PIPELINE_MAX_PHASE_TOKENS", "10000")
+    monkeypatch.setenv("PIPELINE_MAX_UNIT_TOKENS", "10000")
     monkeypatch.setenv("PIPELINE_MAX_TOTAL_TOKENS", "50000")
     set_current_phase("issues")
     cost_accumulator.update(
@@ -210,7 +264,6 @@ def test_continuation_phase_budget_ignores_prior_phase_spend_but_keeps_logical_t
             "serper_calls": 2,
             "searlo_calls": 0,
             "phase_breakdown": {"issues": {"prompt_tokens": 12000, "completion_tokens": 3000, "search_calls": 2}},
-            "_phase_budget_baselines": {"issues": {"prompt_tokens": 12000, "completion_tokens": 3000, "search_calls": 2}},
         }
     )
 

--- a/tests/test_shared_config.py
+++ b/tests/test_shared_config.py
@@ -55,8 +55,8 @@ def test_runtime_config_bounds_search_and_token_ceilings(monkeypatch):
 
     config = PipelineRuntimeConfig.from_env()
 
-    assert config.max_search_calls == 5000
-    assert config.max_total_tokens == 50_000_000
+    assert config.max_search_calls == 20_000
+    assert config.max_total_tokens == 200_000_000
 
 
 def test_review_providers_cannot_be_empty():


### PR DESCRIPTION
## What changed

Search and token ceilings now bind **per unit of work** — one candidate/issue pair, one roster sync, one review pass — rather than per phase.

| ceiling | before | after |
| --- | --- | --- |
| per unit, searches | — | `PIPELINE_MAX_UNIT_SEARCH_CALLS=40` |
| per unit, tokens | — | `PIPELINE_MAX_UNIT_TOKENS=400000` |
| per phase | 120 searches / 1.25M tokens | removed |
| run-wide (runaway guard) | 480 / 5M | 2400 / 20M |

## Why

A phase-wide allowance is shared by every unit in a fan-out. An 84-slot House race spends the 120-search phase ceiling partway through, so whichever candidate the fan-out reaches last is denied every search and records empty verdicts — which then fail review as undocumented absences.

`al-house-02-2026` arrived with **four of seven candidates holding zero issue data** for exactly this reason, and the deferred continuation that would have finished them never ran. It only reached publication by manually batching candidates into separate runs, which is a workaround for the ceiling, not a fix.

The change is small because the plumbing already existed: `_phase_ctx` is a `ContextVar` and each issue unit runs in its own asyncio task, so the context copy is already unit-scoped. Only the *key* was wrong — `phase_family()` collapsed `issue-Alice-Healthcare` and `issue-Bob-Healthcare` into one `issues` bucket for budgeting as well as for reporting. Budgeting now uses the unabbreviated label; **attribution still rolls up by family, so cost reporting is unchanged**.

Run-wide ceilings are raised because they are now runaway guards rather than the working budget — total spend scales with the work planned instead of being capped below it.

## Removed machinery

`_phase_budget_baseline` and the `_phase_budget_baselines` accumulator existed only to stop a resumed continuation from inheriting phase spend against the phase ceiling. Per-unit budgets start each unit fresh, so this is deleted rather than left inert.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 955 passed
- New tests: an exhausted unit does not starve the next unit in the same family; family-level attribution still sums correctly; the run-wide ceiling still bounds runaway; the per-unit token ceiling is unit-scoped; a continuation starts units fresh while logical totals stay cumulative

🤖 Generated with [Claude Code](https://claude.com/claude-code)