### PR TITLE
Make a stale local worker detectable

### DIFF
--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -17,6 +17,11 @@ services:
     build:
       context: .
       dockerfile: pipeline_client/Dockerfile.worker
+      args:
+        # Stamps the image with the commit it was built from so the worker can
+        # report whether it predates merged fixes. Set WORKER_GIT_COMMIT in the
+        # environment (or .env) to the output of `git rev-parse HEAD`.
+        WORKER_GIT_COMMIT: ${WORKER_GIT_COMMIT:-}
     env_file:
       - .env
     environment:

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -35,6 +35,14 @@ The worker reads credentials and configuration from the compose environment.
 Confirm `ADMIN_API_KEY`, OpenRouter/search keys, GCP project/storage settings,
 and application-default GCP credentials before assuming a pending item is stuck.
 
+Build with `WORKER_GIT_COMMIT=$(git rev-parse HEAD)` set so the image is stamped
+with its source commit. The worker logs that commit at startup and warns when it
+cannot report one — an unstamped image is treated as suspect rather than current,
+because a container built before a merged fix keeps claiming work and writes bad
+data with no error. Check the startup line before trusting a "did the fix work"
+test, and remove stale containers rather than leaving them stopped: a `docker
+start` on one silently returns old code to the queue.
+
 ### Cloud Run Job
 
 The production-shaped path is:

--- a/pipeline_client/Dockerfile.worker
+++ b/pipeline_client/Dockerfile.worker
@@ -21,5 +21,12 @@ USER app
 ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
 
+# Build provenance. Without this the staleness check has nothing to compare and
+# a container built before a fix silently keeps claiming work. docker-compose
+# passes the current commit; a bare `docker build` leaves it unset, which the
+# worker reports as unknown rather than assuming it is current.
+ARG WORKER_GIT_COMMIT=""
+ENV WORKER_GIT_COMMIT=${WORKER_GIT_COMMIT}
+
 # Long-lived poller by default; Cloud Run Jobs override env with WORKER_ONCE=true.
 ENTRYPOINT ["python", "-m", "pipeline_client.worker"]

--- a/pipeline_client/worker.py
+++ b/pipeline_client/worker.py
@@ -183,8 +183,13 @@ async def run_worker() -> None:
     from shared.run_health import check_worker_version_staleness
 
     version_check = check_worker_version_staleness(runner=_RUNNER)
-    if version_check.get("is_stale"):
+    # is_stale is None when the image did not report its build commit, which is
+    # just as actionable as a confirmed mismatch — a worker whose provenance is
+    # unknown may predate merged fixes and will corrupt data silently.
+    if version_check.get("is_stale") is not False and version_check.get("warning"):
         logger.warning("WORKER VERSION WARNING: %s", version_check.get("warning"))
+    elif version_check.get("worker_commit"):
+        logger.info("Worker built from commit %s", version_check["worker_commit"])
 
     stop = asyncio.Event()
 

--- a/shared/run_health.py
+++ b/shared/run_health.py
@@ -361,8 +361,22 @@ def check_worker_version_staleness(
         except Exception:
             r_commit = None
 
-    if not w_commit and r_commit:
-        w_commit = r_commit
+    if not w_commit:
+        # Never assume an unknown build matches HEAD. That default made this
+        # check unable to fire at all: nothing stamped WORKER_GIT_COMMIT into the
+        # image, so every worker looked current and a container built before
+        # several merged fixes ran for hours, silently writing bad data.
+        return {
+            "is_stale": None,
+            "runner": "local",
+            "worker_commit": None,
+            "repo_commit": r_commit[:7] if r_commit else None,
+            "warning": (
+                "Worker runner='local' did not report the commit it was built from, so it cannot be "
+                "checked against the repo. Rebuild with 'docker compose -f docker-compose.worker.yml "
+                "up -d --build' to stamp it; until then assume the image may predate recent fixes."
+            ),
+        }
 
     if w_commit and r_commit and w_commit != r_commit:
         warning_msg = (

--- a/tests/test_worker_version_check.py
+++ b/tests/test_worker_version_check.py
@@ -38,3 +38,30 @@ def test_check_worker_version_staleness_different_commits() -> None:
 
 def test_stale_worker_failure_reason_enum() -> None:
     assert RunFailureReason.STALE_WORKER_VERSION.value == "stale_worker_version"
+
+
+def test_unknown_worker_commit_is_not_reported_as_current(monkeypatch) -> None:
+    """Regression: an unreported build commit used to be assumed equal to HEAD.
+
+    Nothing stamped WORKER_GIT_COMMIT into the image, so every worker looked
+    current and this check could never fire. A container built before several
+    merged fixes then ran for hours, silently writing bad data.
+    """
+    monkeypatch.delenv("WORKER_GIT_COMMIT", raising=False)
+    monkeypatch.delenv("GIT_COMMIT", raising=False)
+
+    res = check_worker_version_staleness(runner="local", repo_commit="def567890123")
+
+    assert res["is_stale"] is not False, "unknown provenance must not read as current"
+    assert res["worker_commit"] is None
+    assert "did not report the commit" in res["warning"]
+    assert "docker compose" in res["warning"]
+
+
+def test_worker_commit_from_environment_is_used(monkeypatch) -> None:
+    monkeypatch.setenv("WORKER_GIT_COMMIT", "abc123456789")
+
+    res = check_worker_version_staleness(runner="local", repo_commit="def567890123")
+
+    assert res["is_stale"] is True
+    assert res["worker_commit"] == "abc1234"


### PR DESCRIPTION
## What changed

- The worker image is stamped with the commit it was built from (`WORKER_GIT_COMMIT` build arg, passed by compose)
- Unknown provenance is reported as suspect rather than current
- The worker logs its build commit at startup, and warns when it has none

## Why

`check_worker_version_staleness` existed but **could never fire**:

```python
w_commit = worker_commit or os.getenv("WORKER_GIT_COMMIT") or os.getenv("GIT_COMMIT")
...
if not w_commit and r_commit:
    w_commit = r_commit        # unknown silently becomes "matches"
```

Nothing stamped `WORKER_GIT_COMMIT` into the image, so the worker commit was always unknown — and was then assigned repo HEAD, making every worker compare equal to itself. The repo side was equally blind: it shells out to `git rev-parse` inside a container that contains only `/app/pipeline_client` and `/app/shared`, no repo, so that returns `None` too. Both operands were empty and the result was always "not stale".

A worker built before #240, #242, #244 and #245 kept leasing work for hours as a result. It reverted a sanitizer that had already merged and wrote data that failed validation, and nothing in any log indicated the code was old — the failures looked like data problems. It was only caught by diffing `docker inspect` timestamps against merge times by hand.

`is_stale` is now tri-state: `False` (verified current), `True` (verified mismatch), `None` (cannot tell). The worker treats anything other than `False` as worth warning about, because an image that will not say what it was built from is exactly the case that burned us.

## Operator note

The runbook now says to build with `WORKER_GIT_COMMIT=$(git rev-parse HEAD)`, to check the startup line before trusting a "did the fix work" test, and to **remove** stale containers rather than leave them stopped — a `docker start` on one silently returns old code to the queue.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 957 passed
- New tests: unknown provenance does not read as current; an environment-supplied commit is compared properly
- Verified end to end by rebuilding: `Worker built from commit 054b032`

🤖 Generated with [Claude Code](https://claude.com/claude-code)