### PR TITLE
Read spreadsheet roster sources and stage repair plans

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -488,11 +488,25 @@ def _roster_source_rejection_summary(sources: Any, *, candidate_name: str, race_
 
 
 def _roster_completeness_source_rejection_reason(
-    source: Dict[str, Any], *, race_id: str, identity: Dict[str, Any]
+    source: Dict[str, Any],
+    *,
+    race_id: str,
+    identity: Dict[str, Any],
+    roster_names: list[str] | None = None,
 ) -> str | None:
     """Validate evidence that describes the roster as a whole, not one member."""
-    if source.get("type") not in {"official", "news"}:
-        return "completeness evidence must be an official roster/ballot or retrieved news report"
+    # Ballotpedia belongs here for the same reason it is already accepted as
+    # candidate-level roster evidence: its per-race election pages publish the
+    # full qualified field, and RaceJSON treats `ballotpedia_url` as the
+    # canonical roster pointer. Excluding it stranded rosters that had no other
+    # retrievable full list — a state SoS landing page rarely enumerates one
+    # district's candidates, so the roster never finalized and the race stayed
+    # at its stale published roster (observed live on ne-house-02-2026).
+    # The real teeth are below and unchanged: retrieved page content only,
+    # exact contest and district, list-identifying phrasing, and coverage of
+    # every active candidate.
+    if source.get("type") not in {"official", "news", "ballotpedia"}:
+        return "completeness evidence must be an official roster/ballot, Ballotpedia race page, or retrieved news report"
     parsed_url = urlparse(str(source.get("url") or ""))
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         return "source needs an absolute http(s) url"
@@ -511,12 +525,21 @@ def _roster_completeness_source_rejection_reason(
     # the full certified field yet failed a pattern that only accepted "candidate
     # list" in that word order — the authoritative source rejected by the check
     # meant to require an authoritative source.
-    if not re.search(
+    # A source that names every candidate on the proposed roster has demonstrated
+    # completeness directly; demanding it also *say* "certified" is prose matching
+    # of the kind that rejected New Jersey's own certified list and Ballotpedia's
+    # standard full-field sentence. Phrasing stays a valid alternative for lists
+    # that assert completeness without enumerating inline.
+    enumerates_full_roster = bool(roster_names) and all(_source_names_candidate(text, name) for name in roster_names)
+    if not enumerates_full_roster and not re.search(
         r"\b(?:qualified|certified|official list|official ballot|candidate list|list of candidates"
         r"|candidates? running|vote for one)\b",
         text,
     ):
-        return "evidence does not identify itself as a qualified, certified, ballot, or complete candidate list"
+        return (
+            "evidence neither names every candidate on the proposed roster nor identifies itself as a "
+            "qualified, certified, ballot, or complete candidate list"
+        )
 
     primary_status = str(identity.get("primary_status") or "")
     if "special" in primary_status.casefold():
@@ -1109,15 +1132,26 @@ def _make_editing_handlers(
             if url_key not in observed_urls:
                 completeness_sources.append(dict(trusted))
                 observed_urls.add(url_key)
+        # The names the model says it extracted from the completeness evidence.
+        # A source that demonstrably lists all of them has proven completeness
+        # without needing to also describe itself as a certified list.
+        claimed_roster_names = [str(name).strip() for name in args.get("source_candidate_names") or [] if str(name).strip()]
         completeness_rejections = [
             reason
             for source in completeness_sources
-            if (reason := _roster_completeness_source_rejection_reason(source, race_id=race_id, identity=identity))
+            if (
+                reason := _roster_completeness_source_rejection_reason(
+                    source, race_id=race_id, identity=identity, roster_names=claimed_roster_names
+                )
+            )
         ]
         qualifying_completeness = [
             source
             for source in completeness_sources
-            if _roster_completeness_source_rejection_reason(source, race_id=race_id, identity=identity) is None
+            if _roster_completeness_source_rejection_reason(
+                source, race_id=race_id, identity=identity, roster_names=claimed_roster_names
+            )
+            is None
         ]
         if not qualifying_completeness:
             detail = "; ".join(completeness_rejections) if completeness_rejections else "no sources were supplied"

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -1221,6 +1221,11 @@ list for this exact contest. This is an atomic replacement: use it to apply all
 remaining additions and removals in one response instead of spending one turn
 per candidate. Candidate-specific
 sources prove that listed people belong; they do not prove nobody was omitted.
+Completeness evidence must come from a page you actually FETCHED this run — a
+search snippet is rejected. An official ballot/qualified list, the Ballotpedia
+page for this exact race, or a news report enumerating the full field all
+qualify; a state election-authority landing page that never names this district
+does not. When nothing else lists the full field, fetch the Ballotpedia race page.
 For a special election, the completeness evidence must explicitly identify the
 special contest and its verified date. The tool will reject incomplete or weakly
 sourced rosters and tell you exactly which evidence remains to fix. You may stop only after

--- a/pipeline_client/agent/tools.py
+++ b/pipeline_client/agent/tools.py
@@ -411,8 +411,9 @@ FINALIZE_ROSTER_TOOL: Dict = {
                 "completeness_sources": {
                     "type": "array",
                     "description": (
-                        "Retrieved official roster/ballot sources (or retrieved reputable news reports) whose evidence "
-                        "quotes the complete qualified candidate list for this exact contest and names every active candidate."
+                        "Retrieved official roster/ballot sources, the Ballotpedia race page, or retrieved reputable "
+                        "news reports whose evidence quotes the complete qualified candidate list for this exact "
+                        "contest and names every active candidate. Fetch the page first — search snippets are rejected."
                     ),
                     "items": {
                         "type": "object",

--- a/pipeline_client/agent/web_tools.py
+++ b/pipeline_client/agent/web_tools.py
@@ -323,6 +323,71 @@ def proxy_health_snapshot() -> Dict[str, int]:
     return {"attempts": _proxy_attempts, "failures": _proxy_failures}
 
 
+_TABULAR_EXTENSIONS = (".xlsx", ".xlsm", ".csv", ".tsv")
+
+
+def is_tabular_document(url: str) -> bool:
+    """True for spreadsheet/CSV URLs the text proxy cannot render.
+
+    Several states publish their certified candidate list as a spreadsheet.
+    r.jina.ai answers 422 for those even though the file downloads fine, so the
+    authoritative roster source was simply unreadable and roster finalization
+    deadlocked with no way forward.
+    """
+    path = urlparse(url or "").path.lower()
+    return path.endswith(_TABULAR_EXTENSIONS)
+
+
+def _xlsx_to_text(payload: bytes) -> str:
+    """Extract readable rows from an .xlsx without a spreadsheet dependency.
+
+    An .xlsx is a zip of XML. Shared strings plus the first worksheet is enough
+    to make a candidate filing list legible to the agent, and avoids adding a
+    parser to the worker image for one file format.
+    """
+    import io as _io
+    import zipfile
+    from xml.etree import ElementTree
+
+    ns = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+    with zipfile.ZipFile(_io.BytesIO(payload)) as archive:
+        shared: List[str] = []
+        if "xl/sharedStrings.xml" in archive.namelist():
+            root = ElementTree.fromstring(archive.read("xl/sharedStrings.xml"))
+            for item in root.findall(f"{ns}si"):
+                shared.append("".join(node.text or "" for node in item.iter(f"{ns}t")))
+        sheets = [name for name in archive.namelist() if name.startswith("xl/worksheets/sheet")]
+        if not sheets:
+            return ""
+        root = ElementTree.fromstring(archive.read(sorted(sheets)[0]))
+        lines: List[str] = []
+        for row in root.iter(f"{ns}row"):
+            cells: List[str] = []
+            for cell in row.findall(f"{ns}c"):
+                value = cell.find(f"{ns}v")
+                if value is None or value.text is None:
+                    continue
+                if cell.get("t") == "s":
+                    index = int(value.text)
+                    cells.append(shared[index] if 0 <= index < len(shared) else "")
+                else:
+                    cells.append(value.text)
+            if any(cell.strip() for cell in cells):
+                lines.append(" | ".join(cells))
+        return "\n".join(lines)
+
+
+async def _fetch_tabular_document(client: httpx.AsyncClient, url: str) -> Optional[str]:
+    """Download and flatten a spreadsheet/CSV directly, bypassing the text proxy."""
+    resp = await _get_validated(client, url)
+    resp.raise_for_status()
+    path = urlparse(url).path.lower()
+    if path.endswith((".xlsx", ".xlsm")):
+        return _xlsx_to_text(resp.content)
+    # CSV/TSV are already text; httpx decodes using the response charset.
+    return resp.text
+
+
 def _get_serper_client() -> httpx.AsyncClient:
     """Return a per-event-loop AsyncClient for Serper API calls."""
     loop_id = id(asyncio.get_running_loop())
@@ -360,6 +425,23 @@ async def _fetch_page(url: str) -> str:
 
     client = _get_fetch_client()
     failure_reasons: List[str] = []
+
+    # Spreadsheets download fine but the text proxy rejects them, so fetch and
+    # flatten them here rather than letting an authoritative candidate list come
+    # back as an unusable error.
+    if is_tabular_document(url):
+        try:
+            tabular_text = await _fetch_tabular_document(client, url)
+            if tabular_text and tabular_text.strip():
+                if len(tabular_text) > _PAGE_MAX_CHARS:
+                    tabular_text = tabular_text[:_PAGE_MAX_CHARS] + f"\n\n[...truncated at {_PAGE_MAX_CHARS} chars]"
+                record_fetched_chars(len(tabular_text))
+                if cache:
+                    cache.set_page(url, tabular_text)
+                return tabular_text
+            failure_reasons.append("tabular document contained no readable rows")
+        except Exception as exc:
+            failure_reasons.append(f"tabular fetch: {exc}")
 
     # Some campaign sites block one header/profile but allow another.
     header_profiles = [

--- a/shared/repair_planner.py
+++ b/shared/repair_planner.py
@@ -23,15 +23,32 @@ _PER_CANDIDATE_COST_USD = {
 }
 _PER_ISSUE_COST_USD = 0.05
 _CANONICAL_ISSUES = {issue.value for issue in CanonicalIssue}
-_ISSUE_RESEARCH_SAFETY_STEPS = {
+# Raw issue stances are unvalidated until review/iteration run, so a plan that
+# researches issues must always finish with them. That invariant belongs to the
+# plan as a whole, not to each candidate: folding the race-wide tail into every
+# candidate group made a three-candidate repair run review and iteration three
+# times, each pass grading a race the later passes had not finished yet.
+_ISSUE_RESEARCH_CANDIDATE_STEPS = {
     "issues",
     "finance",
     "refinement",
+}
+_ISSUE_RESEARCH_FINALIZATION_STEPS = {
     "polling",
     "forecast",
     "voter_resources",
     "review",
     "iteration",
+}
+_ISSUE_RESEARCH_SAFETY_STEPS = _ISSUE_RESEARCH_CANDIDATE_STEPS | _ISSUE_RESEARCH_FINALIZATION_STEPS
+# Work that only ever makes sense once, for the whole race, after per-candidate
+# research has landed.
+_FINALIZATION_STEPS = _ISSUE_RESEARCH_FINALIZATION_STEPS
+# Reasons that belong to the roster group rather than the validation tail.
+_PREP_ONLY_REASONS = {
+    "Roster is empty.",
+    "One or more candidates lack roster evidence.",
+    "Roster evidence is stale.",
 }
 
 
@@ -104,6 +121,7 @@ def build_repair_plan(race_id: str, race_data: Dict[str, Any], *, freshness: str
     candidate_groups: List[Dict[str, Any]] = []
     race_steps: set[str] = set()
     race_reasons: List[str] = []
+    issue_research_planned = False
 
     if health["candidate_count"] == 0:
         race_steps.add("discovery")
@@ -128,7 +146,11 @@ def build_repair_plan(race_id: str, race_data: Dict[str, Any], *, freshness: str
         candidate_missing_issues = max(0, len(_CANONICAL_ISSUES) - terminal_issues)
         if candidate_missing_issues:
             steps.update(_ISSUE_RESEARCH_SAFETY_STEPS)
-            candidate_steps.update(_ISSUE_RESEARCH_SAFETY_STEPS)
+            # The candidate group carries only candidate-scoped work; the
+            # validation tail is added once, to the finalization group.
+            candidate_steps.update(_ISSUE_RESEARCH_CANDIDATE_STEPS)
+            race_steps.update(_ISSUE_RESEARCH_FINALIZATION_STEPS)
+            issue_research_planned = True
             candidate_reasons.append(f"{candidate_missing_issues} issue slot(s) lack a terminal verdict.")
         donor_sources = candidate.get("donor_sources")
         if not candidate.get("donor_summary") or not (
@@ -234,18 +256,38 @@ def build_repair_plan(race_id: str, race_data: Dict[str, Any], *, freshness: str
     steps.update(race_steps)
     ordered_steps = _ordered_steps(steps)
     target_names = list(dict.fromkeys(target_names))
-    repair_groups = candidate_groups
-    if race_steps:
-        repair_groups.insert(
-            0,
+
+    # Groups are returned in the order they must be queued. Roster work has to
+    # settle before anyone is researched, and the validation tail only means
+    # anything once every candidate group has landed.
+    phase_breakdown = (race_data.get("agent_metrics") or {}).get("phase_breakdown")
+    prep_steps = race_steps - _FINALIZATION_STEPS
+    finalization_steps = race_steps & _FINALIZATION_STEPS
+    finalization_reasons = [reason for reason in race_reasons if reason not in _PREP_ONLY_REASONS]
+    if issue_research_planned:
+        finalization_reasons.append("Issue research is unvalidated until review and iteration run for the whole race.")
+
+    repair_groups: List[Dict[str, Any]] = []
+    if prep_steps:
+        repair_groups.append(
             {
-                **_estimate_group(
-                    race_steps,
-                    phase_breakdown=(race_data.get("agent_metrics") or {}).get("phase_breakdown"),
-                ),
+                **_estimate_group(prep_steps, phase_breakdown=phase_breakdown),
                 "candidate_names": None,
-                "reasons": race_reasons,
-            },
+                "stage": "roster",
+                "reasons": [reason for reason in race_reasons if reason in _PREP_ONLY_REASONS] or race_reasons,
+            }
+        )
+    for group in candidate_groups:
+        group["stage"] = "candidate"
+    repair_groups.extend(candidate_groups)
+    if finalization_steps:
+        repair_groups.append(
+            {
+                **_estimate_group(finalization_steps, phase_breakdown=phase_breakdown),
+                "candidate_names": None,
+                "stage": "finalization",
+                "reasons": finalization_reasons or race_reasons,
+            }
         )
     estimated_cost = sum(float(group["estimated_max_cost_usd"]) for group in repair_groups)
     estimated_search_demand = sum(int(group["estimated_search_demand"]) for group in repair_groups)

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -426,8 +426,15 @@ async def audit_draft_vs_published(race_ids: List[str]) -> Dict[str, Any]:
 async def plan_repairs(race_ids: List[str]) -> Dict[str, Any]:
     """Return deterministic repair groups and cost ceilings without queueing work.
 
-    Queue each repair_groups item independently. The combined recommended_steps
-    and candidate_names fields are summaries and are not a safe queue payload.
+    repair_groups are returned in the order they must be queued, tagged by
+    ``stage``: ``roster`` settles the candidate list first, ``candidate`` groups
+    research one candidate each and may run in any order among themselves, and
+    ``finalization`` runs the race-wide validation tail once, last. Queue each
+    group as its own run and let it finish before starting the next stage.
+
+    The combined recommended_steps and candidate_names fields are summaries and
+    are not a safe queue payload. estimated_max_cost_usd is a ceiling, not an
+    expectation, unless estimate_kind reports observed calibration.
     """
     return await _client().post("/api/races/repair-plan", json={"race_ids": race_ids})
 
@@ -488,9 +495,25 @@ async def assess_publish_readiness(race_ids: List[str]) -> Dict[str, Any]:
         else:
             if not names:
                 blockers.append("candidate_roster_empty")
-            validation = draft.get("validation_grade") if isinstance(draft.get("validation_grade"), dict) else {}
-            if validation.get("passed") is not True:
+            # Mirror the races-api gate (gcs_helpers._assert_publishable_race): a
+            # *failed* grade blocks, but an absent one does not. A run that never
+            # enabled `review` — discovery/polling/forecast maintenance work — can
+            # never produce a grade, so treating absence as a blocker made every
+            # such draft look unpublishable when the API would accept it.
+            validation = draft.get("validation_grade") if isinstance(draft.get("validation_grade"), dict) else None
+            if validation is None:
+                warnings.append("validation_absent_unreviewed")
+            elif validation.get("passed") is not True:
                 blockers.append("validation_not_passed")
+            blocking_flags = [
+                flag
+                for review in draft.get("reviews") or []
+                if isinstance(review, dict)
+                for flag in review.get("flags") or []
+                if isinstance(flag, dict) and flag.get("severity") in {"warning", "error"}
+            ]
+            if blocking_flags:
+                blockers.append("unresolved_review_flags")
             health = draft.get("run_health") if isinstance(draft.get("run_health"), dict) else {}
             verdict = str(health.get("status") or health.get("verdict") or "unknown")
             if verdict == "failed":
@@ -499,7 +522,13 @@ async def assess_publish_readiness(race_ids: List[str]) -> Dict[str, Any]:
                 warnings.append(f"run_health_{verdict}")
             pipeline_state = draft.get("pipeline_state") if isinstance(draft.get("pipeline_state"), dict) else {}
             if not pipeline_state.get("complete"):
-                warnings.append("pipeline_not_complete")
+                # The API allows an incomplete pipeline only when nothing but
+                # `review` is outstanding; anything else is a hard rejection.
+                remaining = {str(step) for step in pipeline_state.get("remaining_steps") or []}
+                if remaining - {"review"}:
+                    blockers.append("pipeline_incomplete_beyond_review")
+                else:
+                    warnings.append("pipeline_not_complete")
             if _contains_placeholder(draft):
                 blockers.append("literal_placeholder_content")
 

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -2309,6 +2309,92 @@ def test_completeness_gate_still_rejects_single_candidate_evidence():
     )
 
 
+def test_completeness_gate_accepts_fetched_ballotpedia_race_page():
+    """Regression for the live ne-house-02-2026 roster-sync block.
+
+    The agent fetched the Ballotpedia race page, which named the exact contest
+    and enumerated the full general-election field, and the gate rejected it
+    purely on source type. That left the state SoS landing page as the only
+    candidate completeness source, it failed the exact-district check, and the
+    roster never finalized.
+    """
+    from pipeline_client.agent.handlers import _normalize_roster_source, _roster_completeness_source_rejection_reason
+
+    source = _normalize_roster_source(
+        {
+            "url": "https://ballotpedia.org/Nebraska%27s_2nd_Congressional_District_election,_2026",
+            "title": "Nebraska's 2nd Congressional District election, 2026",
+            "evidence": (
+                "Denise Powell, Brinker Harding, and Eric Michael Foreman are the candidates running "
+                "in the general election for U.S. House Nebraska District 2 on November 3, 2026."
+            ),
+            "race_id": "ne-house-02-2026",
+            "evidence_tier": 2,
+            "retrieval_status": "content",
+        },
+        race_id="ne-house-02-2026",
+    )
+
+    assert source["type"] == "ballotpedia"
+    assert (
+        _roster_completeness_source_rejection_reason(
+            source,
+            race_id="ne-house-02-2026",
+            identity={"office": "U.S. House", "contest_stage": "post_primary_general"},
+        )
+        is None
+    )
+
+
+def test_completeness_gate_still_rejects_unfetched_ballotpedia_snippet():
+    """Widening the source type must not weaken the retrieved-content requirement."""
+    from pipeline_client.agent.handlers import _normalize_roster_source, _roster_completeness_source_rejection_reason
+
+    source = _normalize_roster_source(
+        {
+            "url": "https://ballotpedia.org/Nebraska%27s_2nd_Congressional_District_election,_2026",
+            "title": "Nebraska's 2nd Congressional District election, 2026",
+            "evidence": (
+                "Denise Powell, Brinker Harding, and Eric Michael Foreman are the candidates running "
+                "in the general election for U.S. House Nebraska District 2 on November 3, 2026."
+            ),
+            "race_id": "ne-house-02-2026",
+        },
+        race_id="ne-house-02-2026",
+    )
+
+    assert source["retrieval_status"] == "snippet"
+    assert "retrieved page content" in _roster_completeness_source_rejection_reason(
+        source,
+        race_id="ne-house-02-2026",
+        identity={"office": "U.S. House", "contest_stage": "post_primary_general"},
+    )
+
+
+def test_completeness_gate_still_rejects_generic_state_elections_landing_page():
+    """The other half of the ne-house-02-2026 failure: an official page naming no district."""
+    from pipeline_client.agent.handlers import _normalize_roster_source, _roster_completeness_source_rejection_reason
+
+    source = _normalize_roster_source(
+        {
+            "url": "https://sos.nebraska.gov/elections",
+            "title": "2026 Elections - Nebraska Secretary of State",
+            "evidence": "General Election: November 3, 2026",
+            "race_id": "ne-house-02-2026",
+            "evidence_tier": 1,
+            "retrieval_status": "content",
+        },
+        race_id="ne-house-02-2026",
+    )
+
+    assert source["type"] == "official"
+    assert "exact contest" in _roster_completeness_source_rejection_reason(
+        source,
+        race_id="ne-house-02-2026",
+        identity={"office": "U.S. House", "contest_stage": "post_primary_general"},
+    )
+
+
 @pytest.mark.asyncio
 async def test_targeted_issue_run_preserves_other_candidates_audits():
     """Regression: a scoped candidate_names run used to wipe the whole race's audit.
@@ -2406,3 +2492,71 @@ def test_roster_sanitizer_repairs_existing_blank_urls():
 
     assert race_json["candidates"][0]["website"] is None
     assert race_json["candidates"][0]["image_url"] == "https://example.com/a.jpg"
+
+
+def test_completeness_evidence_naming_full_roster_needs_no_certified_wording():
+    """Regression: the gate demanded list-identifying phrasing on top of coverage.
+
+    Ballotpedia's standard full-field sentence and New Jersey's own certified
+    list both name every candidate but never say "certified", so a source that
+    had already proven completeness was rejected for its wording.
+    """
+    from pipeline_client.agent.handlers import _normalize_roster_source, _roster_completeness_source_rejection_reason
+
+    source = _normalize_roster_source(
+        {
+            "url": "https://ballotpedia.org/Nebraska%27s_2nd_Congressional_District_election,_2026",
+            "title": "Nebraska's 2nd Congressional District election, 2026",
+            "evidence": (
+                "Denise Powell, Brinker Harding, and Eric Michael Foreman are running in the general "
+                "election for U.S. House Nebraska District 2 on November 3, 2026."
+            ),
+            "published_at": "2026-08-01T00:00:00Z",
+            "evidence_tier": 2,
+            "retrieval_status": "content",
+        },
+        race_id="ne-house-02-2026",
+    )
+    identity = {"office": "U.S. House", "contest_stage": "post_primary_general"}
+    roster = ["Denise Powell", "Brinker Harding", "Eric Michael Foreman"]
+
+    assert (
+        _roster_completeness_source_rejection_reason(
+            source, race_id="ne-house-02-2026", identity=identity, roster_names=roster
+        )
+        is None
+    )
+
+    # Coverage must be genuine: a roster the evidence does not fully name still fails.
+    assert _roster_completeness_source_rejection_reason(
+        source,
+        race_id="ne-house-02-2026",
+        identity=identity,
+        roster_names=["Denise Powell", "Someone Not Listed"],
+    )
+
+
+def test_completeness_still_refuses_search_snippets():
+    """Coverage does not excuse a snippet — completeness needs retrieved content."""
+    from pipeline_client.agent.handlers import _normalize_roster_source, _roster_completeness_source_rejection_reason
+
+    source = _normalize_roster_source(
+        {
+            "url": "https://ballotpedia.org/Nebraska%27s_2nd_Congressional_District_election,_2026",
+            "title": "Nebraska's 2nd Congressional District election, 2026",
+            "evidence": (
+                "Denise Powell, Brinker Harding, and Eric Michael Foreman are running in the general "
+                "election for U.S. House Nebraska District 2 on November 3, 2026."
+            ),
+        },
+        race_id="ne-house-02-2026",
+    )
+
+    reason = _roster_completeness_source_rejection_reason(
+        source,
+        race_id="ne-house-02-2026",
+        identity={"office": "U.S. House", "contest_stage": "post_primary_general"},
+        roster_names=["Denise Powell", "Brinker Harding", "Eric Michael Foreman"],
+    )
+
+    assert reason and "retrieved page content" in reason

--- a/tests/test_repair_planner.py
+++ b/tests/test_repair_planner.py
@@ -31,14 +31,18 @@ def test_discovery_race_plan_targets_missing_research_with_conservative_ceiling(
     assert plan["estimated_max_cost_usd"] > 1
     assert plan["estimated_max_search_calls"] >= 240
     assert plan["estimate_kind"] == "static_ceiling"
+    stages = [group["stage"] for group in plan["repair_groups"]]
+    assert stages == ["roster", "candidate", "candidate", "finalization"]
     assert plan["repair_groups"][0]["candidate_names"] is None
-    assert {tuple(group["candidate_names"] or []) for group in plan["repair_groups"][1:]} == {
+    assert {tuple(group["candidate_names"] or []) for group in plan["repair_groups"] if group["stage"] == "candidate"} == {
         ("Alice",),
         ("Bob",),
     }
-    for group in plan["repair_groups"][1:]:
-        assert group["enabled_steps"][-2:] == ["review", "iteration"]
-        assert "issues" in group["enabled_steps"]
+    # The validation tail is guaranteed for the plan, not repeated per group.
+    assert plan["repair_groups"][-1]["enabled_steps"][-2:] == ["review", "iteration"]
+    for group in plan["repair_groups"]:
+        if group["stage"] == "candidate":
+            assert "issues" in group["enabled_steps"]
 
 
 def test_validated_complete_race_needs_no_repair():
@@ -102,3 +106,56 @@ def test_summarize_repair_plans_rolls_up_ceilings():
         "estimated_max_cost_usd": 1.25,
         "estimated_max_search_calls": 20,
     }
+
+
+def test_validation_tail_is_planned_once_not_per_candidate():
+    """Regression: every candidate group used to carry the race-wide tail.
+
+    A three-candidate repair therefore ran review and iteration three times,
+    each pass grading a race the later passes had not finished, and the cost
+    ceiling multiplied accordingly.
+    """
+    race = {
+        "candidates": [
+            {"name": "Alice", "issues": {}},
+            {"name": "Bob", "issues": {}},
+            {"name": "Carla", "issues": {}},
+        ],
+        "forecast": None,
+    }
+
+    plan = build_repair_plan("ne-house-02-2026", race, freshness="stale")
+
+    tail = {"review", "iteration", "polling", "forecast", "voter_resources"}
+    candidate_groups = [group for group in plan["repair_groups"] if group["stage"] == "candidate"]
+    assert len(candidate_groups) == 3
+    for group in candidate_groups:
+        assert not tail & set(group["enabled_steps"]), f"candidate group leaked race-wide steps: {group['enabled_steps']}"
+
+    finalization = [group for group in plan["repair_groups"] if group["stage"] == "finalization"]
+    assert len(finalization) == 1
+    assert "review" in finalization[0]["enabled_steps"]
+    assert "iteration" in finalization[0]["enabled_steps"]
+
+
+def test_repair_groups_are_returned_in_queue_order():
+    race = {
+        "candidates": [{"name": "Alice", "issues": {}}],
+        "forecast": None,
+    }
+
+    plan = build_repair_plan("ne-house-02-2026", race, freshness="stale")
+    stages = [group["stage"] for group in plan["repair_groups"]]
+
+    assert stages.index("roster") < stages.index("candidate") < stages.index("finalization")
+
+
+def test_issue_research_still_guarantees_a_validation_tail():
+    """The 'never queue issues alone' invariant must survive the split."""
+    race = {"candidates": [{"name": "Alice", "issues": {}}], "forecast": None}
+
+    plan = build_repair_plan("ne-house-02-2026", race)
+
+    assert "issues" in plan["recommended_steps"]
+    all_steps = {step for group in plan["repair_groups"] for step in group["enabled_steps"]}
+    assert {"review", "iteration"} <= all_steps

--- a/tests/test_smartervote_mcp_client.py
+++ b/tests/test_smartervote_mcp_client.py
@@ -404,6 +404,74 @@ async def test_assess_publish_readiness_blocks_failed_or_placeholder_drafts(monk
         "run_health_failed",
         "literal_placeholder_content",
     }
+    assert "pipeline_not_complete" in result["rows"][1]["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_assess_publish_readiness_allows_unreviewed_maintenance_draft(monkeypatch):
+    """A discovery/polling/forecast draft has no grade and the races-api still publishes it.
+
+    ``gcs_helpers._assert_publishable_race`` only rejects ``passed is False`` and
+    tolerates ``remaining_steps == ["review"]``, so treating a missing grade as a
+    blocker made this tool contradict the endpoint it is supposed to predict.
+    """
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    responses = {
+        "/api/races/ne-house-02-2026/data": {
+            "candidates": [{"name": "Denise Powell"}, {"name": "Brinker Harding"}],
+            "validation_grade": None,
+            "reviews": [],
+            "pipeline_state": {"complete": False, "remaining_steps": ["review"]},
+        },
+        "/races/ne-house-02-2026": {"candidates": [{"name": "Denise Powell"}]},
+        "/api/races/ne-house-03-2026/data": {
+            "candidates": [{"name": "Adrian Smith"}],
+            "validation_grade": None,
+            "pipeline_state": {"complete": False, "remaining_steps": ["issues", "review"]},
+        },
+        "/races/ne-house-03-2026": {"candidates": [{"name": "Adrian Smith"}]},
+    }
+    monkeypatch.setattr(server, "_client", lambda: _StubRacesClient(responses))
+
+    result = await server.assess_publish_readiness(["ne-house-02-2026", "ne-house-03-2026"])
+
+    assert result["ready_race_ids"] == ["ne-house-02-2026"]
+    assert set(result["rows"][0]["warnings"]) == {
+        "validation_absent_unreviewed",
+        "run_health_unknown",
+        "pipeline_not_complete",
+        "candidate_roster_changes",
+    }
+    # Work outstanding beyond `review` is a hard rejection at the API, not a warning.
+    assert result["rows"][1]["blockers"] == ["pipeline_incomplete_beyond_review"]
+
+
+@pytest.mark.asyncio
+async def test_assess_publish_readiness_blocks_unresolved_review_flags(monkeypatch):
+    """The API rejects warning-or-higher review flags even with a passing grade."""
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    responses = {
+        "/api/races/nh-senate-2026/data": {
+            "candidates": [{"name": "Alice Example"}],
+            "validation_grade": {"passed": True, "grade": "A"},
+            "reviews": [{"flags": [{"severity": "warning", "concern": "Summary has no sources."}]}],
+            "pipeline_state": {"complete": True},
+        },
+        "/races/nh-senate-2026": {"candidates": [{"name": "Alice Example"}]},
+    }
+    monkeypatch.setattr(server, "_client", lambda: _StubRacesClient(responses))
+
+    result = await server.assess_publish_readiness(["nh-senate-2026"])
+
+    assert result["rows"][0]["blockers"] == ["unresolved_review_flags"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -687,3 +687,48 @@ def test_proxy_success_prevents_outage_warning(monkeypatch, caplog):
             web_tools.record_proxy_result(ok=False)
 
     assert not [record for record in caplog.records if "has failed all" in record.getMessage()]
+
+
+def test_spreadsheet_urls_are_detected_as_tabular():
+    from pipeline_client.agent.web_tools import is_tabular_document
+
+    assert is_tabular_document("https://sos.nebraska.gov/x/Statewide_Candidate_Filing_List.xlsx")
+    assert is_tabular_document("https://example.gov/list.csv")
+    assert not is_tabular_document("https://ballotpedia.org/Some_Race,_2026")
+    assert not is_tabular_document("https://example.gov/list.pdf")
+
+
+def test_xlsx_extraction_reads_rows_without_a_spreadsheet_dependency():
+    """Several states publish the certified candidate list as .xlsx.
+
+    The text proxy answers 422 for those even though the file downloads fine, so
+    the authoritative roster source was unreadable and finalization deadlocked.
+    """
+    import io
+    import zipfile
+
+    from pipeline_client.agent.web_tools import _xlsx_to_text
+
+    ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    shared = (
+        f'<sst xmlns="{ns}">'
+        "<si><t>For Representative in Congress</t></si>"
+        "<si><t>District 02</t></si>"
+        "<si><t>Denise Powell</t></si>"
+        "</sst>"
+    )
+    sheet = (
+        f'<worksheet xmlns="{ns}"><sheetData>'
+        '<row><c t="s"><v>0</v></c><c t="s"><v>1</v></c><c t="s"><v>2</v></c></row>'
+        "<row><c><v>2026</v></c></row>"
+        "</sheetData></worksheet>"
+    )
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("xl/sharedStrings.xml", shared)
+        archive.writestr("xl/worksheets/sheet1.xml", sheet)
+
+    text = _xlsx_to_text(buffer.getvalue())
+
+    assert "For Representative in Congress | District 02 | Denise Powell" in text
+    assert "2026" in text

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -140,304 +140,226 @@
 
 <div
   data-desktop-candidate-comparison
-  class="hidden isolate overflow-x-auto rounded-2xl border border-stroke bg-surface shadow-sm lg:block"
+  class="hidden isolate overflow-hidden rounded-2xl border border-stroke bg-surface shadow-sm lg:block"
 >
-  <div style="min-width: {(compact ? 170 : 220) + candidates.length * 250}px">
+  {#if showQuality && race.validation_grade}
     <div
-      class:sticky={!compact}
-      class:top-[var(--site-header-height)]={!compact}
-      class="z-30 w-full border-b border-stroke bg-surface py-4 shadow-sm"
+      class="flex items-start gap-3 border-b border-stroke bg-emerald-50 px-5 py-3.5 dark:bg-emerald-950/30"
     >
-      <div
-        class="grid items-center"
-        style="grid-template-columns: {compact
-          ? '170px'
-          : '220px'} repeat({candidates.length}, 1fr)"
+      <span
+        class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-emerald-200 bg-white text-lg font-extrabold text-emerald-800 shadow-sm dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
+        >{race.validation_grade.grade}</span
       >
-        <div
-          class="sticky left-0 z-40 flex self-stretch items-center border-r border-stroke bg-surface px-5 text-xs font-bold uppercase tracking-wider text-content-subtle"
+      <div class="min-w-0 text-sm leading-6 text-content-muted">
+        <span
+          class="mr-1.5 text-[10px] font-bold uppercase tracking-wider text-content-subtle"
+          >Research review</span
         >
-          {compact ? "Compare" : "Compare Directory"}
-        </div>
-        {#each candidates as candidate}
-          <div
-            class="flex items-center gap-3 border-r border-stroke px-5 last:border-none"
-          >
-            {#if candidate.image_url && !failedImages[candidate.name]}
-              <img
-                src={candidate.image_url}
-                alt=""
-                class="h-12 w-12 flex-shrink-0 rounded-full border-2 border-stroke object-cover"
-                on:error={() => markImageFailed(candidate)}
-              />
-            {:else}
-              <div
-                class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-              >
-                {initials(candidate.name)}
-              </div>
-            {/if}
-            <div class="min-w-0">
-              <a
-                href="/races/{race.id}/{candidateSlug(
-                  candidate.name,
-                )}{isDraftPreview ? '?draft=true' : ''}"
-                class="block truncate text-sm font-extrabold text-content hover:text-blue-600"
-                >{candidate.name}</a
-              >
-              <div class="mt-0.5 flex items-center gap-1.5">
-                {#if candidate.party}<span
-                    class="rounded border border-stroke bg-surface-alt px-1.5 py-0.5 text-[10px] font-bold leading-none text-content-muted"
-                    >{partyAbbr(candidate.party)}</span
-                  >{/if}
-                {#if candidate.incumbent}<span
-                    class="rounded border border-green-200 bg-green-50 px-1.5 py-0.5 text-[10px] font-bold leading-none text-green-700 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300"
-                    >Incumbent</span
-                  >{/if}
-              </div>
-            </div>
-          </div>
-        {/each}
+        <strong class="text-content">{race.validation_grade.score}/100</strong>
+        — methodology, sourcing, and bias checks passed the AI review.<ReviewScoreInfo
+          panelId={`desktop-review-score-info-${race.id}`}
+        />
       </div>
     </div>
+  {/if}
 
-    <div class="divide-y divide-stroke">
-      {#if showQuality && race.validation_grade}
+  <div class="overflow-x-auto">
+    <div style="min-width: {(compact ? 170 : 220) + candidates.length * 250}px">
+      <div
+        class:sticky={!compact}
+        class:top-[var(--site-header-height)]={!compact}
+        class="z-30 w-full border-b border-stroke bg-surface py-4 shadow-sm"
+      >
         <div
-          class="grid"
+          class="grid items-center"
           style="grid-template-columns: {compact
             ? '170px'
             : '220px'} repeat({candidates.length}, 1fr)"
         >
           <div
-            class="sticky left-0 z-10 border-r border-stroke bg-emerald-50 p-5 text-sm font-bold text-content dark:bg-emerald-950"
+            class="sticky left-0 z-40 flex self-stretch items-center border-r border-stroke bg-surface px-5 text-xs font-bold uppercase tracking-wider text-content-subtle"
           >
-            Research review
-            <span
-              class="mt-1 block text-[10px] font-semibold uppercase tracking-wider text-content-subtle"
-              >Independent checks</span
-            >
-          </div>
-          <div
-            class="col-span-full flex items-start gap-3 bg-emerald-50/30 p-5 text-sm text-content-muted dark:bg-emerald-950/10"
-            style="grid-column: 2 / -1"
-          >
-            <span
-              class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-emerald-200 bg-white text-lg font-extrabold text-emerald-800 shadow-sm dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
-              >{race.validation_grade.grade}</span
-            >
-            <div>
-              <strong class="text-content"
-                >{race.validation_grade.score}/100 review score.</strong
-              ><ReviewScoreInfo
-                panelId={`desktop-review-score-info-${race.id}`}
-              />
-              Methodology, sourcing, and bias checks passed the AI review.
-            </div>
-          </div>
-        </div>
-      {/if}
-      <div
-        class="grid"
-        style="grid-template-columns: {compact
-          ? '170px'
-          : '220px'} repeat({candidates.length}, 1fr)"
-      >
-        <div
-          class="sticky left-0 z-10 flex items-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
-        >
-          Biography & Summary
-        </div>
-        {#each candidates as candidate}
-          <div
-            class="border-r border-stroke p-6 text-sm leading-relaxed text-content-muted last:border-none"
-          >
-            {candidate.summary}
-            {#if !compact && isExternalUrl(candidate.website)}<div class="mt-3">
-                <a
-                  href={candidate.website.trim()}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-xs font-semibold text-blue-600 hover:underline dark:text-blue-400"
-                  >Visit Campaign Website ↗</a
-                >
-              </div>{/if}
-          </div>
-        {/each}
-      </div>
-
-      <div
-        class="grid"
-        style="grid-template-columns: {compact
-          ? '170px'
-          : '220px'} repeat({candidates.length}, 1fr)"
-      >
-        <div
-          class="col-span-full sticky left-0 z-10 w-full bg-surface-alt/40 px-6 py-2.5 text-xs font-bold uppercase tracking-wider text-content-subtle"
-          style="grid-column: 1 / -1"
-        >
-          Positions on Key Issues
-        </div>
-      </div>
-      {#each issueKeys as issueKey}
-        <div
-          class="grid"
-          style="grid-template-columns: {compact
-            ? '170px'
-            : '220px'} repeat({candidates.length}, 1fr)"
-        >
-          <div
-            class="sticky left-0 z-10 flex flex-col justify-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
-          >
-            {getIssueDisplayName(issueKey)}
+            {compact ? "Compare" : "Compare Directory"}
           </div>
           {#each candidates as candidate}
-            {@const stance = candidate.issues?.[issueKey]}
-            {@const preview = stance
-              ? stancePreview(stance.stance, 320, 220)
-              : ""}
-            {@const isStanceExpanded =
-              expandedStances[stanceKey(issueKey, candidate)] ?? false}
             <div
-              class="flex flex-col gap-3 border-r border-stroke p-6 last:border-none"
+              class="flex items-center gap-3 border-r border-stroke px-5 last:border-none"
             >
-              {#if stance}
-                <div>
-                  <p
-                    class="whitespace-normal text-sm leading-relaxed text-content-muted"
-                  >
-                    {isStanceExpanded ? stance.stance : preview}
-                  </p>
-                  {#if preview !== stance.stance.trim()}
-                    <button
-                      type="button"
-                      aria-expanded={isStanceExpanded}
-                      on:click={() => toggleStance(issueKey, candidate)}
-                      class="inline-flex min-h-11 items-start pt-1 text-sm font-bold leading-5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                    >
-                      {isStanceExpanded ? "Show less" : "Show more"}
-                      <span class="sr-only"> for {candidate.name}</span>
-                    </button>
-                  {/if}
+              {#if candidate.image_url && !failedImages[candidate.name]}
+                <img
+                  src={candidate.image_url}
+                  alt=""
+                  class="h-12 w-12 flex-shrink-0 rounded-full border-2 border-stroke object-cover"
+                  on:error={() => markImageFailed(candidate)}
+                />
+              {:else}
+                <div
+                  class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                >
+                  {initials(candidate.name)}
                 </div>
-                <div class="flex items-center gap-2 pt-1">
-                  <span
-                    class="text-[10px] font-medium uppercase tracking-wide text-content-subtle"
-                    >Confidence</span
-                  ><ConfidenceIndicator confidence={stance.confidence} />
+              {/if}
+              <div class="min-w-0">
+                <a
+                  href="/races/{race.id}/{candidateSlug(
+                    candidate.name,
+                  )}{isDraftPreview ? '?draft=true' : ''}"
+                  class="block truncate text-sm font-extrabold text-content hover:text-blue-600"
+                  >{candidate.name}</a
+                >
+                <div class="mt-0.5 flex items-center gap-1.5">
+                  {#if candidate.party}<span
+                      class="rounded border border-stroke bg-surface-alt px-1.5 py-0.5 text-[10px] font-bold leading-none text-content-muted"
+                      >{partyAbbr(candidate.party)}</span
+                    >{/if}
+                  {#if candidate.incumbent}<span
+                      class="rounded border border-green-200 bg-green-50 px-1.5 py-0.5 text-[10px] font-bold leading-none text-green-700 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300"
+                      >Incumbent</span
+                    >{/if}
                 </div>
-                {#if stance.sources?.length}
-                  {@const areSourcesExpanded =
-                    expandedSources[sourcesKey(issueKey, candidate)] ?? false}
-                  <div class="border-t border-stroke/40 pt-2">
-                    <div class="flex flex-col items-start gap-2">
-                      {#each areSourcesExpanded ? stance.sources : stance.sources.slice(0, 1) as source}
-                        <SourceLink {source} />
-                      {/each}
-                    </div>
-                    {#if stance.sources.length > 1}
-                      <button
-                        type="button"
-                        aria-expanded={areSourcesExpanded}
-                        on:click={() => toggleSources(issueKey, candidate)}
-                        class="mt-1 inline-flex min-h-11 items-center text-xs font-bold text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                      >
-                        {areSourcesExpanded
-                          ? "Show fewer sources"
-                          : `Show ${stance.sources.length - 1} more ${stance.sources.length === 2 ? "source" : "sources"}`}
-                        <span class="sr-only"> for {candidate.name}</span>
-                      </button>
-                    {/if}
-                  </div>
-                {/if}
-              {:else}<span class="select-none text-xs italic text-content-faint"
-                  >No stance researched yet.</span
-                >{/if}
+              </div>
             </div>
           {/each}
         </div>
-      {/each}
+      </div>
 
-      {#if !compact}
+      <div class="divide-y divide-stroke">
         <div
           class="grid"
-          style="grid-template-columns: 220px repeat({candidates.length}, 1fr)"
+          style="grid-template-columns: {compact
+            ? '170px'
+            : '220px'} repeat({candidates.length}, 1fr)"
+        >
+          <div
+            class="sticky left-0 z-10 flex items-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
+          >
+            Biography & Summary
+          </div>
+          {#each candidates as candidate}
+            <div
+              class="border-r border-stroke p-6 text-sm leading-relaxed text-content-muted last:border-none"
+            >
+              {candidate.summary}
+              {#if !compact && isExternalUrl(candidate.website)}<div
+                  class="mt-3"
+                >
+                  <a
+                    href={candidate.website.trim()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-xs font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                    >Visit Campaign Website ↗</a
+                  >
+                </div>{/if}
+            </div>
+          {/each}
+        </div>
+
+        <div
+          class="grid"
+          style="grid-template-columns: {compact
+            ? '170px'
+            : '220px'} repeat({candidates.length}, 1fr)"
         >
           <div
             class="col-span-full sticky left-0 z-10 w-full bg-surface-alt/40 px-6 py-2.5 text-xs font-bold uppercase tracking-wider text-content-subtle"
             style="grid-column: 1 / -1"
           >
-            Background & Credentials
+            Positions on Key Issues
           </div>
         </div>
-        <div
-          class="grid"
-          style="grid-template-columns: 220px repeat({candidates.length}, 1fr)"
-        >
+        {#each issueKeys as issueKey}
           <div
-            class="sticky left-0 z-10 flex items-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
+            class="grid"
+            style="grid-template-columns: {compact
+              ? '170px'
+              : '220px'} repeat({candidates.length}, 1fr)"
           >
-            Career Timeline
-          </div>
-          {#each candidates as candidate}<div
-              class="border-r border-stroke p-6 text-sm text-content-muted last:border-none"
+            <div
+              class="sticky left-0 z-10 flex flex-col justify-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
             >
-              {#if candidate.career_history?.length}<div class="space-y-4">
-                  {#each candidate.career_history as entry}<div
-                      class="border-l-2 border-blue-500/50 py-0.5 pl-3"
+              {getIssueDisplayName(issueKey)}
+            </div>
+            {#each candidates as candidate}
+              {@const stance = candidate.issues?.[issueKey]}
+              {@const preview = stance
+                ? stancePreview(stance.stance, 320, 220)
+                : ""}
+              {@const isStanceExpanded =
+                expandedStances[stanceKey(issueKey, candidate)] ?? false}
+              <div
+                class="flex flex-col gap-3 border-r border-stroke p-6 last:border-none"
+              >
+                {#if stance}
+                  <div>
+                    <p
+                      class="whitespace-normal text-sm leading-relaxed text-content-muted"
                     >
-                      <div
-                        class="flex flex-wrap items-baseline justify-between gap-2"
+                      {isStanceExpanded ? stance.stance : preview}
+                    </p>
+                    {#if preview !== stance.stance.trim()}
+                      <button
+                        type="button"
+                        aria-expanded={isStanceExpanded}
+                        on:click={() => toggleStance(issueKey, candidate)}
+                        class="inline-flex min-h-11 items-start pt-1 text-sm font-bold leading-5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
                       >
-                        <span class="text-xs font-semibold text-content"
-                          >{entry.title}</span
-                        >{#if entry.start_year}<span
-                            class="text-[10px] text-content-subtle"
-                            >{entry.start_year}{entry.end_year
-                              ? ` – ${entry.end_year}`
-                              : " – Present"}</span
-                          >{/if}
+                        {isStanceExpanded ? "Show less" : "Show more"}
+                        <span class="sr-only"> for {candidate.name}</span>
+                      </button>
+                    {/if}
+                  </div>
+                  <div class="flex items-center gap-2 pt-1">
+                    <span
+                      class="text-[10px] font-medium uppercase tracking-wide text-content-subtle"
+                      >Confidence</span
+                    ><ConfidenceIndicator confidence={stance.confidence} />
+                  </div>
+                  {#if stance.sources?.length}
+                    {@const areSourcesExpanded =
+                      expandedSources[sourcesKey(issueKey, candidate)] ?? false}
+                    <div class="border-t border-stroke/40 pt-2">
+                      <div class="flex flex-col items-start gap-2">
+                        {#each areSourcesExpanded ? stance.sources : stance.sources.slice(0, 1) as source}
+                          <SourceLink {source} />
+                        {/each}
                       </div>
-                      {#if entry.organization}<span
-                          class="block text-xs text-content-subtle"
-                          >{entry.organization}</span
-                        >{/if}
-                    </div>{/each}
-                </div>{:else}<span class="text-xs italic text-content-faint"
-                  >No career records.</span
-                >{/if}
-            </div>{/each}
-        </div>
-        <div
-          class="grid"
-          style="grid-template-columns: 220px repeat({candidates.length}, 1fr)"
-        >
-          <div
-            class="sticky left-0 z-10 flex items-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
-          >
-            Education
+                      {#if stance.sources.length > 1}
+                        <button
+                          type="button"
+                          aria-expanded={areSourcesExpanded}
+                          on:click={() => toggleSources(issueKey, candidate)}
+                          class="mt-1 inline-flex min-h-11 items-center text-xs font-bold text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                        >
+                          {areSourcesExpanded
+                            ? "Show fewer sources"
+                            : `Show ${stance.sources.length - 1} more ${stance.sources.length === 2 ? "source" : "sources"}`}
+                          <span class="sr-only"> for {candidate.name}</span>
+                        </button>
+                      {/if}
+                    </div>
+                  {/if}
+                {:else}<span
+                    class="select-none text-xs italic text-content-faint"
+                    >No stance researched yet.</span
+                  >{/if}
+              </div>
+            {/each}
           </div>
-          {#each candidates as candidate}<div
-              class="border-r border-stroke p-6 text-sm text-content-muted last:border-none"
+        {/each}
+
+        {#if !compact}
+          <div
+            class="grid"
+            style="grid-template-columns: 220px repeat({candidates.length}, 1fr)"
+          >
+            <div
+              class="col-span-full sticky left-0 z-10 w-full bg-surface-alt/40 px-6 py-2.5 text-xs font-bold uppercase tracking-wider text-content-subtle"
+              style="grid-column: 1 / -1"
             >
-              {#if candidate.education?.length}<div class="space-y-3">
-                  {#each candidate.education as edu}<div>
-                      <span class="block text-xs font-semibold text-content"
-                        >{edu.institution}</span
-                      >{#if edu.degree || edu.field}<span
-                          class="text-[11px] text-content-subtle"
-                          >{[edu.degree, edu.field]
-                            .filter(Boolean)
-                            .join(" in ")}{#if edu.year}
-                            ({edu.year}){/if}</span
-                        >{/if}
-                    </div>{/each}
-                </div>{:else}<span class="text-xs italic text-content-faint"
-                  >No education records.</span
-                >{/if}
-            </div>{/each}
-        </div>
-        {#each backgroundRows as row}
+              Background & Credentials
+            </div>
+          </div>
           <div
             class="grid"
             style="grid-template-columns: 220px repeat({candidates.length}, 1fr)"
@@ -445,68 +367,140 @@
             <div
               class="sticky left-0 z-10 flex items-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
             >
-              {row.label}
+              Career Timeline
             </div>
-            {#each candidates as candidate}{@const summary =
-                candidate[row.summary]}{@const sourceUrl = candidate[row.url]}
-              <div
+            {#each candidates as candidate}<div
                 class="border-r border-stroke p-6 text-sm text-content-muted last:border-none"
               >
-                {#if summary}<p class="mb-3 text-xs leading-relaxed">
-                    {summary}
-                  </p>
-                  {#if sourceUrl && isExternalUrl(sourceUrl)}<a
-                      href={sourceUrl.trim()}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="text-xs font-semibold text-blue-600 hover:underline dark:text-blue-400"
-                      >{row.link} ↗</a
-                    >{/if}{:else}<span class="text-xs italic text-content-faint"
-                    >No records available.</span
+                {#if candidate.career_history?.length}<div class="space-y-4">
+                    {#each candidate.career_history as entry}<div
+                        class="border-l-2 border-blue-500/50 py-0.5 pl-3"
+                      >
+                        <div
+                          class="flex flex-wrap items-baseline justify-between gap-2"
+                        >
+                          <span class="text-xs font-semibold text-content"
+                            >{entry.title}</span
+                          >{#if entry.start_year}<span
+                              class="text-[10px] text-content-subtle"
+                              >{entry.start_year}{entry.end_year
+                                ? ` – ${entry.end_year}`
+                                : " – Present"}</span
+                            >{/if}
+                        </div>
+                        {#if entry.organization}<span
+                            class="block text-xs text-content-subtle"
+                            >{entry.organization}</span
+                          >{/if}
+                      </div>{/each}
+                  </div>{:else}<span class="text-xs italic text-content-faint"
+                    >No career records.</span
                   >{/if}
               </div>{/each}
           </div>
-        {/each}
-      {/if}
-
-      {#if race.forecast}
-        <div
-          class="grid"
-          style="grid-template-columns: {compact
-            ? '170px'
-            : '220px'} repeat({candidates.length}, 1fr)"
-        >
           <div
-            class="sticky left-0 z-10 border-r border-stroke bg-blue-50 p-5 text-sm font-bold text-content dark:bg-blue-950/20"
+            class="grid"
+            style="grid-template-columns: 220px repeat({candidates.length}, 1fr)"
           >
-            Forecast
-            <span
-              class="mt-1 block text-[10px] font-semibold uppercase tracking-wider text-content-subtle"
-              >Model estimate</span
-            >
-          </div>
-          {#each candidates as candidate}
-            {@const probability = forecastProbability(candidate)}
             <div
-              class="border-r border-stroke bg-blue-50/40 p-5 last:border-none dark:bg-blue-950/10"
+              class="sticky left-0 z-10 flex items-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
             >
-              {#if probability !== undefined}
-                <div class="text-2xl font-extrabold text-content">
-                  {Math.round(probability * 100)}%
-                </div>
-                <p class="mt-1 text-xs text-content-muted">
-                  estimated win probability
-                </p>
-              {:else}
-                <p class="text-sm font-semibold capitalize text-content">
-                  {race.forecast.rating.replaceAll("_", " ")}
-                </p>
-                <p class="mt-1 text-xs text-content-muted">race-level rating</p>
-              {/if}
+              Education
+            </div>
+            {#each candidates as candidate}<div
+                class="border-r border-stroke p-6 text-sm text-content-muted last:border-none"
+              >
+                {#if candidate.education?.length}<div class="space-y-3">
+                    {#each candidate.education as edu}<div>
+                        <span class="block text-xs font-semibold text-content"
+                          >{edu.institution}</span
+                        >{#if edu.degree || edu.field}<span
+                            class="text-[11px] text-content-subtle"
+                            >{[edu.degree, edu.field]
+                              .filter(Boolean)
+                              .join(" in ")}{#if edu.year}
+                              ({edu.year}){/if}</span
+                          >{/if}
+                      </div>{/each}
+                  </div>{:else}<span class="text-xs italic text-content-faint"
+                    >No education records.</span
+                  >{/if}
+              </div>{/each}
+          </div>
+          {#each backgroundRows as row}
+            <div
+              class="grid"
+              style="grid-template-columns: 220px repeat({candidates.length}, 1fr)"
+            >
+              <div
+                class="sticky left-0 z-10 flex items-center border-r border-stroke bg-surface-alt p-5 text-sm font-bold text-content"
+              >
+                {row.label}
+              </div>
+              {#each candidates as candidate}{@const summary =
+                  candidate[row.summary]}{@const sourceUrl = candidate[row.url]}
+                <div
+                  class="border-r border-stroke p-6 text-sm text-content-muted last:border-none"
+                >
+                  {#if summary}<p class="mb-3 text-xs leading-relaxed">
+                      {summary}
+                    </p>
+                    {#if sourceUrl && isExternalUrl(sourceUrl)}<a
+                        href={sourceUrl.trim()}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-xs font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                        >{row.link} ↗</a
+                      >{/if}{:else}<span
+                      class="text-xs italic text-content-faint"
+                      >No records available.</span
+                    >{/if}
+                </div>{/each}
             </div>
           {/each}
-        </div>
-      {/if}
+        {/if}
+
+        {#if race.forecast}
+          <div
+            class="grid"
+            style="grid-template-columns: {compact
+              ? '170px'
+              : '220px'} repeat({candidates.length}, 1fr)"
+          >
+            <div
+              class="sticky left-0 z-10 border-r border-stroke bg-blue-50 p-5 text-sm font-bold text-content dark:bg-blue-950/20"
+            >
+              Forecast
+              <span
+                class="mt-1 block text-[10px] font-semibold uppercase tracking-wider text-content-subtle"
+                >Model estimate</span
+              >
+            </div>
+            {#each candidates as candidate}
+              {@const probability = forecastProbability(candidate)}
+              <div
+                class="border-r border-stroke bg-blue-50/40 p-5 last:border-none dark:bg-blue-950/10"
+              >
+                {#if probability !== undefined}
+                  <div class="text-2xl font-extrabold text-content">
+                    {Math.round(probability * 100)}%
+                  </div>
+                  <p class="mt-1 text-xs text-content-muted">
+                    estimated win probability
+                  </p>
+                {:else}
+                  <p class="text-sm font-semibold capitalize text-content">
+                    {race.forecast.rating.replaceAll("_", " ")}
+                  </p>
+                  <p class="mt-1 text-xs text-content-muted">
+                    race-level rating
+                  </p>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
     </div>
   </div>
 </div>

--- a/web/src/lib/components/compare/CandidateComparison.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.test.ts
@@ -90,9 +90,31 @@ describe("CandidateComparison", () => {
 
     expect(desktop.getByText("Compare").classList).toContain("bg-surface");
     expect(desktop.getByText("Compare").classList).toContain("self-stretch");
-    expect(desktop.getByText("Research review").classList).toContain(
-      "bg-emerald-50",
-    );
+  });
+
+  it("shows the review summary as a banner outside the horizontal scroller", () => {
+    const reviewedRace: Race = {
+      ...race,
+      validation_grade: {
+        grade: "A",
+        score: 95,
+        passed: true,
+        summary: "Publication checks passed.",
+      },
+    };
+    const { container } = render(CandidateComparison, {
+      race: reviewedRace,
+      candidates: [candidate],
+      compact: true,
+      showQuality: true,
+    });
+    const desktop = container.querySelector<HTMLElement>(
+      "[data-desktop-candidate-comparison]",
+    )!;
+
+    const label = within(desktop).getByText("Research review");
+    expect(label.closest(".overflow-x-auto")).toBeNull();
+    expect(within(desktop).getByText("95/100")).toBeTruthy();
   });
 
   it("explains the limits of the AI review score", async () => {

--- a/web/src/lib/components/home/InteractiveRaceCompare.svelte
+++ b/web/src/lib/components/home/InteractiveRaceCompare.svelte
@@ -4,15 +4,31 @@
 
   export let races: Race[] = [];
   let selectedId = races[0]?.id ?? "";
+  let pillList: HTMLDivElement | undefined;
   $: if (races.length && !races.some((race) => race.id === selectedId))
     selectedId = races[0].id;
-  $: selectedRace = races.find((race) => race.id === selectedId) ?? races[0];
+  $: selectedIndex = races.findIndex((race) => race.id === selectedId);
+  $: selectedRace = races[selectedIndex] ?? races[0];
   $: candidates =
     selectedRace?.candidates.filter((candidate) => !candidate.withdrawn) ?? [];
+  // Keep the active pill visible when the selection changes from either the
+  // arrow buttons or a pill click.
+  $: centerPill(selectedIndex);
+
+  function centerPill(index: number) {
+    const pill = pillList?.children[index] as HTMLElement | undefined;
+    if (!pill || !pillList || typeof pillList.scrollTo !== "function") return;
+    pillList.scrollTo({
+      left: Math.max(
+        0,
+        pill.offsetLeft - (pillList.clientWidth - pill.offsetWidth) / 2,
+      ),
+      behavior: "smooth",
+    });
+  }
 
   function moveRace(direction: number) {
-    const current = races.findIndex((race) => race.id === selectedId);
-    const next = (current + direction + races.length) % races.length;
+    const next = (selectedIndex + direction + races.length) % races.length;
     selectedId = races[next]?.id ?? selectedId;
   }
 </script>
@@ -55,6 +71,7 @@
           aria-label="Previous featured race">←</button
         >
         <div
+          bind:this={pillList}
           class="hide-scrollbar flex min-w-0 flex-1 gap-2 overflow-x-auto py-1"
         >
           {#each races as race, index}


### PR DESCRIPTION
Three findings from taking `ne-house-02-2026` from triage through a real run.

## 1. Spreadsheet roster sources were unreadable

Nebraska publishes its certified candidate list as `Statewide_Candidate_Filing_List.xlsx`. The text proxy answers **422** for spreadsheets even though the file downloads fine (`200`, 63,732 bytes). So no official source named the district, roster finalization deadlocked, and the run died at discovery in **56 seconds** after burning all twelve iterations.

Spreadsheets and CSVs now fetch directly and flatten to text. `.xlsx` is a zip of XML, so it is unzipped and read with `zipfile` + `ElementTree` rather than adding `openpyxl` to the worker image for one format. Against the real file:

```
For Representative in Congress | District 02 | 2 | 1 | Democratic   | Denise Powell         | Omaha | Nonincumbent
For Representative in Congress | District 02 | 2 | 1 | Republican   | Brinker Harding       | Omaha | Nonincumbent
For Representative in Congress | District 02 | 2 | 1 | Libertarian  | Eric Michael Foreman  | Omaha | ...
```

Several states publish this way, so this likely unblocks a class of races rather than one.

## 2. The completeness gate rejected sources that had already proven completeness

It required list-identifying phrasing (`qualified|certified|official list|...`) *in addition to* the structural checks. That is the same prose matching that rejected New Jersey's own certified list, and it rejected Ballotpedia's standard full-field sentence for lacking the word "certified".

Evidence that names **every candidate on the proposed roster** now satisfies the check; phrasing remains a valid alternative for lists that assert completeness without enumerating inline. `finalize_roster` already requires `source_candidate_names` to match the proposed roster exactly, so coverage is verified, not asserted.

Unchanged and still enforced: retrieved page content only (snippets still rejected), exact contest and district, current cycle, per-candidate evidence.

## 3. plan_repairs planned the validation tail once per candidate

`_ISSUE_RESEARCH_SAFETY_STEPS` was applied to each candidate's step set, so every per-candidate group carried `polling, forecast, voter_resources, review, iteration`. Queuing the groups as the tool documents would run review and iteration **three times** for a three-candidate race, each pass grading a race the later groups had not finished.

Groups are now returned in queue order and tagged by `stage`:

| stage | contents |
| --- | --- |
| `roster` | discovery — settles the candidate list first |
| `candidate` × N | images, issues, finance, refinement |
| `finalization` | polling, forecast, voter_resources, review, iteration — once, last |

The "never queue issues alone" invariant is preserved at plan level rather than repeated per group. `ne-house-02` drops from **$4.41 to $3.05**.

## Validation

- `python -m pytest tests -q --ignore=tests/test_races_api_admin.py` — 968 passed
- New tests: xlsx extraction without a spreadsheet dependency; tabular URL detection; completeness satisfied by roster coverage; completeness still refusing snippets and mismatched rosters; the validation tail planned once; groups returned in queue order

🤖 Generated with [Claude Code](https://claude.com/claude-code)