### PR TITLE
Wire roster adjudication into the agent loop, and centralize the GCS client

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -109,9 +109,64 @@ def _source_is_current_cycle(source: Dict[str, Any], *, race_id: str, text: str)
 
 
 def _source_names_candidate(text: str, candidate_name: str) -> bool:
-    """True when every word of the candidate's name appears in the source text."""
+    """True when every word of the candidate's name appears in the source text.
+
+    A cheap prefilter, not a decision. Unordered substring matching over a
+    concatenated blob, so "Justin Maldonado" is satisfied by a page mentioning a
+    different Justin and a different Maldonado. Confirming a source is really
+    about this person is the adjudicator's job; this only avoids paying for a
+    model call on evidence that plainly does not mention them.
+    """
     name_words = re.findall(r"[a-z0-9]+", candidate_name.casefold())
     return bool(name_words) and all(word in text for word in name_words)
+
+
+def _verdict_for(args: Dict[str, Any], claim: str, url: Any = "") -> Dict[str, Any] | None:
+    """Look up the adjudicator's verdict for one claim about one source.
+
+    The agent loop resolves these before dispatch and injects them under
+    ``_adjudications`` (see ``roster_adjudicator.collect_roster_adjudications``).
+    A missing verdict is not an approval — callers must treat absence as a block,
+    which is what keeps a direct handler call or an unreachable adjudicator from
+    opening the gate.
+    """
+    adjudications = args.get("_adjudications")
+    if not isinstance(adjudications, dict):
+        return None
+    by_url = adjudications.get(claim)
+    if not isinstance(by_url, dict):
+        return None
+    verdict = by_url.get(str(url or "").strip())
+    return verdict if isinstance(verdict, dict) else None
+
+
+def _adjudicator_supports(args: Dict[str, Any], claim: str, url: Any = "") -> bool:
+    """True only on an explicit supporting verdict. Absence and failure both block."""
+    verdict = _verdict_for(args, claim, url)
+    return bool(verdict and verdict.get("supports") is True)
+
+
+def _adjudicator_reason(args: Dict[str, Any], claim: str, url: Any = "") -> str:
+    """The adjudicator's own words, surfaced verbatim to the calling model.
+
+    Generic rejections are what sent models hunting for more sources when a
+    single field was wrong, so the specific reason has to survive to the caller.
+    """
+    verdict = _verdict_for(args, claim, url)
+    if not verdict:
+        return "no adjudication was recorded for this source"
+    return str(verdict.get("reason") or "no reason given")
+
+
+def _record_verdict_on_source(source: Dict[str, Any], args: Dict[str, Any], claim: str) -> None:
+    """Persist the verdict onto the stored source so the decision outlives the run.
+
+    Without this a rejection is a flaky gate nobody can debug after the fact;
+    with it, a published draft carries why each source was accepted.
+    """
+    verdict = _verdict_for(args, claim, source.get("url"))
+    if verdict:
+        source["adjudication"] = dict(verdict)
 
 
 def _canonical_roster_name(name: str) -> str:

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -34,6 +34,7 @@ from .model_registry import (
     NEMOTRON_ULTRA_MODEL,
     normalize_model_id,
 )
+from .roster_adjudicator import collect_roster_adjudications
 from .run_budget import RunBudget, RunBudgetExceeded
 from .source_types import normalize_source_type
 from .tools import BALLOTPEDIA_ELECTION_TOOL, BALLOTPEDIA_TOOL, FETCH_TOOL, IMAGE_SEARCH_TOOL, SEARCH_TOOL
@@ -793,6 +794,18 @@ async def _agent_loop(
                         "researched_urls": sorted(researched_urls),
                         "fetched_urls": sorted(fetched_urls),
                     }
+                    # Reading-comprehension judgments about roster evidence need a
+                    # network call, and the editing handlers are synchronous. Resolve
+                    # them here — where we are already async — and hand the handler
+                    # finished verdicts, exactly as the research trace is handed over.
+                    adjudications = await collect_roster_adjudications(
+                        tool_name=fn.name,
+                        args=args,
+                        race_id=race_id or "",
+                        run_budget=run_budget,
+                    )
+                    if adjudications:
+                        args["_adjudications"] = adjudications
                     try:
                         if fn.name == "read_profile" and context_budget.narrow_phase and args.get("section", "full") == "full":
                             handler_result = (

--- a/pipeline_client/agent/roster_adjudicator.py
+++ b/pipeline_client/agent/roster_adjudicator.py
@@ -277,6 +277,75 @@ async def adjudicate(
     return verdict
 
 
+#: Which tool arguments carry evidence, and what claim each is offered in support of.
+#: ``subject_key`` names the arg holding the candidate the claim is about; when it is
+#: None the claim is about the race as a whole.
+_TOOL_EVIDENCE_SPECS: Dict[str, tuple] = {
+    # (args_key, claim, subject_key, condition_key)
+    "add_candidate": (("roster_sources", Claim.MEMBERSHIP, "name", None),),
+    "set_candidate_roster_sources": (("roster_sources", Claim.MEMBERSHIP, "candidate_name", None),),
+    "remove_candidate": (
+        ("sources", Claim.OMISSION, "name", "not_on_roster"),
+        ("sources", Claim.WRONG_CONTEST, "name", "wrong_contest"),
+    ),
+    "finalize_roster": (("completeness_sources", Claim.COMPLETENESS, None, None),),
+}
+
+
+async def collect_roster_adjudications(
+    *,
+    tool_name: str,
+    args: Mapping[str, Any],
+    race_id: str,
+    run_budget: Any = None,
+) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """Resolve every evidence judgment a roster tool call will need.
+
+    Returns ``{claim: {url: verdict_record}}``. Called from the async agent loop
+    so the synchronous editing handlers receive finished verdicts rather than
+    having to make a network call themselves.
+
+    Returns empty for tools that carry no evidence, so non-roster tools cost
+    nothing. ``remove_candidate`` without ``not_on_roster``/``wrong_contest`` is
+    an ordinary withdrawal and is judged on its reason text, not its sources.
+    """
+    specs = _TOOL_EVIDENCE_SPECS.get(tool_name)
+    results: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    if specs:
+        for args_key, claim, subject_key, condition_key in specs:
+            if condition_key and args.get(condition_key) is not True:
+                continue
+            sources = args.get(args_key)
+            if not isinstance(sources, list) or not sources:
+                continue
+            subject = str(args.get(subject_key) or "") if subject_key else ""
+            verdicts = await adjudicate_sources(
+                claim=claim,
+                subject=subject,
+                contest=race_id,
+                sources=[source for source in sources if isinstance(source, dict)],
+                run_budget=run_budget,
+            )
+            if verdicts:
+                results[claim] = verdicts
+
+    # A withdrawal is argued in prose, not with a source object, so it is judged
+    # from the reason text rather than from an evidence list.
+    if tool_name == "remove_candidate" and args.get("not_on_roster") is not True and args.get("wrong_contest") is not True:
+        reason = str(args.get("reason") or "").strip()
+        if reason:
+            verdict = await adjudicate(
+                claim=Claim.WITHDRAWAL,
+                subject=str(args.get("name") or ""),
+                contest=race_id,
+                source={"evidence": reason},
+                run_budget=run_budget,
+            )
+            results[Claim.WITHDRAWAL] = {"": verdict.to_record()}
+
+    return results
+
+
 async def adjudicate_sources(
     *,
     claim: str,

--- a/pipeline_client/backend/gcs_client.py
+++ b/pipeline_client/backend/gcs_client.py
@@ -1,0 +1,56 @@
+"""One place to build a Google Cloud Storage client.
+
+Six modules used to construct their own, and one of them lived in
+``backend/main.py`` — the local debug API that CLAUDE.md documents as "not
+production". ``race_manager``, the central production race-state service,
+imported ``_get_gcs_client`` from it. Because that import is lazy (inside the
+function, per this project's circular-dependency convention) it does not fail at
+startup: it fails the first time a run actually needs GCS, part-way through, in
+whichever deployment did not expect to be importing a FastAPI debug app.
+
+Importing this module has no side effects and pulls in no web framework.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger("pipeline")
+
+_client: Optional[Any] = None
+_lock = threading.Lock()
+
+
+def get_gcs_client() -> Optional[Any]:
+    """Return a lazily built, process-wide GCS client, or None if unavailable.
+
+    Returns None rather than raising when the library is missing or credentials
+    cannot be resolved: callers run in local mode without GCS, and every call
+    site already branches on a falsy client. The reason is logged once.
+    """
+    global _client
+    if _client is not None:
+        return _client
+    with _lock:
+        if _client is not None:  # another thread won the race
+            return _client
+        try:
+            from google.cloud import storage  # type: ignore
+
+            _client = storage.Client()
+        except ImportError:
+            logger.warning("google-cloud-storage is not installed; GCS features are unavailable")
+            return None
+        except Exception as exc:  # credentials missing, metadata server unreachable
+            logger.warning("GCS client init failed: %s", exc)
+            return None
+    return _client
+
+
+def reset_gcs_client() -> None:
+    """Drop the memoized client. For tests; harmless in production."""
+    global _client
+    with _lock:
+        _client = None

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -101,12 +101,9 @@ class AgentHandler:
 
     def _get_storage_client(self):
         """Return a GCS storage client without importing FastAPI app modules."""
-        try:
-            from google.cloud import storage  # type: ignore
+        from pipeline_client.backend.gcs_client import get_gcs_client
 
-            return storage.Client()
-        except Exception:
-            return None
+        return get_gcs_client()
 
     async def handle(self, payload: Dict[str, Any], options: Dict[str, Any]) -> Any:
         """Run the agent for a race_id and publish the result.

--- a/pipeline_client/backend/main.py
+++ b/pipeline_client/backend/main.py
@@ -29,7 +29,6 @@ from .step_registry import REGISTRY
 load_dotenv(dotenv_path=Path(__file__).resolve().parents[2] / ".env")
 
 _RACE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,99}$")
-_gcs_client = None
 http_bearer = HTTPBearer(auto_error=False)
 
 
@@ -40,18 +39,15 @@ def _validate_race_id(race_id: str) -> None:
 
 
 def _get_gcs_client():
-    """Return a lazily initialized GCS client, or None if the library is missing."""
-    global _gcs_client
-    if _gcs_client is not None:
-        return _gcs_client
-    try:
-        from google.cloud import storage as gcs  # type: ignore
+    """Return a lazily initialized GCS client, or None if unavailable.
 
-        _gcs_client = gcs.Client()
-        return _gcs_client
-    except ImportError:
-        logging.warning("google-cloud-storage not installed")
-        return None
+    Kept as a thin alias so this debug app's own routes keep working. The client
+    itself now lives in ``backend.gcs_client``; production code must import it
+    from there rather than from this module, which is local-debug only.
+    """
+    from pipeline_client.backend.gcs_client import get_gcs_client
+
+    return get_gcs_client()
 
 
 @asynccontextmanager

--- a/pipeline_client/backend/race_manager.py
+++ b/pipeline_client/backend/race_manager.py
@@ -361,9 +361,9 @@ class RaceManager:
 
             gcs_bucket = settings.gcs_bucket
             if gcs_bucket:
-                from pipeline_client.backend.main import _get_gcs_client
+                from pipeline_client.backend.gcs_client import get_gcs_client
 
-                client = _get_gcs_client()
+                client = get_gcs_client()
                 if client is not None:
                     bucket = client.bucket(gcs_bucket)
                     has_gcs_draft = bucket.blob(f"drafts/{race_id}.json").exists()
@@ -661,9 +661,9 @@ class RaceManager:
         now = _now_iso()
 
         try:
-            from pipeline_client.backend.main import _get_gcs_client
+            from pipeline_client.backend.gcs_client import get_gcs_client
 
-            client = _get_gcs_client()
+            client = get_gcs_client()
             if client is None:
                 logger.warning("google-cloud-storage not available; skipping GCS hydration")
                 return 0

--- a/pipeline_client/worker.py
+++ b/pipeline_client/worker.py
@@ -112,12 +112,9 @@ def _get_db() -> Any:
 
 
 def _get_gcs() -> Any:
-    try:
-        storage = __import__("google.cloud.storage", fromlist=["Client"])
-        return storage.Client()
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("GCS client init failed: %s", exc)
-        return None
+    from pipeline_client.backend.gcs_client import get_gcs_client
+
+    return get_gcs_client()
 
 
 def _bucket_name() -> str:

--- a/tests/test_gcs_client.py
+++ b/tests/test_gcs_client.py
@@ -1,0 +1,117 @@
+"""One GCS client factory, and production code must not reach it through the debug app.
+
+race_manager imported _get_gcs_client from backend/main.py — the local debug
+FastAPI app that CLAUDE.md marks "not production". The import was lazy, so it
+would not have failed at startup; it would have failed the first time a run
+needed GCS, part-way through, in a deployment that never meant to import a web
+framework at all.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from pipeline_client.backend import gcs_client
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    gcs_client.reset_gcs_client()
+    yield
+    gcs_client.reset_gcs_client()
+
+
+def test_missing_library_returns_none_rather_than_raising(monkeypatch):
+    """Local mode runs without GCS; every call site branches on a falsy client."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_storage(name, *args, **kwargs):
+        if name == "google.cloud":
+            raise ImportError("no google-cloud-storage")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_storage)
+    assert gcs_client.get_gcs_client() is None
+
+
+def test_credential_failure_returns_none_rather_than_raising(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _bad_creds(name, *args, **kwargs):
+        if name == "google.cloud":
+            raise RuntimeError("could not determine credentials")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _bad_creds)
+    assert gcs_client.get_gcs_client() is None
+
+
+def test_client_is_built_once(monkeypatch):
+    """Six modules used to build their own; the point of the factory is one."""
+    built = {"n": 0}
+
+    class _FakeClient:
+        def __init__(self):
+            built["n"] += 1
+
+    class _FakeStorage:
+        Client = _FakeClient
+
+    monkeypatch.setattr(gcs_client, "_client", None)
+    import sys
+    import types
+
+    fake = types.ModuleType("google.cloud")
+    fake.storage = _FakeStorage  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "google.cloud", fake)
+
+    first = gcs_client.get_gcs_client()
+    second = gcs_client.get_gcs_client()
+    assert first is second
+    assert built["n"] == 1
+
+
+def _imported_modules(path: pathlib.Path) -> set[str]:
+    """Module names this file actually imports, at any nesting depth.
+
+    Parsed rather than grepped: the docstrings here name backend.main and
+    FastAPI to explain the layering rule, and a text search would flag the
+    explanation as the violation.
+    """
+    import ast
+
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+    return names
+
+
+def test_factory_module_pulls_in_no_web_framework():
+    """Importing the factory must stay free of FastAPI, or the layering fix is undone."""
+    imported = _imported_modules(REPO_ROOT / "pipeline_client" / "backend" / "gcs_client.py")
+    for module in imported:
+        assert not module.startswith(("fastapi", "starlette")), f"factory imports a web framework: {module}"
+        assert "backend.main" not in module, f"factory imports the debug app: {module}"
+
+
+def test_no_production_module_imports_the_debug_app():
+    """backend/main.py is local-debug only; run.py is the one legitimate consumer."""
+    offenders = []
+    for path in REPO_ROOT.joinpath("pipeline_client").rglob("*.py"):
+        if path.name == "run.py" or (path.name == "main.py" and path.parent.name == "backend"):
+            continue
+        for module in _imported_modules(path):
+            if module.endswith("backend.main"):
+                offenders.append(f"{path.relative_to(REPO_ROOT)} -> {module}")
+    assert not offenders, f"production modules importing the debug app: {offenders}"

--- a/tests/test_roster_adjudicator.py
+++ b/tests/test_roster_adjudicator.py
@@ -294,3 +294,86 @@ def test_verdict_record_is_persistable():
     record = adj.Verdict(supports=False, reason="wrong district").to_record()
     assert json.loads(json.dumps(record)) == record
     assert record["reason"] == "wrong district"
+
+
+# --- what the agent loop collects per tool call --------------------------------
+
+
+def _collect(monkeypatch, tool_name, args, verdict='{"supports": true, "reason": "ok"}'):
+    calls = []
+
+    async def _reply_with(messages, **kwargs):
+        calls.append(messages[1]["content"])
+        return _reply(verdict)
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _reply_with)
+    result = _run(adj.collect_roster_adjudications(tool_name=tool_name, args=args, race_id="ne-house-02-2026"))
+    return result, calls
+
+
+def test_non_roster_tools_cost_nothing(monkeypatch):
+    """Every editing call passes through the collector; only roster ones may spend."""
+    result, calls = _collect(monkeypatch, "set_issue_stance", {"candidate_name": "X", "stance": "..."})
+    assert result == {}
+    assert calls == []
+
+
+def test_add_candidate_adjudicates_membership(monkeypatch):
+    result, calls = _collect(monkeypatch, "add_candidate", {"name": "Jane Roe", "roster_sources": [_source()]})
+    assert set(result) == {adj.Claim.MEMBERSHIP}
+    assert result[adj.Claim.MEMBERSHIP][_source()["url"]]["supports"] is True
+    assert len(calls) == 1
+
+
+def test_finalize_roster_adjudicates_completeness(monkeypatch):
+    result, _ = _collect(monkeypatch, "finalize_roster", {"completeness_sources": [_source()]})
+    assert set(result) == {adj.Claim.COMPLETENESS}
+
+
+def test_remove_candidate_claim_follows_the_flag(monkeypatch):
+    """The same sources argue a different claim depending on why removal was requested."""
+    omission, _ = _collect(monkeypatch, "remove_candidate", {"name": "X", "not_on_roster": True, "sources": [_source()]})
+    assert set(omission) == {adj.Claim.OMISSION}
+
+    wrong, _ = _collect(monkeypatch, "remove_candidate", {"name": "X", "wrong_contest": True, "sources": [_source()]})
+    assert set(wrong) == {adj.Claim.WRONG_CONTEST}
+
+
+def test_plain_removal_is_judged_on_its_reason_not_its_sources(monkeypatch):
+    """A withdrawal is argued in prose; there is no source object to grade."""
+    result, calls = _collect(monkeypatch, "remove_candidate", {"name": "X", "reason": "Withdrew on June 2, 2026."})
+    assert set(result) == {adj.Claim.WITHDRAWAL}
+    assert result[adj.Claim.WITHDRAWAL][""]["supports"] is True
+    assert "Withdrew on June 2, 2026." in calls[0]
+
+
+def test_removal_with_no_reason_asks_nothing(monkeypatch):
+    result, calls = _collect(monkeypatch, "remove_candidate", {"name": "X"})
+    assert result == {}
+    assert calls == []
+
+
+def test_empty_source_list_asks_nothing(monkeypatch):
+    """Structural gates already reject this; no reason to pay a model to agree."""
+    result, calls = _collect(monkeypatch, "add_candidate", {"name": "X", "roster_sources": []})
+    assert result == {}
+    assert calls == []
+
+
+def test_provider_failure_yields_blocking_verdicts_not_absence(monkeypatch):
+    """Fail-closed must produce a recorded refusal the handler can surface, not silence."""
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("quota exhausted")
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _boom)
+    result = _run(
+        adj.collect_roster_adjudications(
+            tool_name="add_candidate",
+            args={"name": "Jane Roe", "roster_sources": [_source()]},
+            race_id="ne-house-02-2026",
+        )
+    )
+    record = result[adj.Claim.MEMBERSHIP][_source()["url"]]
+    assert record["supports"] is False
+    assert record["unavailable"] is True

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -50,20 +50,27 @@ def test_get_db_falls_back_to_new_firestore_client_when_shared_db_is_none(monkey
 # ---------------------------------------------------------------------------
 
 
-def test_get_gcs_returns_client_on_success(monkeypatch):
+def test_get_gcs_delegates_to_the_shared_factory(monkeypatch):
+    """The worker no longer builds its own client.
+
+    Construction and its failure modes (missing library, bad credentials,
+    build-once memoization) are covered in tests/test_gcs_client.py, which is
+    where that code now lives. What matters here is that the worker asks the
+    shared factory instead of constructing a sixth independent client.
+    """
+    from pipeline_client.backend import gcs_client
+
     fake_client = MagicMock()
-    fake_storage_module = types.SimpleNamespace(Client=lambda: fake_client)
-    monkeypatch.setitem(__import__("sys").modules, "google.cloud.storage", fake_storage_module)
+    monkeypatch.setattr(gcs_client, "get_gcs_client", lambda: fake_client)
 
     assert worker._get_gcs() is fake_client
 
 
-def test_get_gcs_returns_none_and_logs_warning_on_exception(monkeypatch):
-    def exploding_client():
-        raise RuntimeError("no credentials")
+def test_get_gcs_propagates_factory_unavailability(monkeypatch):
+    """A None from the factory must reach the caller — every call site branches on it."""
+    from pipeline_client.backend import gcs_client
 
-    fake_storage_module = types.SimpleNamespace(Client=exploding_client)
-    monkeypatch.setitem(__import__("sys").modules, "google.cloud.storage", fake_storage_module)
+    monkeypatch.setattr(gcs_client, "get_gcs_client", lambda: None)
 
     assert worker._get_gcs() is None
 

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -155,10 +155,8 @@
           class="mr-1.5 text-[10px] font-bold uppercase tracking-wider text-content-subtle"
           >Research review</span
         >
-        <strong class="text-content">{race.validation_grade.score}/100</strong>
-        — methodology, sourcing, and bias checks passed the AI review.<ReviewScoreInfo
-          panelId={`desktop-review-score-info-${race.id}`}
-        />
+        <strong class="text-content">{race.validation_grade.score}/100</strong
+        ><ReviewScoreInfo panelId={`desktop-review-score-info-${race.id}`} />
       </div>
     </div>
   {/if}

--- a/web/src/lib/components/compare/MobileCandidateComparison.svelte
+++ b/web/src/lib/components/compare/MobileCandidateComparison.svelte
@@ -72,7 +72,7 @@
         <strong class="text-content">Research review:</strong>
         {race.validation_grade.score}/100<ReviewScoreInfo
           panelId={`mobile-review-score-info-${race.id}`}
-        /> after methodology, sourcing, and bias checks.
+        />
       </div>
     </div>
   {/if}


### PR DESCRIPTION
Three independent changes, folded into one PR to keep the count down.

## 1. Resolve roster evidence judgments in the agent loop

The adjudicator landed in #249 but nothing called it. Wiring it meant settling *where* the call happens.

The editing handlers are synchronous closures with ~9 production and ~90 test call sites. Making them async to fit a network call would have been a far larger change than the judgment warrants. Instead the agent loop resolves judgments before dispatch and injects finished verdicts under `_adjudications`, exactly as it already injects `_research_trace`. Handlers stay synchronous, the fixture replay harness keeps working, no phase or test signature changes.

`collect_roster_adjudications` maps each roster tool to the claims its arguments are offered in support of — `add_candidate` and `set_candidate_roster_sources` argue membership, `finalize_roster` argues completeness, `remove_candidate` argues omission or wrong-contest depending on which flag is set. A plain withdrawal has no source object to grade, so it is judged on its reason prose. Non-roster tools collect nothing and cost nothing.

Handler-side helpers read those verdicts, treat a missing verdict as a **block** rather than an approval, and record the verdict onto the stored source so a published draft carries why each source was accepted.

**The four gates still run their existing checks.** Flipping them over needs the test-corpus migration, which is its own change so a regression stays attributable.

## 2. Build the GCS client in one place

Six modules constructed their own `storage.Client()`. `race_manager` — the central production race-state service — got its from `backend/main.py`, the local debug FastAPI app CLAUDE.md marks "not production".

The import is lazy per this project's circular-dependency convention, so it would not have failed at startup. It would have failed the first time a run needed GCS, part-way through, in a deployment that never meant to import a web framework. `handlers/agent.py` already carried a comment about avoiding that import, so the hazard had been noticed and worked around once locally.

`backend/gcs_client.py` now owns construction. A guard test walks `pipeline_client` and fails if anything other than `run.py` imports the debug app again.

## 3. Drop review-score prose that duplicates its own tooltip

The comparison headers spelled out "methodology, sourcing, and bias checks" next to a `ReviewScoreInfo` icon whose panel already explains the score in more detail. Mobile carried the same sentence and is cleaned up with it so the two layouts agree.

## Testing

1052 pipeline + 93 admin + 40 races-api passing. Frontend: lint clean, `svelte-check` 0 errors across 701 files, 173 unit tests.

Two test-quality notes:
- The import-layering guards parse with `ast` rather than grepping — these docstrings name `backend.main` to explain the rule, and a text search flagged the explanation as the violation.
- The worker's client-construction tests moved to `tests/test_gcs_client.py` where that code now lives, rather than being deleted; the worker keeps tests that it delegates.

## Not included

`PhaseContext`, the admin-test rewrite, and the `phases/__init__` shim deletion remain outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)