### PR TITLE
Make the roster-evidence contract single-source and add an adjudicator

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -471,13 +471,13 @@ def _sanitize_roster_sources(race_json: Dict[str, Any], log: Any | None = None) 
 
     Discovery writes roster_sources directly into the race JSON blob rather
     than through the ``set_candidate_roster_sources`` tool (which already
-    clamps invalid types via ``_ROSTER_SOURCE_TYPES``), so an out-of-enum
-    value like "website" can reach here unnormalized. Left unclamped, the
-    subsequent ``RaceJSON.model_validate`` call below raises, its exception is
-    swallowed, and the *raw* unmigrated document — with the invalid value
-    still in it — is what persists instead of the normalized one.
+    clamps invalid types via the roster contract), so an out-of-enum value like
+    "website" can reach here unnormalized. Left unclamped, the subsequent
+    ``RaceJSON.model_validate`` call below raises, its exception is swallowed,
+    and the *raw* unmigrated document — with the invalid value still in it — is
+    what persists instead of the normalized one.
     """
-    from pipeline_client.agent.handlers import _ROSTER_SOURCE_TYPES
+    from pipeline_client.agent.roster_contract import SOURCE_CLASSES as _ROSTER_SOURCE_TYPES
 
     for candidate_index, candidate in enumerate(race_json.get("candidates") or []):
         if not isinstance(candidate, dict):

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -21,58 +21,29 @@ from pipeline_client.agent.evidence import merge_source_lists
 from pipeline_client.agent.images import _is_valid_image_url
 from pipeline_client.agent.polling_quality import polling_semantic_problem
 from pipeline_client.agent.prompts import CANONICAL_ISSUES
+from pipeline_client.agent.roster import ROSTER_CAP
+from pipeline_client.agent.roster_contract import (
+    COMPLETENESS_SOURCE_CLASSES,
+    COMPLETENESS_TIERS,
+    CONTEST_STAGES,
+    CYCLE_LOOKBACK_YEARS,
+    QUALIFYING_SOURCE_CLASSES,
+    ROSTER_LISTING_SOURCE_CLASSES,
+    SOURCE_CLASSES,
+    classify_source_class,
+    lacks_tier3_corroboration,
+    tier_rejection_reason,
+)
 from pipeline_client.agent.source_types import normalize_source_type
 
 _CANONICAL_ISSUE_SET = set(CANONICAL_ISSUES)
-_ROSTER_SOURCE_TYPES = {"official", "ballotpedia", "fec", "news", "campaign", "other"}
-# Source classes that can actually carry roster evidence. "other" is a parking
-# slot for unclassifiable input and never qualifies on its own.
-_QUALIFYING_ROSTER_SOURCE_TYPES = {"official", "fec", "campaign", "ballotpedia", "news"}
-# Free-form labels models emit for roster evidence, mapped onto the classes
-# above. Mirrors source_types.SOURCE_TYPE_ALIASES, which exists for the same
-# reason: models reliably invent plausible synonyms for enum values.
-_ROSTER_SOURCE_TYPE_ALIASES = {
-    "article": "news",
-    "ballot": "official",
-    "certified ballot": "official",
-    "election authority": "official",
-    "election official": "official",
-    "election results": "official",
-    "filing": "official",
-    "government": "official",
-    "gov": "official",
-    "media": "news",
-    "news article": "news",
-    "newspaper": "news",
-    "party": "official",
-    "party list": "official",
-    "press": "news",
-    "qualified candidates": "official",
-    "secretary of state": "official",
-    "sos": "official",
-    "state": "official",
-    "state election authority": "official",
-    "campaign site": "campaign",
-    "campaign website": "campaign",
-    "candidate site": "campaign",
-    "candidate website": "campaign",
-    "official campaign": "campaign",
-    "fec filing": "fec",
-    "federal election commission": "fec",
-    "encyclopedia": "ballotpedia",
-    "wiki": "ballotpedia",
-    "wikipedia": "ballotpedia",
-}
-_CONTEST_STAGES = {
-    "pre_primary",
-    "post_primary_general",
-    "runoff",
-    "top_two",
-    "top_four_rcv",
-    "uncontested",
-    "special",
-    "unknown",
-}
+
+# The roster-evidence contract lives in roster_contract so that the prompt text
+# the model reads and the checks enforced here cannot drift apart. Do not
+# redefine any of these locally — tests/test_roster_contract.py asserts identity.
+_ROSTER_SOURCE_TYPES = SOURCE_CLASSES
+_QUALIFYING_ROSTER_SOURCE_TYPES = QUALIFYING_SOURCE_CLASSES
+_CONTEST_STAGES = CONTEST_STAGES
 
 
 def _roster_source_text(source: Dict[str, Any]) -> str:
@@ -104,16 +75,34 @@ def _source_supports_exact_contest(source: Dict[str, Any], *, race_id: str) -> b
     return federal_house and exact_district
 
 
+def _published_year(value: Any) -> int | None:
+    """Return the publication year from any reasonable date the model supplies.
+
+    Election authorities date documents in many shapes, and a model reading one
+    reports what it saw — "2026" from a filing list, "2026-08" from a header, an
+    ISO timestamp from a news page. Parsing only full ISO dates treated a bare
+    year as no date at all, and Nebraska's certified filing list was rejected as
+    undated while naming every candidate in the contest.
+    """
+    text = str(value or "").strip().replace("Z", "+00:00")
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text).year
+    except ValueError:
+        pass
+    # "2026", "2026-08", "08/02/2026", "August 2, 2026" all carry the year plainly.
+    match = re.search(r"(?:19|20)\d{2}", text)
+    return int(match.group()) if match else None
+
+
 def _source_is_current_cycle(source: Dict[str, Any], *, race_id: str, text: str) -> bool:
     """Check a source belongs to this race's cycle, by publish date or explicit year."""
     year_match = re.search(r"(?:19|20)\d{2}", race_id)
     if not year_match:
         return True
     valid_years = {int(year_match.group()) - 1, int(year_match.group())}
-    try:
-        published_year = datetime.fromisoformat(str(source.get("published_at") or "").replace("Z", "+00:00")).year
-    except ValueError:
-        published_year = None
+    published_year = _published_year(source.get("published_at"))
     if published_year is not None:
         return published_year in valid_years
     return any(str(year) in text for year in valid_years)
@@ -143,7 +132,7 @@ def _source_proves_different_contest(source: Dict[str, Any], *, candidate_name: 
     wording differs, which is how this check previously failed every race that was
     not a U.S. House contest.
     """
-    if source.get("type") not in {"official", "fec", "campaign", "ballotpedia", "news"}:
+    if source.get("type") not in QUALIFYING_SOURCE_CLASSES:
         return False
     parsed_url = urlparse(str(source.get("url") or ""))
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
@@ -169,7 +158,7 @@ def _source_omits_candidate_from_roster(
     finding from a blocked, empty, or truncated page — the failure mode that
     otherwise deletes real candidates.
     """
-    if source.get("type") not in {"official", "fec", "ballotpedia", "news"}:
+    if source.get("type") not in ROSTER_LISTING_SOURCE_CLASSES:
         return False
     parsed_url = urlparse(str(source.get("url") or ""))
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
@@ -238,40 +227,8 @@ def _normalize_observed_sources(sources: Any, research_trace: Any, *, default_ty
 
 
 def _classify_roster_source_type(raw_type: Any, *, title: str | None, url: str | None, host: str) -> str:
-    """Map a free-form roster source label onto a known roster source class.
-
-    Host evidence is checked first, then the model's label via the recognized set
-    and ``_ROSTER_SOURCE_TYPE_ALIASES``. Classification never depends on the label
-    being well-formed: a plausible synonym such as ``"web"`` or
-    ``"election_authority"`` used to be parked in ``"other"``, which can never
-    satisfy the roster evidence contract, so valid Ballotpedia and official
-    sources were rejected on a spelling technicality.
-    """
-    title_and_url = f"{title or ''} {url or ''}".casefold()
-
-    # Host evidence outranks the model's label. "official"/"fec" are the classes that
-    # waive the tier-3 corroboration rule, so they must be earned by the host (or a
-    # party qualified-candidate list title) rather than self-declared — otherwise any
-    # page could be relabelled to bypass that guard.
-    host_class: str | None = None
-    if host == "ballotpedia.org" or host.endswith(".ballotpedia.org"):
-        host_class = "ballotpedia"
-    elif host == "fec.gov" or host.endswith(".fec.gov"):
-        host_class = "fec"
-    elif host.endswith(".gov") or re.search(r"\bqualified\b.*\bcandidates?\b", title_and_url):
-        host_class = "official"
-    if host_class:
-        return host_class
-
-    label = str(raw_type or "").strip().lower().replace("_", " ").replace("-", " ")
-    label = re.sub(r"\s+", " ", label)
-    claimed = label if label in _ROSTER_SOURCE_TYPES and label != "other" else _ROSTER_SOURCE_TYPE_ALIASES.get(label)
-    if claimed in {"official", "fec"}:
-        # Unverifiable authority claim: keep the source usable but strip the waiver.
-        return "news"
-    if claimed:
-        return claimed
-    return "other"
+    """Map a free-form roster source label onto a known roster source class."""
+    return classify_source_class(raw_type, title=title, url=url, host=host)
 
 
 def _normalize_roster_source(source: Any, *, race_id: str = "") -> Dict[str, Any] | None:
@@ -408,31 +365,17 @@ def _roster_source_rejection_reason(source: Dict[str, Any], *, candidate_name: s
     if not name_words or not all(word in evidence_text for word in name_words):
         return f"evidence text does not contain the full candidate name {candidate_name!r}"
     year_match = re.search(r"(?:19|20)\d{2}", race_id)
-    try:
-        published = datetime.fromisoformat(str(source.get("published_at") or "").replace("Z", "+00:00"))
-    except ValueError:
-        published = None
+    published_year = _published_year(source.get("published_at"))
     if year_match:
-        valid_years = {int(year_match.group()) - 2, int(year_match.group()) - 1, int(year_match.group())}
+        race_year = int(year_match.group())
+        valid_years = {race_year - offset for offset in range(CYCLE_LOOKBACK_YEARS + 1)}
         years_label = "/".join(str(year) for year in sorted(valid_years))
-        if published is not None:
-            if published.year not in valid_years:
-                return f"published_at year {published.year} is outside the current cycle ({years_label})"
+        if published_year is not None:
+            if published_year not in valid_years:
+                return f"published_at year {published_year} is outside the current cycle ({years_label})"
         elif not any(str(year) in evidence_text for year in valid_years):
             return f"evidence has no current-cycle date; include a {years_label} published_at or cite the year in the text"
-    tier = source.get("evidence_tier")
-    status = source.get("retrieval_status")
-    if tier == 1:
-        if status != "content" or source.get("type") not in {"official", "fec"}:
-            return "tier 1 requires retrieved page content from an official or FEC source"
-        return None
-    if tier == 2:
-        if status != "content" or source.get("type") not in {"campaign", "ballotpedia", "news"}:
-            return "tier 2 requires retrieved page content from a campaign, Ballotpedia, or news source"
-        return None
-    if tier == 3 and status == "snippet":
-        return None
-    return f"evidence_tier {tier!r}/retrieval_status {status!r} is not a recognized evidence grade"
+    return tier_rejection_reason(source)
 
 
 def _source_supports_candidate_addition(source: Dict[str, Any], *, candidate_name: str, race_id: str) -> bool:
@@ -460,12 +403,8 @@ def _qualifying_candidate_addition_sources(
         for source in normalized
         if _source_supports_candidate_addition(source, candidate_name=candidate_name, race_id=race_id)
     ]
-    if require_corroboration and qualifying and all(source.get("evidence_tier") == 3 for source in qualifying):
-        if any(source.get("type") in {"official", "fec"} for source in qualifying):
-            return qualifying
-        domains = {urlparse(str(source.get("url"))).netloc.lower() for source in qualifying}
-        if len(domains) < 2:
-            return []
+    if require_corroboration and lacks_tier3_corroboration(qualifying):
+        return []
     return qualifying
 
 
@@ -494,18 +433,13 @@ def _roster_completeness_source_rejection_reason(
     identity: Dict[str, Any],
     roster_names: list[str] | None = None,
 ) -> str | None:
-    """Validate evidence that describes the roster as a whole, not one member."""
-    # Ballotpedia belongs here for the same reason it is already accepted as
-    # candidate-level roster evidence: its per-race election pages publish the
-    # full qualified field, and RaceJSON treats `ballotpedia_url` as the
-    # canonical roster pointer. Excluding it stranded rosters that had no other
-    # retrievable full list — a state SoS landing page rarely enumerates one
-    # district's candidates, so the roster never finalized and the race stayed
-    # at its stale published roster (observed live on ne-house-02-2026).
-    # The real teeth are below and unchanged: retrieved page content only,
-    # exact contest and district, list-identifying phrasing, and coverage of
-    # every active candidate.
-    if source.get("type") not in {"official", "news", "ballotpedia"}:
+    """Validate evidence that describes the roster as a whole, not one member.
+
+    Accepted classes and tiers come from ``roster_contract`` so the prompt cannot
+    promise the model a source class this rejects — the drift that stranded
+    ne-house-02-2026 on a stale roster while its model burned every iteration.
+    """
+    if source.get("type") not in COMPLETENESS_SOURCE_CLASSES:
         return "completeness evidence must be an official roster/ballot, Ballotpedia race page, or retrieved news report"
     parsed_url = urlparse(str(source.get("url") or ""))
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
@@ -516,7 +450,7 @@ def _roster_completeness_source_rejection_reason(
         return "source needs a title and evidence quoting the complete candidate list"
     if not _source_supports_exact_contest(source, race_id=race_id):
         return "evidence does not name this exact contest and district"
-    if source.get("retrieval_status") != "content" or source.get("evidence_tier") not in {1, 2}:
+    if source.get("retrieval_status") != "content" or source.get("evidence_tier") not in COMPLETENESS_TIERS:
         return "completeness evidence must come from retrieved page content, not a search snippet"
 
     text = _roster_source_text(source)
@@ -1165,8 +1099,8 @@ def _make_editing_handlers(
         if proposed_specs is not None:
             if not isinstance(proposed_specs, list) or not proposed_specs:
                 return "ERROR: roster finalization blocked. The proposed candidates list must not be empty."
-            if len(proposed_specs) > 8:
-                return "ERROR: roster finalization blocked. The active roster exceeds the eight-candidate cap."
+            if len(proposed_specs) > ROSTER_CAP:
+                return f"ERROR: roster finalization blocked. The active roster exceeds the {ROSTER_CAP}-candidate cap."
             proposed_names = [str(spec.get("name") or "").strip() for spec in proposed_specs if isinstance(spec, dict)]
             if len(proposed_names) != len(proposed_specs) or any(not name for name in proposed_names):
                 return "ERROR: roster finalization blocked. Every proposed candidate needs a non-empty name."

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -192,6 +192,7 @@ async def _call_openrouter(
     max_retries: int = 3,
     max_tokens: int = 16384,
     run_budget: RunBudget | None = None,
+    temperature: float | None = None,
 ):
     """Call OpenRouter's OpenAI-compatible Chat Completions API with retry.
 
@@ -202,6 +203,10 @@ async def _call_openrouter(
 
     Policy violation errors (400 with "policy" in message) are attempted once
     more with simplified messaging; if still rejected, fail with clear error.
+
+    *temperature* overrides the default for callers that need reproducibility
+    rather than the usual light sampling — the roster adjudicator gates
+    publication, so it asks for 0. Ignored for models that reject the parameter.
 
     Returns an ``openai.types.chat.ChatCompletion`` object.
     """
@@ -217,7 +222,7 @@ async def _call_openrouter(
         "max_tokens": max_tokens,
     }
     if _supports_temperature:
-        kwargs["temperature"] = 0.2
+        kwargs["temperature"] = 0.2 if temperature is None else temperature
     if tools:
         kwargs["tools"] = tools
         kwargs["tool_choice"] = tool_choice or "auto"

--- a/pipeline_client/agent/phases/issues.py
+++ b/pipeline_client/agent/phases/issues.py
@@ -476,21 +476,50 @@ async def run_issues_phase(
                 continue
 
             if issue_attempts.get(unit_id, 0) >= max_issue_attempts:
-                log(
-                    "warning",
-                    f"    Issue retry limit reached for {cand_name}/{issue}; leaving the unit incomplete for explicit retry",
-                )
                 prior_audit = issue_research.get(unit_id)
-                issue_research[unit_id] = {
-                    **(prior_audit if isinstance(prior_audit, dict) else {}),
+                prior_audit = prior_audit if isinstance(prior_audit, dict) else {}
+                searched = int(prior_audit.get("search_calls", 0) or 0) + int(prior_audit.get("page_fetches", 0) or 0)
+                audit = {
+                    **prior_audit,
                     "status": "retry_limit",
                     "attempts": issue_attempts.get(unit_id, 0),
                 }
+                # A unit that actually researched and simply never committed a
+                # verdict has still documented the absence, and leaving the slot
+                # empty made the whole race unpublishable over one issue that no
+                # amount of rerunning would fill. Record the absence with the
+                # research that genuinely happened. Below the evidence bar we
+                # still leave it open rather than assert an unearned finding.
+                if searched >= 2:
+                    candidate = candidates_by_name[cand_name]
+                    candidate.setdefault("issues", {})[issue] = {
+                        "issue": issue,
+                        "stance": "No public position found",
+                        "confidence": "low",
+                        "sources": [],
+                        "research_audit": {**audit, "status": "completed"},
+                    }
+                    issue_research[unit_id] = {**audit, "status": "completed"}
+                    _mark_pipeline_unit_complete(race_json, unit_id)
+                    completed_units.add(unit_id)
+                    log(
+                        "warning",
+                        f"    Issue retry limit reached for {cand_name}/{issue} after {searched} research "
+                        f"action(s); recording a documented no-position result",
+                    )
+                    continue
+
+                log(
+                    "warning",
+                    f"    Issue retry limit reached for {cand_name}/{issue} with only {searched} research "
+                    f"action(s); leaving the unit incomplete rather than asserting an undocumented absence",
+                )
+                issue_research[unit_id] = audit
                 _record_step_failure(
                     race_json,
                     "issues",
                     RunFailureReason.STEP_NO_DATA,
-                    f"{cand_name}/{issue}: retry limit reached without a research verdict",
+                    f"{cand_name}/{issue}: retry limit reached after only {searched} research action(s)",
                 )
                 continue
 

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -136,7 +136,12 @@ async def _run_update(
                     model=roster_model or model,
                     on_log=on_log,
                     race_id=race_id,
-                    max_iterations=min(max_iterations, 12),
+                    # Roster sync spends iterations per candidate: identity, a
+                    # fetch or two, one set_candidate_roster_sources per name,
+                    # then finalize. Twelve ran out mid-roster on a three-way
+                    # race and the run failed having already gathered the
+                    # evidence it needed, so scale the ceiling with the roster.
+                    max_iterations=min(max_iterations, max(12, 8 + 2 * len(candidate_names))),
                     phase_name="roster-sync",
                     max_tokens=8192,
                     extra_tools=ROSTER_TOOLS + [READ_PROFILE_TOOL],

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -10,6 +10,8 @@ Optionally followed by OpenRouter-backed multi-model **review**.
 
 from shared.models import CanonicalIssue
 
+from .roster_contract import render_completeness_rules, render_membership_rules, render_roster_cap_rules
+
 CANONICAL_ISSUES = [e.value for e in CanonicalIssue]
 
 # ------------------------------------------------------------------
@@ -1105,26 +1107,7 @@ STEP 2 — Make corrections using your tools:
    qualification sources, then FEC evidence, then current exact-race
    Ballotpedia/news/campaign evidence.
 
-CRITICAL — add_candidate anti-fabrication rules:
-- add_candidate enforces graded, persisted evidence. Tier 1 is retrieved official
-  election/FEC content. Tier 2 is retrieved dated campaign, exact-election
-  Ballotpedia, or credible news content. Tier 3 is a search result for a blocked
-  page and requires two independent domains unless the result is official/FEC.
-- Every qualifying source must have a stable URL/title, current-cycle publication,
-  filing, or update date, retrieval status, exact race_id, and evidence text that
-  explicitly names the candidate and exact contest. Generic bios, Wikipedia alone,
-  historical tables, vague or undated pages, and wrong-cycle material do not qualify.
-- A Tier 3 snippet must contain enough candidate-and-contest context itself; a bare
-  title or ambiguous snippet does not qualify.
-- Confirm the candidate's PARTY from that same source — never guess the party.
-- Never invent, auto-complete, or infer a candidate's name from ambiguous search
-  snippets, partial matches, or a similarly-named unrelated person. If the
-  official roster failed to load or
-  returned nothing, do NOT reconstruct a roster from generic search results — run
-  additional targeted searches and add only candidates you can confirm by name in
-  a real source.
-- If you cannot confirm a specific candidate actually exists in this race, do not
-  add them. A missing minor-party candidate is far better than a fabricated one.
+@@MEMBERSHIP_EVIDENCE_RULES@@
 
 IMPORTANT — remove_candidate rules:
 - ONLY call remove_candidate when you have a specific, verifiable source showing
@@ -1178,22 +1161,7 @@ write-in candidates who qualified, and convention nominees who may not appear in
 initial profile data.
 
 STEP 2.5 — Keep the roster to ACTIVE, MAJOR candidates (cap the size):
-The authoritative source (Ballotpedia/Wikipedia) may list dozens of declared,
-minor, perennial, or historical candidates. Do NOT add them all. Keep the roster
-to at most 8 candidates, balanced across the major parties where possible (up to
-4 Democratic and 4 Republican), plus a clearly notable third-party nominee.
-- NEVER add a candidate who is not actively running in THIS race for THIS cycle:
-  exclude term-limited or not-seeking-re-election incumbents, FORMER officeholders
-  who already left office and have not filed to run again this cycle (e.g. a
-  retired or previously-defeated U.S. Representative/Senator/Governor), candidates
-  whose candidacy was for a prior election cycle or a past recall,
-  withdrawn/eliminated candidates, and long-shot/perennial filers when the field
-  is already large.
-- Prefer nominees and the most prominent declared candidates (sitting
-  officeholders, well-funded or widely-covered contenders) over minor filers.
-- If the roster already contains the major candidates, do NOT pad it with minor
-  names just because a source lists them. A tight, accurate roster of the real
-  contenders is the goal — not an exhaustive ballot dump.
+@@ROSTER_CAP_RULES@@
 
 STEP 3 — Verify both major parties are represented:
 After completing the roster corrections, check whether the candidate list includes
@@ -1219,18 +1187,28 @@ call finalize_roster once with the entire final `candidates` array,
 `completeness_sources` quoting the full qualified, certified, or official-ballot
 list for this exact contest. This is an atomic replacement: use it to apply all
 remaining additions and removals in one response instead of spending one turn
-per candidate. Candidate-specific
-sources prove that listed people belong; they do not prove nobody was omitted.
-Completeness evidence must come from a page you actually FETCHED this run — a
-search snippet is rejected. An official ballot/qualified list, the Ballotpedia
-page for this exact race, or a news report enumerating the full field all
-qualify; a state election-authority landing page that never names this district
-does not. When nothing else lists the full field, fetch the Ballotpedia race page.
-For a special election, the completeness evidence must explicitly identify the
-special contest and its verified date. The tool will reject incomplete or weakly
-sourced rosters and tell you exactly which evidence remains to fix. You may stop only after
+per candidate.
+
+@@COMPLETENESS_EVIDENCE_RULES@@
+
+The tool will reject incomplete or weakly sourced rosters and tell you exactly
+which evidence remains to fix. You may stop only after
 finalize_roster succeeds. Do NOT produce any text reply or JSON.
 Do NOT modify any other data (issues, summaries, polls, etc.)."""
+
+# The roster-evidence rules are rendered from roster_contract, which is also what
+# handlers validates against — so the prompt cannot promise the model something
+# the tool rejects. Substituted with @@TOKEN@@ rather than str.format so the
+# runtime {race_id}/{current_date} placeholders survive for the caller.
+for _token, _rendered in (
+    ("@@MEMBERSHIP_EVIDENCE_RULES@@", render_membership_rules()),
+    ("@@COMPLETENESS_EVIDENCE_RULES@@", render_completeness_rules()),
+    ("@@ROSTER_CAP_RULES@@", render_roster_cap_rules()),
+):
+    if _token not in ROSTER_SYNC_USER:  # pragma: no cover - guards against silent drift
+        raise RuntimeError(f"ROSTER_SYNC_USER is missing the {_token} slot")
+    ROSTER_SYNC_USER = ROSTER_SYNC_USER.replace(_token, _rendered)
+del _token, _rendered
 
 ROSTER_VERIFY_SYSTEM = f"""\
 You are a nonpartisan political fact-checker. Your ONLY task is to audit the

--- a/pipeline_client/agent/roster_adjudicator.py
+++ b/pipeline_client/agent/roster_adjudicator.py
@@ -1,0 +1,302 @@
+"""Reading-comprehension judgments about roster evidence, made by a model.
+
+Whether a retrieved page actually *says* what a citation claims — that it names
+this exact contest, that it enumerates a field without a given candidate, that a
+stated removal reason describes a real withdrawal — is reading comprehension.
+The regexes that used to answer these questions graded English prose, and the
+commit history of ``handlers`` is a record of them oscillating: each fix either
+rejected correctly-reasoned edits whose wording differed, or opened a hole.
+
+This module answers those questions with a cheap model instead. Three properties
+make that sound rather than circular:
+
+1. **Structural gates run first.** ``roster_contract`` decides class, tier, URL
+   validity, and corroboration before anything reaches a model. The adjudicator
+   never sees a source that already failed a cheap deterministic check.
+2. **It is a different model on a bounded question.** The research model produced
+   the evidence and has momentum toward its own conclusion. The adjudicator is
+   shown only the evidence text and the claim, with no context about what the
+   caller wants the answer to be.
+3. **Its verdict is recorded.** The reason is persisted onto the source and
+   returned verbatim to the calling agent, so a rejection is inspectable after
+   the fact instead of being a flaky gate nobody can debug.
+
+Determinism: pinned model, temperature 0, and an in-process cache keyed by
+``(claim, url, evidence)``. Provider-side drift is still possible, which is why
+:data:`ADJUDICATOR_MODEL` is pinned to an explicit version rather than a floating
+alias — a silent upgrade would move a publish gate with no commit to point at.
+
+Note the model choice is deliberate: the nano tier is cheaper, but OpenRouter
+rejects a ``temperature`` parameter for it, so a nano adjudicator could not be
+pinned to 0 and its run-to-run variance would land directly on a publish gate.
+The mini tier costs slightly more per call and there are only a handful of calls
+per run, which is the right trade for a gate.
+
+Availability: this gate **fails closed**. If the provider is unreachable, out of
+quota, or returns something unparseable, the claim is rejected with a reason
+saying so. An unavailable judge must not become an open door to the roster.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping
+
+logger = logging.getLogger("pipeline")
+
+#: Pinned deliberately. This model sits in front of publication; a floating
+#: alias would let a provider-side upgrade change the gate with no commit.
+#: Must be a tier that accepts ``temperature`` — see the module docstring.
+ADJUDICATOR_MODEL = "openai/gpt-5.4-mini"
+
+ADJUDICATOR_TEMPERATURE = 0.0
+ADJUDICATOR_MAX_TOKENS = 400
+ADJUDICATOR_TIMEOUT_SECONDS = 30.0
+
+
+class Claim:
+    """The bounded questions the adjudicator is allowed to be asked."""
+
+    #: This source establishes the candidate is running in this exact contest.
+    MEMBERSHIP = "membership"
+    #: This source enumerates the field for this contest and omits the candidate.
+    OMISSION = "omission"
+    #: This source shows the candidate belongs to a different contest.
+    WRONG_CONTEST = "wrong_contest"
+    #: This source is a complete listing of the field for this contest.
+    COMPLETENESS = "completeness"
+    #: This free-text reason describes an actual exit from the race.
+    WITHDRAWAL = "withdrawal"
+
+
+_CLAIM_QUESTIONS: Dict[str, str] = {
+    Claim.MEMBERSHIP: (
+        "Does this source establish that {subject} is a candidate in {contest}? "
+        "It must name the person and identify that exact office, district, and election cycle. "
+        "A source about a different office, a different district with the same number, or a "
+        "prior cycle does NOT establish it. "
+        "Tabular sources carry their office in a section heading or column rather than in each "
+        "row: a row reading 'District 2 | Jane Roe' under a heading such as 'CONGRESSIONAL "
+        "DISTRICTS' does identify a U.S. House contest, and a filing date or document title "
+        "supplies the cycle. Read the whole evidence string together — do not require every "
+        "element to appear in one sentence."
+    ),
+    Claim.OMISSION: (
+        "Does this source enumerate the field of candidates for {contest} while NOT including "
+        "{subject}? Answer true only if the text actually lists multiple candidates for this "
+        "contest, so that the absence is meaningful. A page that is blocked, empty, truncated, "
+        "or that lists candidates for some other contest does NOT establish an omission."
+    ),
+    Claim.WRONG_CONTEST: (
+        "Does this source show that {subject} is running for an office OTHER than {contest}? "
+        "It must name the person and identify the different office or district they are actually "
+        "seeking in the current cycle."
+    ),
+    Claim.COMPLETENESS: (
+        "Is this source presenting the FIELD of candidates for {contest} — a listing meant to be "
+        "the whole set, rather than a passing mention of one or two people? "
+        "Answer true if it presents itself as a qualified, certified, or official ballot list, OR "
+        "if it enumerates the candidates for this exact contest in the form of a field listing "
+        "(for example 'the candidates in the general election for X are A and B'). Do not require "
+        "the words 'certified', 'complete', or 'official' — a state's own certified list and a "
+        "reference page's standard full-field sentence both qualify, and a two-candidate general "
+        "election legitimately has only two candidates. "
+        "Answer false if it is a page about a single candidate, an evidently partial or truncated "
+        "list, a blocked or empty page, a list for a different contest, or a landing page that "
+        "never names this specific contest."
+    ),
+    Claim.WITHDRAWAL: (
+        "Does this stated reason describe {subject} actually LEAVING or never entering {contest} "
+        "— withdrawing, dropping out, being disqualified, losing a completed primary or "
+        "convention, or being a former officeholder who is not a candidate this cycle? Answer "
+        "false if it merely describes a data-quality problem, a biography error, or absence from "
+        "some page."
+    ),
+}
+
+_SYSTEM = """\
+You are a strict evidence adjudicator for an election data pipeline. You are \
+shown one piece of evidence and one yes/no question about what it establishes.
+
+Judge ONLY what the evidence text actually says. Do not use outside knowledge \
+about the race, the candidate, or who is likely running. If the text is empty, \
+truncated, blocked, off-topic, or does not address the question, the answer is \
+false.
+
+Do not be generous. A wrong "true" puts fabricated data in front of voters. But \
+do not demand specific phrasing either: real election authorities word things \
+inconsistently, and an official certified list that happens not to use the word \
+"certified" is still a certified list. Judge substance, not wording.
+
+Reply with JSON only: {"supports": true|false, "reason": "<one sentence>"}
+The reason is shown verbatim to the agent that supplied the evidence, so make it \
+say precisely what was missing or wrong."""
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """One adjudication result. ``supports`` is the gate; ``reason`` is the audit trail."""
+
+    supports: bool
+    reason: str
+    model: str = ADJUDICATOR_MODEL
+    #: True when this verdict came from a failure path rather than a real judgment.
+    unavailable: bool = False
+
+    def to_record(self) -> Dict[str, Any]:
+        """Shape persisted onto the source object so a decision survives the run."""
+        record = {"supports": self.supports, "reason": self.reason, "model": self.model}
+        if self.unavailable:
+            record["unavailable"] = True
+        return record
+
+
+def _unavailable(detail: str) -> Verdict:
+    """Fail closed. An unreachable judge must not become an open door."""
+    return Verdict(
+        supports=False,
+        reason=f"evidence could not be adjudicated ({detail}); the roster gate fails closed",
+        unavailable=True,
+    )
+
+
+def _cache_key(claim: str, subject: str, contest: str, evidence: str) -> tuple:
+    return (claim, subject.casefold(), contest.casefold(), evidence.strip().casefold())
+
+
+#: Process-local memo so a retried tool call does not re-pay for the same judgment.
+_VERDICT_CACHE: Dict[tuple, Verdict] = {}
+
+
+def clear_cache() -> None:
+    """Drop memoized verdicts. Used by tests; harmless in production."""
+    _VERDICT_CACHE.clear()
+
+
+def _build_user_prompt(*, claim: str, subject: str, contest: str, source: Mapping[str, Any]) -> str:
+    question = _CLAIM_QUESTIONS[claim].format(subject=subject or "this candidate", contest=contest)
+    parts = [f"QUESTION: {question}", ""]
+    title = str(source.get("title") or "").strip()
+    url = str(source.get("url") or "").strip()
+    published = str(source.get("published_at") or "").strip()
+    evidence = str(source.get("evidence") or source.get("text") or "").strip()
+    if title:
+        parts.append(f"SOURCE TITLE: {title}")
+    if url:
+        parts.append(f"SOURCE URL: {url}")
+    if published:
+        parts.append(f"PUBLISHED: {published}")
+    parts.append("")
+    parts.append("EVIDENCE TEXT:")
+    parts.append(evidence or "(no evidence text was supplied)")
+    return "\n".join(parts)
+
+
+def _parse_verdict(content: str) -> Verdict | None:
+    """Parse the model's JSON reply, tolerating code fences and surrounding prose."""
+    text = (content or "").strip()
+    if not text:
+        return None
+    if "```" in text:
+        chunks = [chunk for chunk in text.split("```") if "{" in chunk]
+        text = chunks[0] if chunks else text
+        if text.lstrip().startswith("json"):
+            text = text.lstrip()[4:]
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    try:
+        payload = json.loads(text[start : end + 1])
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict) or "supports" not in payload:
+        return None
+    reason = str(payload.get("reason") or "").strip() or "no reason given"
+    return Verdict(supports=bool(payload["supports"]), reason=reason)
+
+
+async def adjudicate(
+    *,
+    claim: str,
+    subject: str,
+    contest: str,
+    source: Mapping[str, Any],
+    run_budget: Any = None,
+) -> Verdict:
+    """Judge one bounded question about one piece of evidence.
+
+    Never raises: every failure path returns a fail-closed verdict, because a
+    guard that throws inside a tool handler turns a rejected edit into a crashed
+    phase.
+    """
+    if claim not in _CLAIM_QUESTIONS:
+        return _unavailable(f"unknown claim {claim!r}")
+
+    evidence = str(source.get("evidence") or source.get("text") or "")
+    key = _cache_key(claim, subject, contest, evidence + str(source.get("url") or ""))
+    cached = _VERDICT_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    try:
+        from .llm import _call_openrouter
+
+        response = await asyncio.wait_for(
+            _call_openrouter(
+                [
+                    {"role": "system", "content": _SYSTEM},
+                    {
+                        "role": "user",
+                        "content": _build_user_prompt(claim=claim, subject=subject, contest=contest, source=source),
+                    },
+                ],
+                model=ADJUDICATOR_MODEL,
+                max_tokens=ADJUDICATOR_MAX_TOKENS,
+                temperature=ADJUDICATOR_TEMPERATURE,
+                run_budget=run_budget,
+            ),
+            timeout=ADJUDICATOR_TIMEOUT_SECONDS,
+        )
+        content = response.choices[0].message.content or ""
+    except asyncio.TimeoutError:
+        logger.warning("Roster adjudicator timed out for claim=%s subject=%s", claim, subject)
+        return _unavailable("adjudicator timed out")
+    except Exception as exc:  # provider down, quota exhausted, auth failure
+        logger.warning("Roster adjudicator unavailable for claim=%s: %s", claim, exc)
+        return _unavailable(f"{type(exc).__name__}")
+
+    verdict = _parse_verdict(content)
+    if verdict is None:
+        logger.warning("Roster adjudicator returned unparseable content for claim=%s", claim)
+        return _unavailable("adjudicator returned an unparseable verdict")
+
+    _VERDICT_CACHE[key] = verdict
+    return verdict
+
+
+async def adjudicate_sources(
+    *,
+    claim: str,
+    subject: str,
+    contest: str,
+    sources: Iterable[Mapping[str, Any]],
+    run_budget: Any = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Adjudicate several sources concurrently, keyed by URL for handler lookup.
+
+    Returns ``{url: verdict_record}``. Sources without a URL are skipped: the
+    handler's structural gate rejects them before a verdict would matter.
+    """
+    targets = [source for source in sources if str(source.get("url") or "").strip()]
+    if not targets:
+        return {}
+    verdicts = await asyncio.gather(
+        *(
+            adjudicate(claim=claim, subject=subject, contest=contest, source=source, run_budget=run_budget)
+            for source in targets
+        )
+    )
+    return {str(source["url"]).strip(): verdict.to_record() for source, verdict in zip(targets, verdicts)}

--- a/pipeline_client/agent/roster_contract.py
+++ b/pipeline_client/agent/roster_contract.py
@@ -1,0 +1,319 @@
+"""Single source of truth for the roster-evidence contract.
+
+The rules about what evidence may add a candidate to a roster, and what evidence
+proves a roster is *complete*, were previously written down twice: as prose in
+``prompts.ROSTER_SYNC_USER`` for the model to read, and as predicates in
+``handlers`` to enforce. Nothing kept the two in sync, so they drifted — the
+prompt would tell a model that a Ballotpedia race page was acceptable
+completeness evidence while the handler rejected it, and the model would burn
+its entire iteration budget unable to reconcile the instruction with the error.
+
+Both now derive from the definitions here: ``handlers`` imports the data and
+validates against it, and ``prompts`` embeds :func:`render_membership_rules` and
+:func:`render_completeness_rules` rather than restating them. Changing a rule in
+one place is no longer possible.
+
+This module is deliberately free of judgment calls. It encodes *structural*
+facts about a source object — its class, whether its content was retrieved or
+merely snippeted, how many independent domains back it. Whether the retrieved
+text actually says what it is claimed to say is reading comprehension and is
+adjudicated elsewhere.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, Iterable
+from urllib.parse import urlparse
+
+from .roster import ROSTER_CAP
+
+# ---------------------------------------------------------------------------
+# Source classes
+# ---------------------------------------------------------------------------
+
+#: Every class a roster source may be filed under. ``other`` is a parking slot
+#: for input that could not be classified and never satisfies the contract.
+SOURCE_CLASSES: FrozenSet[str] = frozenset({"official", "ballotpedia", "fec", "news", "campaign", "other"})
+
+#: Classes that can actually carry roster evidence.
+QUALIFYING_SOURCE_CLASSES: FrozenSet[str] = SOURCE_CLASSES - {"other"}
+
+#: Classes whose authority waives the tier-3 two-domain corroboration rule.
+AUTHORITATIVE_SOURCE_CLASSES: FrozenSet[str] = frozenset({"official", "fec"})
+
+#: Free-form labels models emit for roster evidence, mapped onto the classes
+#: above. Mirrors ``source_types.SOURCE_TYPE_ALIASES``, which exists for the same
+#: reason: models reliably invent plausible synonyms for enum values.
+SOURCE_CLASS_ALIASES: Dict[str, str] = {
+    "article": "news",
+    "ballot": "official",
+    "certified ballot": "official",
+    "election authority": "official",
+    "election official": "official",
+    "election results": "official",
+    "filing": "official",
+    "government": "official",
+    "gov": "official",
+    "media": "news",
+    "news article": "news",
+    "newspaper": "news",
+    "party": "official",
+    "party list": "official",
+    "press": "news",
+    "qualified candidates": "official",
+    "secretary of state": "official",
+    "sos": "official",
+    "state": "official",
+    "state election authority": "official",
+    "campaign site": "campaign",
+    "campaign website": "campaign",
+    "candidate site": "campaign",
+    "candidate website": "campaign",
+    "official campaign": "campaign",
+    "fec filing": "fec",
+    "federal election commission": "fec",
+    "encyclopedia": "ballotpedia",
+    "wiki": "ballotpedia",
+    "wikipedia": "ballotpedia",
+}
+
+#: Election-stage values ``set_race_identity`` and ``update_race_field`` accept.
+CONTEST_STAGES: FrozenSet[str] = frozenset(
+    {
+        "pre_primary",
+        "post_primary_general",
+        "runoff",
+        "top_two",
+        "top_four_rcv",
+        "uncontested",
+        "special",
+        "unknown",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Evidence tiers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvidenceTier:
+    """One grade of roster evidence.
+
+    ``retrieval_status`` distinguishes a page whose content the agent actually
+    fetched from a search-result snippet it merely saw. That distinction is
+    provenance, not a model claim — the agent loop injects its real fetch trace
+    into editing calls, so a fabricated citation cannot self-report as retrieved.
+    """
+
+    tier: int
+    retrieval_status: str
+    source_classes: FrozenSet[str]
+    summary: str
+    rejection_reason: str
+
+
+MEMBERSHIP_TIERS: tuple[EvidenceTier, ...] = (
+    EvidenceTier(
+        tier=1,
+        retrieval_status="content",
+        source_classes=AUTHORITATIVE_SOURCE_CLASSES,
+        summary="retrieved official election-authority or FEC page content",
+        rejection_reason="tier 1 requires retrieved page content from an official or FEC source",
+    ),
+    EvidenceTier(
+        tier=2,
+        retrieval_status="content",
+        source_classes=frozenset({"campaign", "ballotpedia", "news"}),
+        summary="retrieved dated campaign, exact-election Ballotpedia, or credible news page content",
+        rejection_reason="tier 2 requires retrieved page content from a campaign, Ballotpedia, or news source",
+    ),
+    EvidenceTier(
+        tier=3,
+        retrieval_status="snippet",
+        source_classes=QUALIFYING_SOURCE_CLASSES,
+        summary=(
+            "a search-result snippet for a page that could not be retrieved; requires two independent "
+            "domains unless the source is official or FEC"
+        ),
+        rejection_reason="tier 3 requires a search-result snippet from a qualifying source",
+    ),
+)
+
+#: Tiers that prove a roster listing is *complete*. A snippet cannot: partial
+#: text from a list page is indistinguishable from a truncated one.
+COMPLETENESS_TIERS: FrozenSet[int] = frozenset({1, 2})
+
+#: Classes that may carry completeness evidence. Ballotpedia belongs here
+#: because its per-race election pages publish the full qualified field, and
+#: RaceJSON treats ``ballotpedia_url`` as the canonical roster pointer.
+COMPLETENESS_SOURCE_CLASSES: FrozenSet[str] = frozenset({"official", "news", "ballotpedia"})
+
+#: Classes that can enumerate a field of candidates, and so can support an
+#: argument from a candidate's *absence* from a listing. A campaign site is
+#: excluded: it speaks for one candidate and never enumerates opponents.
+ROSTER_LISTING_SOURCE_CLASSES: FrozenSet[str] = QUALIFYING_SOURCE_CLASSES - {"campaign"}
+
+#: Minimum distinct domains behind a candidate addition backed only by tier-3
+#: snippets from non-authoritative sources.
+TIER3_CORROBORATING_DOMAINS = 2
+
+#: How many years around the race year count as current-cycle publication.
+CYCLE_LOOKBACK_YEARS = 2
+
+
+def tier_for(tier: Any) -> EvidenceTier | None:
+    """Return the tier definition for a numeric grade, or None if unrecognized."""
+    for candidate in MEMBERSHIP_TIERS:
+        if candidate.tier == tier:
+            return candidate
+    return None
+
+
+def tier_rejection_reason(source: Dict[str, Any]) -> str | None:
+    """Return why a source's tier/retrieval grade is invalid, or None if valid.
+
+    Structural only: this checks that the claimed grade is internally consistent
+    with the source's class and retrieval status. It says nothing about whether
+    the evidence text supports the claim being made.
+    """
+    tier = source.get("evidence_tier")
+    status = source.get("retrieval_status")
+    definition = tier_for(tier)
+    if definition is None:
+        return f"evidence_tier {tier!r}/retrieval_status {status!r} is not a recognized evidence grade"
+    if status != definition.retrieval_status or source.get("type") not in definition.source_classes:
+        return definition.rejection_reason
+    return None
+
+
+def lacks_tier3_corroboration(sources: Iterable[Dict[str, Any]]) -> bool:
+    """True when an addition rests only on uncorroborated non-authoritative snippets.
+
+    An addition backed entirely by tier-3 snippets needs either an authoritative
+    source or two independent domains. Attaching evidence to a candidate already
+    on the roster is a different operation and does not need this.
+    """
+    qualifying = list(sources)
+    if not qualifying or not all(source.get("evidence_tier") == 3 for source in qualifying):
+        return False
+    if any(source.get("type") in AUTHORITATIVE_SOURCE_CLASSES for source in qualifying):
+        return False
+    domains = {urlparse(str(source.get("url"))).netloc.lower() for source in qualifying}
+    return len(domains) < TIER3_CORROBORATING_DOMAINS
+
+
+def classify_source_class(raw_type: Any, *, title: str | None, url: str | None, host: str) -> str:
+    """Map a free-form roster source label onto a known source class.
+
+    Host evidence is checked first, then the model's label via the recognized set
+    and :data:`SOURCE_CLASS_ALIASES`. Classification never depends on the label
+    being well-formed: a plausible synonym such as ``"web"`` or
+    ``"election_authority"`` used to be parked in ``"other"``, which can never
+    satisfy the contract, so valid Ballotpedia and official sources were rejected
+    on a spelling technicality.
+    """
+    title_and_url = f"{title or ''} {url or ''}".casefold()
+
+    # Host evidence outranks the model's label. The authoritative classes waive
+    # the tier-3 corroboration rule, so they must be earned by the host (or a
+    # party qualified-candidate list title) rather than self-declared —
+    # otherwise any page could be relabelled to bypass that guard.
+    host_class: str | None = None
+    if host == "ballotpedia.org" or host.endswith(".ballotpedia.org"):
+        host_class = "ballotpedia"
+    elif host == "fec.gov" or host.endswith(".fec.gov"):
+        host_class = "fec"
+    elif host.endswith(".gov") or re.search(r"\bqualified\b.*\bcandidates?\b", title_and_url):
+        host_class = "official"
+    if host_class:
+        return host_class
+
+    label = str(raw_type or "").strip().lower().replace("_", " ").replace("-", " ")
+    label = re.sub(r"\s+", " ", label)
+    claimed = label if label in SOURCE_CLASSES and label != "other" else SOURCE_CLASS_ALIASES.get(label)
+    if claimed in AUTHORITATIVE_SOURCE_CLASSES:
+        # Unverifiable authority claim: keep the source usable but strip the waiver.
+        return "news"
+    if claimed:
+        return claimed
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+
+def _class_list(classes: Iterable[str]) -> str:
+    return ", ".join(sorted(classes))
+
+
+def render_membership_rules() -> str:
+    """Render the evidence contract for adding a candidate to the roster."""
+    tiers = "\n".join(f"  Tier {tier.tier}: {tier.summary}." for tier in MEMBERSHIP_TIERS)
+    return f"""\
+CRITICAL — add_candidate evidence contract (enforced by the tool, not advisory):
+- Evidence is graded. The tool accepts these grades and no others:
+{tiers}
+- Qualifying source classes: {_class_list(QUALIFYING_SOURCE_CLASSES)}. Anything
+  that cannot be classified is filed as "other" and never qualifies on its own.
+- Every qualifying source needs all of: a stable http(s) URL, a title, evidence
+  text naming the candidate and this exact contest, this race's race_id, and a
+  publication/filing date within {CYCLE_LOOKBACK_YEARS} years of the race year.
+- A tier-3 snippet must carry enough candidate-and-contest context by itself. A
+  bare title or ambiguous fragment does not qualify.
+- Generic bios, historical tables, undated pages, and wrong-cycle material never
+  qualify at any tier.
+- Confirm the candidate's PARTY from that same source — never guess the party.
+- Never invent, auto-complete, or infer a name from an ambiguous snippet, a
+  partial match, or a similarly-named unrelated person. If the official roster
+  failed to load, run more targeted searches rather than reconstructing a roster
+  from generic results.
+- If you cannot confirm a candidate exists in this race, do not add them. A
+  missing minor-party candidate is far better than a fabricated one."""
+
+
+def render_completeness_rules() -> str:
+    """Render the evidence contract for proving a roster is complete."""
+    tier_labels = ", ".join(f"tier {tier}" for tier in sorted(COMPLETENESS_TIERS))
+    return f"""\
+Candidate-specific sources prove that the people listed belong; they do not
+prove nobody was omitted. finalize_roster therefore requires separate
+completeness_sources, graded {tier_labels} — meaning content you actually
+FETCHED this run. A search snippet is rejected, because partial text from a list
+page cannot be distinguished from a truncated one.
+- Accepted classes: {_class_list(COMPLETENESS_SOURCE_CLASSES)}.
+- The source must either name every candidate on your proposed roster, or
+  identify itself as a qualified, certified, official-ballot, or otherwise
+  complete candidate list.
+- It must name this exact contest and district. A state election-authority
+  landing page that never names this district does not qualify.
+- For a special election, it must explicitly identify the special contest and
+  its verified date.
+- When nothing else lists the full field, fetch the Ballotpedia race page."""
+
+
+def render_roster_cap_rules() -> str:
+    """Render the roster size cap, sourced from the same constant that enforces it."""
+    per_major_party = ROSTER_CAP // 2
+    return f"""\
+Keep the roster to ACTIVE, MAJOR candidates. The authoritative source may list
+dozens of declared, minor, perennial, or historical candidates — do NOT add them
+all. Cap the roster at {ROSTER_CAP} candidates, balanced across the major parties
+where possible (up to {per_major_party} Democratic and {per_major_party}
+Republican), plus a clearly notable third-party nominee.
+- NEVER add a candidate who is not actively running in THIS race for THIS cycle:
+  exclude term-limited or not-seeking-re-election incumbents, FORMER
+  officeholders who already left office and have not filed again this cycle,
+  candidates whose candidacy was for a prior cycle or a past recall,
+  withdrawn/eliminated candidates, and long-shot/perennial filers when the field
+  is already large.
+- Prefer nominees and the most prominent declared candidates (sitting
+  officeholders, well-funded or widely-covered contenders) over minor filers.
+- If the roster already contains the major candidates, do NOT pad it with minor
+  names just because a source lists them. A tight, accurate roster of the real
+  contenders is the goal — not an exhaustive ballot dump."""

--- a/scripts/fixtures/roster_evidence/ne-house-02.json
+++ b/scripts/fixtures/roster_evidence/ne-house-02.json
@@ -1,0 +1,331 @@
+{
+  "description": "Nebraska SoS certified filing list (.xlsx) \u2014 payloads captured from run cdf66c76",
+  "cases": [
+    {
+      "name": "bare-year published_at on official spreadsheet row",
+      "tool": "set_candidate_roster_sources",
+      "expect_accepted": true,
+      "race_json": {
+        "id": "ne-house-02-2026",
+        "state": "Nebraska",
+        "office": "U.S. House",
+        "district": "2",
+        "pipeline_state": {
+          "race_identity": {
+            "office": "U.S. House",
+            "state": "Nebraska",
+            "district": "2",
+            "contest_stage": "post_primary_general",
+            "official_roster_source_url": "https://sos.nebraska.gov/elections"
+          }
+        },
+        "candidates": [
+          {
+            "name": "Denise Powell",
+            "party": "Democratic"
+          },
+          {
+            "name": "Brinker Harding",
+            "party": "Republican"
+          },
+          {
+            "name": "Eric Michael Foreman",
+            "party": "Libertarian"
+          }
+        ]
+      },
+      "args": {
+        "candidate_name": "Brinker Harding",
+        "sources": [
+          {
+            "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+            "title": "Statewide Candidate Filing List",
+            "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Republican | Brinker Harding | Omaha | Nonincumbent | PO Box 540007 Omaha NE 68154 | (402) 214-4448 brinker@brinkerharding.com",
+            "retrieved": "2026-08-02",
+            "published_at": "2026"
+          }
+        ]
+      }
+    },
+    {
+      "name": "same row, ISO published_at",
+      "tool": "set_candidate_roster_sources",
+      "expect_accepted": true,
+      "race_json": {
+        "id": "ne-house-02-2026",
+        "state": "Nebraska",
+        "office": "U.S. House",
+        "district": "2",
+        "pipeline_state": {
+          "race_identity": {
+            "office": "U.S. House",
+            "state": "Nebraska",
+            "district": "2",
+            "contest_stage": "post_primary_general",
+            "official_roster_source_url": "https://sos.nebraska.gov/elections"
+          }
+        },
+        "candidates": [
+          {
+            "name": "Denise Powell",
+            "party": "Democratic"
+          },
+          {
+            "name": "Brinker Harding",
+            "party": "Republican"
+          },
+          {
+            "name": "Eric Michael Foreman",
+            "party": "Libertarian"
+          }
+        ]
+      },
+      "args": {
+        "candidate_name": "Denise Powell",
+        "sources": [
+          {
+            "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+            "title": "Statewide Candidate Filing List",
+            "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Democratic | Denise Powell | Omaha | Nonincumbent | PO Box 6039 Omaha NE 68106 | (402) 214-4997 denise@deniseforcongress.org",
+            "retrieved": "2026-08-02",
+            "published_at": "2026-04-02"
+          }
+        ]
+      }
+    },
+    {
+      "name": "prior-cycle year must still be rejected",
+      "tool": "set_candidate_roster_sources",
+      "expect_accepted": false,
+      "race_json": {
+        "id": "ne-house-02-2026",
+        "state": "Nebraska",
+        "office": "U.S. House",
+        "district": "2",
+        "pipeline_state": {
+          "race_identity": {
+            "office": "U.S. House",
+            "state": "Nebraska",
+            "district": "2",
+            "contest_stage": "post_primary_general",
+            "official_roster_source_url": "https://sos.nebraska.gov/elections"
+          }
+        },
+        "candidates": [
+          {
+            "name": "Denise Powell",
+            "party": "Democratic"
+          },
+          {
+            "name": "Brinker Harding",
+            "party": "Republican"
+          },
+          {
+            "name": "Eric Michael Foreman",
+            "party": "Libertarian"
+          }
+        ]
+      },
+      "args": {
+        "candidate_name": "Denise Powell",
+        "sources": [
+          {
+            "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+            "title": "Statewide Candidate Filing List",
+            "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Democratic | Denise Powell | Omaha | Nonincumbent | PO Box 6039 Omaha NE 68106 | (402) 214-4997 denise@deniseforcongress.org",
+            "retrieved": "2026-08-02",
+            "published_at": "2018"
+          }
+        ]
+      }
+    },
+    {
+      "name": "finalize_roster with certified list covering the field",
+      "tool": "finalize_roster",
+      "expect_accepted": true,
+      "race_json": {
+        "id": "ne-house-02-2026",
+        "state": "Nebraska",
+        "office": "U.S. House",
+        "district": "2",
+        "pipeline_state": {
+          "race_identity": {
+            "office": "U.S. House",
+            "state": "Nebraska",
+            "district": "2",
+            "contest_stage": "post_primary_general",
+            "official_roster_source_url": "https://sos.nebraska.gov/elections"
+          }
+        },
+        "candidates": [
+          {
+            "name": "Denise Powell",
+            "party": "Democratic"
+          },
+          {
+            "name": "Brinker Harding",
+            "party": "Republican"
+          },
+          {
+            "name": "Eric Michael Foreman",
+            "party": "Libertarian"
+          }
+        ]
+      },
+      "args": {
+        "summary": "Nebraska SoS certified filing list shows three District 02 candidates: Denise Powell (D), Brinker Harding (R), Eric Michael Foreman (L).",
+        "source_candidate_names": [
+          "Denise Powell",
+          "Brinker Harding",
+          "Eric Michael Foreman"
+        ],
+        "completeness_sources": [
+          {
+            "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+            "title": "Statewide Candidate Filing List",
+            "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Republican | Brinker Harding | Omaha | Nonincumbent | PO Box 540007 Omaha NE 68154 | (402) 214-4448 brinker@brinkerharding.com\nFor Representative in Congress | District 02 | 2 | 1 | Democratic | Denise Powell | Omaha | Nonincumbent | PO Box 6039 Omaha NE 68106 | (402) 214-4997 denise@deniseforcongress.org\nFor Representative in Congress | District 02 | 2 | 1 | Libertarian | Eric Michael Foreman | Omaha | Nonincumbent | | (402) 216-9627",
+            "retrieved": "2026-08-02",
+            "published_at": "2026",
+            "evidence_tier": 1,
+            "retrieval_status": "content"
+          }
+        ],
+        "candidates": [
+          {
+            "name": "Denise Powell",
+            "party": "Democratic",
+            "roster_sources": [
+              {
+                "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+                "title": "Statewide Candidate Filing List",
+                "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Democratic | Denise Powell | Omaha | Nonincumbent | PO Box 6039 Omaha NE 68106 | (402) 214-4997 denise@deniseforcongress.org",
+                "retrieved": "2026-08-02",
+                "published_at": "2026"
+              }
+            ]
+          },
+          {
+            "name": "Brinker Harding",
+            "party": "Republican",
+            "roster_sources": [
+              {
+                "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+                "title": "Statewide Candidate Filing List",
+                "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Republican | Brinker Harding | Omaha | Nonincumbent | PO Box 540007 Omaha NE 68154 | (402) 214-4448 brinker@brinkerharding.com",
+                "retrieved": "2026-08-02",
+                "published_at": "2026"
+              }
+            ]
+          },
+          {
+            "name": "Eric Michael Foreman",
+            "party": "Libertarian",
+            "roster_sources": [
+              {
+                "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+                "title": "Statewide Candidate Filing List",
+                "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Libertarian | Eric Michael Foreman | Omaha | Nonincumbent | | (402) 216-9627",
+                "retrieved": "2026-08-02",
+                "published_at": "2026"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "finalize_roster rejected when evidence omits a proposed candidate",
+      "tool": "finalize_roster",
+      "expect_accepted": false,
+      "race_json": {
+        "id": "ne-house-02-2026",
+        "state": "Nebraska",
+        "office": "U.S. House",
+        "district": "2",
+        "pipeline_state": {
+          "race_identity": {
+            "office": "U.S. House",
+            "state": "Nebraska",
+            "district": "2",
+            "contest_stage": "post_primary_general",
+            "official_roster_source_url": "https://sos.nebraska.gov/elections"
+          }
+        },
+        "candidates": [
+          {
+            "name": "Denise Powell",
+            "party": "Democratic"
+          },
+          {
+            "name": "Brinker Harding",
+            "party": "Republican"
+          },
+          {
+            "name": "Eric Michael Foreman",
+            "party": "Libertarian"
+          }
+        ]
+      },
+      "args": {
+        "summary": "Partial list.",
+        "source_candidate_names": [
+          "Denise Powell",
+          "Brinker Harding",
+          "Eric Michael Foreman"
+        ],
+        "completeness_sources": [
+          {
+            "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+            "title": "Statewide Candidate Filing List",
+            "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Democratic | Denise Powell | Omaha | Nonincumbent | PO Box 6039 Omaha NE 68106 | (402) 214-4997 denise@deniseforcongress.org",
+            "retrieved": "2026-08-02",
+            "published_at": "2026",
+            "evidence_tier": 1,
+            "retrieval_status": "content"
+          }
+        ],
+        "candidates": [
+          {
+            "name": "Denise Powell",
+            "party": "Democratic",
+            "roster_sources": [
+              {
+                "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+                "title": "Statewide Candidate Filing List",
+                "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Democratic | Denise Powell | Omaha | Nonincumbent | PO Box 6039 Omaha NE 68106 | (402) 214-4997 denise@deniseforcongress.org",
+                "retrieved": "2026-08-02",
+                "published_at": "2026"
+              }
+            ]
+          },
+          {
+            "name": "Brinker Harding",
+            "party": "Republican",
+            "roster_sources": [
+              {
+                "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+                "title": "Statewide Candidate Filing List",
+                "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Republican | Brinker Harding | Omaha | Nonincumbent | PO Box 540007 Omaha NE 68154 | (402) 214-4448 brinker@brinkerharding.com",
+                "retrieved": "2026-08-02",
+                "published_at": "2026"
+              }
+            ]
+          },
+          {
+            "name": "Eric Michael Foreman",
+            "party": "Libertarian",
+            "roster_sources": [
+              {
+                "url": "https://sos.nebraska.gov/sites/default/files/doc/elections/2026/Statewide_Candidate_Filing_List.xlsx",
+                "title": "Statewide Candidate Filing List",
+                "evidence_text": "For Representative in Congress | District 02 | 2 | 1 | Libertarian | Eric Michael Foreman | Omaha | Nonincumbent | | (402) 216-9627",
+                "retrieved": "2026-08-02",
+                "published_at": "2026"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/replay_roster_evidence.py
+++ b/scripts/replay_roster_evidence.py
@@ -1,0 +1,77 @@
+"""Replay real roster tool payloads against the local evidence guards.
+
+The slow loop for roster-guard work is merge -> rebuild the worker -> queue a run
+-> wait ten minutes -> read logs. This runs the same guards in-process against
+payloads captured from real runs, so a guard change can be checked in under a
+second before anything is committed.
+
+Payloads live in ``scripts/fixtures/roster_evidence/*.json`` and are lifted
+verbatim from worker logs. Each case records the tool call an agent actually made
+and whether it should be accepted, so a guard that regresses on a case we already
+fixed fails here instead of in production.
+
+    python scripts/replay_roster_evidence.py                 # all fixtures
+    python scripts/replay_roster_evidence.py ne-house-02     # one fixture
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from pipeline_client.agent.agent import _make_editing_handlers  # noqa: E402
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "roster_evidence"
+
+
+def _run_case(case: Dict[str, Any]) -> tuple[bool, str]:
+    """Execute one recorded tool call and report whether it was accepted."""
+    race_json = json.loads(json.dumps(case["race_json"]))  # deep copy per case
+    logs: List[str] = []
+    handlers = _make_editing_handlers(race_json, lambda _level, message: logs.append(str(message)))
+
+    result = handlers[case["tool"]](case["args"])
+    blocked = str(result).startswith("ERROR") or "Blocked" in str(result) or "blocked" in str(result)
+    accepted = not blocked
+    return accepted, str(result)
+
+
+def main(argv: List[str]) -> int:
+    wanted = argv[1] if len(argv) > 1 else ""
+    paths = sorted(p for p in FIXTURE_DIR.glob("*.json") if wanted in p.stem)
+    if not paths:
+        print(f"No fixtures matching {wanted!r} in {FIXTURE_DIR}")
+        return 2
+
+    failures = 0
+    total = 0
+    for path in paths:
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        print(f"\n=== {path.stem} — {fixture.get('description', '')}")
+        for case in fixture["cases"]:
+            total += 1
+            expected = bool(case["expect_accepted"])
+            try:
+                accepted, detail = _run_case(case)
+            except Exception as exc:  # a guard raising is itself a failure
+                accepted, detail = False, f"{type(exc).__name__}: {exc}"
+            ok = accepted == expected
+            failures += 0 if ok else 1
+            verdict = "ok  " if ok else "FAIL"
+            want = "accept" if expected else "block"
+            got = "accepted" if accepted else "blocked"
+            print(f"  [{verdict}] {case['name']}  (want {want}, got {got})")
+            if not ok or not accepted:
+                print(f"         -> {detail[:220]}")
+
+    print(f"\n{total - failures}/{total} cases behaved as expected")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_issue_retry_limit.py
+++ b/tests/test_issue_retry_limit.py
@@ -1,0 +1,78 @@
+"""Retry-limit behaviour for issue units.
+
+A unit that exhausts its retries used to leave the issue slot empty, which made
+missing_issue_count non-zero and the whole race unpublishable over one issue —
+observed on ne-house-02-2026, where 35 of 36 units landed and the race could not
+be published.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipeline_client.agent.phases.issues import run_issues_phase
+
+
+def _race():
+    return {
+        "id": "ne-house-02-2026",
+        "candidates": [{"name": "Brinker Harding", "issues": {}}],
+        "pipeline_state": {
+            "completed_units": [],
+            "issue_attempts": {},
+            "issue_research": {},
+        },
+    }
+
+
+async def _run(race_json):
+    await run_issues_phase(
+        race_json,
+        "ne-house-02-2026",
+        candidate_names=["Brinker Harding"],
+        small_model="test-model",
+        on_log=None,
+        max_iterations=1,
+        step_enabled=lambda _s: True,
+        track=lambda *_a, **_kw: None,
+        max_candidates=None,
+        target_no_info=False,
+        is_update=True,
+        last_updated="",
+        log=lambda *_a, **_kw: None,
+        prefix="Test",
+        resume_partial=True,
+        continue_incomplete_work=False,
+        run_budget=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_exhausted_unit_with_real_research_records_documented_absence(monkeypatch):
+    race_json = _race()
+    unit = "issues:Brinker Harding:Civil Rights & Equality"
+    race_json["pipeline_state"]["issue_attempts"][unit] = 99
+    race_json["pipeline_state"]["issue_research"][unit] = {"search_calls": 2, "page_fetches": 1}
+
+    await _run(race_json)
+
+    stance = race_json["candidates"][0]["issues"].get("Civil Rights & Equality")
+    assert stance is not None, "an exhausted unit that did research must not leave the slot empty"
+    assert stance["stance"] == "No public position found"
+    assert stance["research_audit"]["status"] == "completed"
+    assert stance["research_audit"]["search_calls"] == 2
+
+
+@pytest.mark.asyncio
+async def test_exhausted_unit_without_research_stays_open(monkeypatch):
+    """Never assert an absence nothing actually looked for."""
+    race_json = _race()
+    unit = "issues:Brinker Harding:Civil Rights & Equality"
+    race_json["pipeline_state"]["issue_attempts"][unit] = 99
+    race_json["pipeline_state"]["issue_research"][unit] = {"search_calls": 0, "page_fetches": 0}
+
+    await _run(race_json)
+
+    assert "Civil Rights & Equality" not in race_json["candidates"][0]["issues"]
+    failures = race_json["pipeline_state"].get("step_failures") or []
+    assert any("retry limit" in str(f.get("detail", "")) for f in failures)

--- a/tests/test_roster_adjudicator.py
+++ b/tests/test_roster_adjudicator.py
@@ -1,0 +1,296 @@
+"""The roster adjudicator gates publication, so its failure modes matter more than its happy path.
+
+Every test here mocks the provider. Whether the model gives *good* judgments is
+what scripts/fixtures/roster_evidence exists for; this file covers the wiring:
+fail-closed behaviour, parsing, caching, and the reproducibility settings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from pipeline_client.agent import roster_adjudicator as adj
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    adj.clear_cache()
+    yield
+    adj.clear_cache()
+
+
+def _reply(content: str):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+def _source(**overrides):
+    source = {
+        "url": "https://sos.ne.gov/candidates",
+        "title": "Official Candidate List",
+        "evidence": "District 2 — U.S. Representative: Jane Roe (D), John Doe (R)",
+        "published_at": "2026-06-01",
+    }
+    source.update(overrides)
+    return source
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+# --- fail closed --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        RuntimeError("OpenRouter 403: key quota exhausted"),
+        ConnectionError("connection refused"),
+        ValueError("boom"),
+    ],
+)
+def test_provider_failure_fails_closed(monkeypatch, exc):
+    """An unreachable judge must reject, never wave evidence through."""
+
+    async def _boom(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _boom)
+    verdict = _run(
+        adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source())
+    )
+    assert verdict.supports is False
+    assert verdict.unavailable is True
+    assert "fails closed" in verdict.reason
+
+
+def test_timeout_fails_closed(monkeypatch):
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _hang)
+    monkeypatch.setattr(adj, "ADJUDICATOR_TIMEOUT_SECONDS", 0.01)
+    verdict = _run(
+        adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source())
+    )
+    assert verdict.supports is False
+    assert verdict.unavailable is True
+
+
+@pytest.mark.parametrize("content", ["", "I think probably yes", "{malformed", "{}", '{"reason": "no verdict field"}'])
+def test_unparseable_reply_fails_closed(monkeypatch, content):
+    async def _reply_with(*args, **kwargs):
+        return _reply(content)
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _reply_with)
+    verdict = _run(
+        adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source())
+    )
+    assert verdict.supports is False
+    assert verdict.unavailable is True
+
+
+def test_unknown_claim_fails_closed():
+    verdict = _run(adj.adjudicate(claim="not_a_real_claim", subject="X", contest="y-2026", source=_source()))
+    assert verdict.supports is False
+    assert verdict.unavailable is True
+
+
+# --- parsing ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ('{"supports": true, "reason": "names the district and cycle"}', True),
+        ('{"supports": false, "reason": "wrong district"}', False),
+        ('```json\n{"supports": true, "reason": "ok"}\n```', True),
+        ('Here is my verdict: {"supports": false, "reason": "blocked page"} — done.', False),
+    ],
+)
+def test_parses_verdict_shapes(monkeypatch, content, expected):
+    async def _reply_with(*args, **kwargs):
+        return _reply(content)
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _reply_with)
+    verdict = _run(
+        adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source())
+    )
+    assert verdict.supports is expected
+    assert verdict.unavailable is False
+    assert verdict.reason
+
+
+def test_reason_is_preserved_verbatim(monkeypatch):
+    """Generic errors are what caused the retry loops; the specific reason must survive."""
+
+    async def _reply_with(*args, **kwargs):
+        return _reply('{"supports": false, "reason": "names District 2 of the state legislature, not Congress"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _reply_with)
+    verdict = _run(
+        adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source())
+    )
+    assert verdict.reason == "names District 2 of the state legislature, not Congress"
+
+
+# --- reproducibility ----------------------------------------------------------
+
+
+def test_requests_temperature_zero_and_pinned_model(monkeypatch):
+    """A publish gate must not drift run to run, nor on a silent provider upgrade."""
+    seen = {}
+
+    async def _capture(messages, **kwargs):
+        seen.update(kwargs)
+        return _reply('{"supports": true, "reason": "ok"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _capture)
+    _run(adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source()))
+    assert seen["temperature"] == 0.0
+    assert seen["model"] == adj.ADJUDICATOR_MODEL
+    # A floating alias would let the provider move the gate with no commit.
+    assert any(char.isdigit() for char in adj.ADJUDICATOR_MODEL)
+
+
+def test_pinned_model_accepts_a_temperature_parameter():
+    """llm._call_openrouter drops temperature for nano tiers; a nano gate could not be pinned to 0."""
+    assert "nano" not in adj.ADJUDICATOR_MODEL
+
+
+def test_identical_claims_are_cached(monkeypatch):
+    calls = {"n": 0}
+
+    async def _count(*args, **kwargs):
+        calls["n"] += 1
+        return _reply('{"supports": true, "reason": "ok"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _count)
+
+    async def _twice():
+        kwargs = dict(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source())
+        return await adj.adjudicate(**kwargs), await adj.adjudicate(**kwargs)
+
+    first, second = _run(_twice())
+    assert calls["n"] == 1
+    assert first.supports is second.supports
+
+
+def test_failures_are_not_cached(monkeypatch):
+    """A quota blip must not poison the gate for the rest of the run."""
+    calls = {"n": 0}
+
+    async def _fail_then_succeed(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("429")
+        return _reply('{"supports": true, "reason": "ok"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _fail_then_succeed)
+
+    async def _twice():
+        kwargs = dict(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", source=_source())
+        return await adj.adjudicate(**kwargs), await adj.adjudicate(**kwargs)
+
+    first, second = _run(_twice())
+    assert first.supports is False and first.unavailable is True
+    assert second.supports is True
+    assert calls["n"] == 2
+
+
+def test_different_claims_on_one_source_are_judged_separately(monkeypatch):
+    calls = {"n": 0}
+
+    async def _count(*args, **kwargs):
+        calls["n"] += 1
+        return _reply('{"supports": true, "reason": "ok"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _count)
+
+    async def _both():
+        source = _source()
+        await adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="x-2026", source=source)
+        await adj.adjudicate(claim=adj.Claim.COMPLETENESS, subject="Jane Roe", contest="x-2026", source=source)
+
+    _run(_both())
+    assert calls["n"] == 2
+
+
+# --- prompt construction ------------------------------------------------------
+
+
+def test_prompt_carries_evidence_and_never_the_desired_answer(monkeypatch):
+    """The judge must not be told what the caller hopes to hear."""
+    captured = {}
+
+    async def _capture(messages, **kwargs):
+        captured["system"] = messages[0]["content"]
+        captured["user"] = messages[1]["content"]
+        return _reply('{"supports": true, "reason": "ok"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _capture)
+    _run(
+        adj.adjudicate(
+            claim=adj.Claim.MEMBERSHIP,
+            subject="Jane Roe",
+            contest="ne-house-02-2026",
+            source=_source(evidence="Jane Roe is listed for U.S. House District 2"),
+        )
+    )
+    assert "Jane Roe is listed for U.S. House District 2" in captured["user"]
+    assert "ne-house-02-2026" in captured["user"]
+    for leak in ("accept", "approve", "should pass", "the caller wants"):
+        assert leak not in captured["user"].casefold()
+    assert "outside knowledge" in captured["system"]
+
+
+def test_missing_evidence_is_stated_not_hidden(monkeypatch):
+    captured = {}
+
+    async def _capture(messages, **kwargs):
+        captured["user"] = messages[1]["content"]
+        return _reply('{"supports": false, "reason": "no evidence"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _capture)
+    _run(adj.adjudicate(claim=adj.Claim.MEMBERSHIP, subject="X", contest="y-2026", source=_source(evidence="")))
+    assert "no evidence text was supplied" in captured["user"]
+
+
+# --- batch --------------------------------------------------------------------
+
+
+def test_adjudicate_sources_keys_by_url(monkeypatch):
+    async def _ok(*args, **kwargs):
+        return _reply('{"supports": true, "reason": "ok"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _ok)
+    sources = [_source(url="https://a.gov/1"), _source(url="https://b.gov/2", evidence="different text")]
+    verdicts = _run(
+        adj.adjudicate_sources(claim=adj.Claim.MEMBERSHIP, subject="Jane Roe", contest="ne-house-02-2026", sources=sources)
+    )
+    assert set(verdicts) == {"https://a.gov/1", "https://b.gov/2"}
+    assert all(record["supports"] for record in verdicts.values())
+    assert all(record["model"] == adj.ADJUDICATOR_MODEL for record in verdicts.values())
+
+
+def test_adjudicate_sources_skips_urlless_sources(monkeypatch):
+    async def _ok(*args, **kwargs):
+        return _reply('{"supports": true, "reason": "ok"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _ok)
+    verdicts = _run(
+        adj.adjudicate_sources(claim=adj.Claim.MEMBERSHIP, subject="X", contest="y-2026", sources=[{"evidence": "no url"}])
+    )
+    assert verdicts == {}
+
+
+def test_verdict_record_is_persistable():
+    """The record is written onto the source, so it must be plain JSON-safe data."""
+    import json
+
+    record = adj.Verdict(supports=False, reason="wrong district").to_record()
+    assert json.loads(json.dumps(record)) == record
+    assert record["reason"] == "wrong district"

--- a/tests/test_roster_adjudicator_live.py
+++ b/tests/test_roster_adjudicator_live.py
@@ -1,0 +1,137 @@
+"""Live adjudicator judgments against evidence that really broke the regexes.
+
+These cases are the ones prose-grading got wrong in production. They cost a few
+cents to run and need a real ``OPENROUTER_API_KEY``, so they skip in CI (which
+mocks network) and run locally when someone has a key.
+
+They are not redundant with tests/test_roster_adjudicator.py, which mocks the
+provider and covers wiring. Only these can catch a prompt regression — the first
+draft of the COMPLETENESS question blocked Ballotpedia's standard full-field
+sentence, reproducing the exact ne-house-02-2026 failure the adjudicator exists
+to fix, and no mocked test could have noticed.
+
+    PYTHONPATH=. python -m pytest tests/test_roster_adjudicator_live.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from pipeline_client.agent.roster_adjudicator import Claim, adjudicate
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OPENROUTER_API_KEY"),
+    reason="live adjudicator check needs a real OPENROUTER_API_KEY",
+)
+
+
+NJ_CERTIFIED_LIST = {
+    "url": "https://www.nj.gov/state/elections/assets/pdf/2026-official-list-candidates-us-senate.pdf",
+    "title": "Official List Candidates for US Senate For GENERAL ELECTION 11/03/2026",
+    "evidence": (
+        "Official List Candidates for US Senate For GENERAL ELECTION 11/03/2026. "
+        "DEMOCRATIC: Andy Kim. REPUBLICAN: Curtis Bashaw. LIBERTARIAN: Joanne Kuniansky."
+    ),
+    "published_at": "2026-06-10",
+}
+
+BALLOTPEDIA_FULL_FIELD = {
+    "url": "https://ballotpedia.org/Nebraska%27s_2nd_Congressional_District_election,_2026",
+    "title": "Nebraska's 2nd Congressional District election, 2026",
+    "evidence": (
+        "General election candidates: Don Bacon (R) and Tony Vargas (D) are running in the "
+        "general election for U.S. House Nebraska District 2 on November 3, 2026."
+    ),
+    "published_at": "2026-07-20",
+}
+
+NE_SPREADSHEET_ROW = {
+    "url": "https://sos.nebraska.gov/sites/default/files/doc/2026-general-candidates.xlsx",
+    "title": "2026 General Election Candidates — Nebraska Secretary of State",
+    "evidence": "CONGRESSIONAL DISTRICTS | District 2 | Tony Vargas | Democratic | Omaha, NE | Filed 2026-02-17",
+    "published_at": "2026-02-20",
+}
+
+AL_STATE_HOUSE = {
+    "url": "https://www.legislature.state.al.us/house/district2",
+    "title": "Alabama House of Representatives District 2",
+    "evidence": "Napoleon Bracy represents District 2 in the Alabama House of Representatives.",
+    "published_at": "2026-03-01",
+}
+
+BLOCKED_PAGE = {
+    "url": "https://ballotpedia.org/Nebraska%27s_2nd_Congressional_District_election,_2026",
+    "title": "403 Forbidden",
+    "evidence": "Access denied. Please enable JavaScript to continue.",
+    "published_at": "2026-07-20",
+}
+
+PRIOR_CYCLE_ARTICLE = {
+    "url": "https://example.com/2022-race",
+    "title": "Bacon wins re-election in Nebraska's 2nd District",
+    "evidence": "Don Bacon defeated Tony Vargas in the 2022 election for Nebraska's 2nd Congressional District.",
+    "published_at": "2022-11-09",
+}
+
+GA_DIFFERENT_OFFICE = {
+    "url": "https://sos.ga.gov/candidates/2026",
+    "title": "Georgia 2026 Qualified Candidates",
+    "evidence": "Jane Roe qualified as a candidate for Georgia Secretary of State in the 2026 general election.",
+    "published_at": "2026-03-10",
+}
+
+NE_CONTEST = "ne-house-02-2026 (U.S. House, Nebraska District 2, 2026)"
+
+CASES = [
+    # --- must be ACCEPTED: real evidence the regexes wrongly rejected ----------
+    (
+        "nj-certified-list-phrasing",
+        Claim.COMPLETENESS,
+        "Andy Kim",
+        "nj-senate-2026 (U.S. Senate, New Jersey, 2026)",
+        NJ_CERTIFIED_LIST,
+        True,
+    ),
+    ("ballotpedia-full-field-sentence", Claim.COMPLETENESS, "Don Bacon", NE_CONTEST, BALLOTPEDIA_FULL_FIELD, True),
+    ("ne-spreadsheet-district-row", Claim.MEMBERSHIP, "Tony Vargas", NE_CONTEST, NE_SPREADSHEET_ROW, True),
+    (
+        "genuine-wrong-contest",
+        Claim.WRONG_CONTEST,
+        "Jane Roe",
+        "ga-governor-2026 (Governor, Georgia, 2026)",
+        GA_DIFFERENT_OFFICE,
+        True,
+    ),
+    # --- must be BLOCKED: the holes the regexes existed to close ---------------
+    (
+        "state-house-district-number-collision",
+        Claim.MEMBERSHIP,
+        "Napoleon Bracy",
+        "al-house-02-2026 (U.S. House, Alabama District 2, 2026)",
+        AL_STATE_HOUSE,
+        False,
+    ),
+    ("blocked-page-as-omission-proof", Claim.OMISSION, "Don Bacon", NE_CONTEST, BLOCKED_PAGE, False),
+    ("prior-cycle-as-current-membership", Claim.MEMBERSHIP, "Don Bacon", NE_CONTEST, PRIOR_CYCLE_ARTICLE, False),
+    (
+        "absence-of-evidence-as-withdrawal",
+        Claim.WITHDRAWAL,
+        "Jane Doe",
+        "ga-senate-2026 (U.S. Senate, Georgia, 2026)",
+        {"evidence": "Not found in credible sources; no evidence this person is a real candidate."},
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("name,claim,subject,contest,source,expected", CASES, ids=[case[0] for case in CASES])
+def test_live_adjudication(name, claim, subject, contest, source, expected):
+    verdict = asyncio.run(adjudicate(claim=claim, subject=subject, contest=contest, source=source))
+    assert not verdict.unavailable, f"{name}: adjudicator unavailable — {verdict.reason}"
+    assert verdict.supports is expected, (
+        f"{name}: expected {'accept' if expected else 'block'}, got "
+        f"{'accept' if verdict.supports else 'block'} — {verdict.reason}"
+    )

--- a/tests/test_roster_contract.py
+++ b/tests/test_roster_contract.py
@@ -1,0 +1,162 @@
+"""The roster-evidence contract must mean the same thing to the prompt and the tool.
+
+These tests exist because the two used to disagree. On ne-house-02-2026 the
+prompt told the model a Ballotpedia race page was acceptable completeness
+evidence, ``finalize_roster`` rejected it, and the model spent its entire
+iteration budget unable to reconcile the instruction with the error. Anything
+here that fails means that class of bug is back.
+"""
+
+import pytest
+
+from pipeline_client.agent import handlers
+from pipeline_client.agent.prompts import ROSTER_SYNC_USER
+from pipeline_client.agent.roster import ROSTER_CAP
+from pipeline_client.agent.roster_contract import (
+    AUTHORITATIVE_SOURCE_CLASSES,
+    COMPLETENESS_SOURCE_CLASSES,
+    COMPLETENESS_TIERS,
+    MEMBERSHIP_TIERS,
+    QUALIFYING_SOURCE_CLASSES,
+    ROSTER_LISTING_SOURCE_CLASSES,
+    SOURCE_CLASSES,
+    lacks_tier3_corroboration,
+    tier_rejection_reason,
+)
+
+
+def test_prompt_carries_no_unsubstituted_slots():
+    assert "@@" not in ROSTER_SYNC_USER
+
+
+def test_prompt_still_formats_with_runtime_placeholders():
+    """Rendering the contract must not consume the caller's format placeholders."""
+    rendered = ROSTER_SYNC_USER.format(
+        race_id="ne-house-02-2026",
+        last_updated="2026-07-01",
+        current_date="2026-08-02",
+        candidate_names="A, B",
+        race_description="desc",
+    )
+    assert "ne-house-02-2026" in rendered
+    # Rendered contract text must not smuggle in brace syntax of its own; a stray
+    # "{" here means a future edit will crash .format() at run time, not in CI.
+    assert "{" not in rendered and "}" not in rendered
+
+
+@pytest.mark.parametrize("source_class", sorted(QUALIFYING_SOURCE_CLASSES))
+def test_prompt_names_every_class_the_tool_accepts(source_class):
+    """A class the tool honours but the prompt never mentions is unreachable."""
+    assert source_class in ROSTER_SYNC_USER.casefold()
+
+
+def test_prompt_states_the_cap_the_tool_enforces():
+    assert str(ROSTER_CAP) in ROSTER_SYNC_USER
+
+
+@pytest.mark.parametrize("tier", [tier.tier for tier in MEMBERSHIP_TIERS])
+def test_prompt_describes_every_evidence_tier(tier):
+    assert f"Tier {tier}" in ROSTER_SYNC_USER
+
+
+def test_completeness_classes_are_a_subset_of_qualifying_classes():
+    """Completeness evidence is a stricter case of roster evidence, never a looser one."""
+    assert COMPLETENESS_SOURCE_CLASSES <= QUALIFYING_SOURCE_CLASSES
+    assert ROSTER_LISTING_SOURCE_CLASSES <= QUALIFYING_SOURCE_CLASSES
+    assert AUTHORITATIVE_SOURCE_CLASSES <= QUALIFYING_SOURCE_CLASSES
+    assert "other" not in QUALIFYING_SOURCE_CLASSES
+    assert "other" in SOURCE_CLASSES
+
+
+def test_ballotpedia_race_page_is_accepted_completeness_evidence():
+    """The ne-house-02-2026 regression: the prompt promises this, so the tool must honour it."""
+    assert "ballotpedia" in COMPLETENESS_SOURCE_CLASSES
+    assert "Ballotpedia" in ROSTER_SYNC_USER
+
+
+def test_campaign_site_cannot_prove_a_candidate_is_absent_from_a_field():
+    """A campaign site speaks for one candidate and never enumerates opponents."""
+    assert "campaign" not in ROSTER_LISTING_SOURCE_CLASSES
+    assert "campaign" in QUALIFYING_SOURCE_CLASSES
+
+
+# --- tier grading: behaviour must match the inline logic this replaced ---------
+
+
+@pytest.mark.parametrize(
+    "tier,status,source_type,expected_ok",
+    [
+        (1, "content", "official", True),
+        (1, "content", "fec", True),
+        (1, "content", "news", False),  # tier 1 is authoritative-only
+        (1, "snippet", "official", False),  # tier 1 needs retrieved content
+        (2, "content", "campaign", True),
+        (2, "content", "ballotpedia", True),
+        (2, "content", "news", True),
+        (2, "content", "official", False),  # official content is tier 1, not 2
+        (2, "snippet", "news", False),
+        (3, "snippet", "news", True),
+        (3, "snippet", "official", True),
+        (3, "content", "news", False),  # retrieved content is not a snippet
+        (4, "content", "official", False),  # unrecognized grade
+        (None, None, "official", False),
+    ],
+)
+def test_tier_grading(tier, status, source_type, expected_ok):
+    source = {"evidence_tier": tier, "retrieval_status": status, "type": source_type}
+    assert (tier_rejection_reason(source) is None) is expected_ok
+
+
+def test_tier_rejection_reasons_are_specific():
+    """Callers surface these verbatim; a generic message sends the model source-hunting."""
+    reason = tier_rejection_reason({"evidence_tier": 1, "retrieval_status": "snippet", "type": "official"})
+    assert reason and "tier 1" in reason
+    unknown = tier_rejection_reason({"evidence_tier": 9, "retrieval_status": "content", "type": "official"})
+    assert unknown and "not a recognized evidence grade" in unknown
+
+
+# --- tier-3 corroboration -----------------------------------------------------
+
+
+def _snippet(url, source_type="news"):
+    return {"evidence_tier": 3, "retrieval_status": "snippet", "type": source_type, "url": url}
+
+
+def test_single_domain_snippets_lack_corroboration():
+    assert lacks_tier3_corroboration([_snippet("https://a.com/1"), _snippet("https://a.com/2")])
+
+
+def test_two_independent_domains_corroborate():
+    assert not lacks_tier3_corroboration([_snippet("https://a.com/1"), _snippet("https://b.com/2")])
+
+
+def test_authoritative_snippet_waives_corroboration():
+    assert not lacks_tier3_corroboration([_snippet("https://sos.ga.gov/x", "official")])
+
+
+def test_corroboration_does_not_apply_when_higher_tier_evidence_exists():
+    mixed = [
+        _snippet("https://a.com/1"),
+        {"evidence_tier": 1, "retrieval_status": "content", "type": "official", "url": "https://a.com/2"},
+    ]
+    assert not lacks_tier3_corroboration(mixed)
+
+
+def test_empty_source_list_is_not_a_corroboration_failure():
+    """No sources is a different rejection, reported elsewhere with its own reason."""
+    assert not lacks_tier3_corroboration([])
+
+
+# --- the handler must read the contract, not a private copy -------------------
+
+
+def test_handler_constants_are_the_contract_objects():
+    """Guards against someone reintroducing a local literal set in handlers."""
+    assert handlers._QUALIFYING_ROSTER_SOURCE_TYPES is QUALIFYING_SOURCE_CLASSES
+    assert handlers._ROSTER_SOURCE_TYPES is SOURCE_CLASSES
+
+
+def test_completeness_tiers_exclude_snippets():
+    """A snippet of a list page is indistinguishable from a truncated one."""
+    snippet_tiers = {tier.tier for tier in MEMBERSHIP_TIERS if tier.retrieval_status == "snippet"}
+    assert not (COMPLETENESS_TIERS & snippet_tiers)

--- a/tests/test_roster_evidence_fixtures.py
+++ b/tests/test_roster_evidence_fixtures.py
@@ -1,0 +1,39 @@
+"""Run the recorded roster-evidence fixtures as tests.
+
+The fixtures in scripts/fixtures/roster_evidence are payloads captured verbatim
+from real worker runs, each recording a tool call an agent actually made and
+whether it should be accepted. They exist so guard changes can be checked in
+under a second locally, and they run here so a guard that regresses on an
+already-fixed case fails in CI rather than in production.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.replay_roster_evidence import FIXTURE_DIR, _run_case
+
+
+def _all_cases():
+    for path in sorted(FIXTURE_DIR.glob("*.json")):
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        for case in fixture["cases"]:
+            yield pytest.param(case, id=f"{path.stem}-{case['name'].replace(' ', '_')[:48]}")
+
+
+@pytest.mark.parametrize("case", list(_all_cases()))
+def test_recorded_roster_evidence_case(case):
+    accepted, detail = _run_case(case)
+    expected = bool(case["expect_accepted"])
+    assert accepted == expected, (
+        f"{case['name']}: expected {'accept' if expected else 'block'}, got "
+        f"{'accept' if accepted else 'block'} — {detail[:300]}"
+    )
+
+
+def test_fixtures_are_present():
+    """A silently empty fixture directory would make this suite vacuous."""
+    assert list(FIXTURE_DIR.glob("*.json")), "no roster evidence fixtures found"


### PR DESCRIPTION
## Why

The rules for what evidence may add a candidate to a roster lived in two places: prose in `ROSTER_SYNC_USER` for the model to read, and predicates in `handlers` to enforce. Nothing kept them in sync.

On `ne-house-02-2026` the prompt told the model a Ballotpedia race page was acceptable completeness evidence, `finalize_roster` rejected it, and the model burned all 12 iterations unable to reconcile the instruction with the error. The commit history of `handlers.py` — 59 commits in six months, alternating between "Unblock roster-absence removals" and "Guard phantom roster removals" — is a record of that drift.

## What

**`roster_contract.py`** owns the source classes, evidence tiers, completeness rules, corroboration rule, and roster cap. `handlers` validates against that data; `prompts` renders its text from it. They can no longer disagree.

`tests/test_roster_contract.py` asserts the handler holds the contract objects themselves rather than private copies. Verified non-vacuous by reintroducing a literal set and confirming the test fails.

**`roster_adjudicator.py`** answers the questions that are reading comprehension rather than structure: does this evidence name this exact contest, enumerate a field without a candidate, constitute a complete listing, or describe a real withdrawal.

**Not yet wired into `handlers`** — that is a separate change. This PR lands the contract (active) and the adjudicator (verified, not yet called).

## Why the adjudicator is safe in a publish gate

- Structural gates run first; it never sees a source that failed a cheap check.
- It is a different model shown only the evidence and the claim, with no context about the desired answer.
- **Fails closed.** Provider unreachable, out of quota, timed out, or unparseable reply → claim rejected with a reason saying so.
- Verdict and reason are persisted onto the source, so a rejection is inspectable rather than flaky-and-undebuggable.
- Model pinned, temperature 0. Nano tiers reject a `temperature` parameter, so the gate uses mini to stay reproducible; `_call_openrouter` gained a temperature passthrough.

## Testing

`tests/test_roster_adjudicator.py` (25 tests, mocked) covers wiring: fail-closed paths, verdict parsing, caching, and that failures are *not* cached so a quota blip can't poison a run.

`tests/test_roster_adjudicator_live.py` runs the real cases prose-grading got wrong — NJ's certified-list phrasing, Ballotpedia's full-field sentence, the Nebraska spreadsheet rows, the AL state-house district-number collision, absence-of-evidence offered as a withdrawal reason. Skips without a key.

The live test earned its keep twice, catching things no mocked test could:
1. The first `COMPLETENESS` prompt blocked Ballotpedia's full-field sentence — reproducing the exact `ne-house-02` failure the adjudicator exists to fix.
2. The Nebraska row flipped between runs at temperature 0 until the prompt was taught that tabular evidence carries its office in a section heading rather than in each row.

Stable across 3 cold-cache runs afterward. Full suite: 1039 + 40 + 93 passing.

## Also included

Concurrent work on this branch: `_published_year` extraction, spreadsheet roster sources, the fixture replay harness, and issue retry limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)