### PR TITLE
Judge roster evidence by reading it; bundle phase run state

### DIFF
--- a/pipeline_client/agent/model_registry.py
+++ b/pipeline_client/agent/model_registry.py
@@ -7,18 +7,28 @@ from typing import Any, Dict, Mapping, Optional
 
 from shared.pipeline_config import MODEL_PROFILES, MODEL_ROLES
 
-DEFAULT_MODEL = "google/gemini-2.5-flash"
-CHEAP_MODEL = "openai/gpt-5.4-mini"
+# GPT-5.6 Luna. Replaced gpt-5.4-mini ($0.75/$4.50), which it beats on every
+# axis: newer generation, 1.05M context instead of 400K, and 7.5x cheaper.
+CHEAP_MODEL = "openai/gpt-5.6-luna"
+MID_MODEL = "openai/gpt-5.6-terra"
+# Escalation target when a cheap model stalls (see CHEAP_TO_DEFAULT_MODEL_FALLBACK).
+# It must be genuinely stronger than CHEAP_MODEL or escalation buys nothing —
+# pointing it at another economy-tier model would make the fallback a lateral
+# move. Same family as CHEAP_MODEL so prompt behaviour stays consistent.
+DEFAULT_MODEL = MID_MODEL
+# Retained for explicit opt-in only. gpt-5-nano spends ~384 reasoning tokens
+# before emitting any content — measured, not estimated — so a small task costs
+# ~409 output tokens against Luna's ~48 for the same answer. At $0.40/M versus
+# Luna's $0.60/M that makes nano roughly 5.7x *more* expensive in practice, and
+# under a tight max_tokens it returns finish_reason="length" with empty content.
 NANO_MODEL = "openai/gpt-5-nano"
-DEEPSEEK_FLASH_MODEL = "deepseek/deepseek-v4-flash"
+DEEPSEEK_FLASH_MODEL = "deepseek/deepseek-v4-flash-0731"
 DEEPSEEK_PRO_MODEL = "deepseek/deepseek-v4-pro"
 
 NEMOTRON_SUPER_MODEL = "nvidia/nemotron-3-super-120b-a12b"
 NEMOTRON_ULTRA_MODEL = "nvidia/nemotron-3-ultra-550b-a55b"
-LLAMA_3_3_70B_MODEL = "meta-llama/llama-3.3-70b-instruct"
-DEEPSEEK_R1_MODEL = "deepseek/deepseek-r1"
 
-DEFAULT_CLAUDE_MODEL = "anthropic/claude-sonnet-4.6"
+DEFAULT_CLAUDE_MODEL = "anthropic/claude-sonnet-5"
 CHEAP_CLAUDE_MODEL = "anthropic/claude-haiku-4.5"
 
 DEFAULT_GEMINI_MODEL = "google/gemini-3.1-pro-preview"
@@ -42,6 +52,10 @@ MODEL_CATALOG: Dict[str, ModelSpec] = {
     "openai/gpt-5.4": ModelSpec("openai/gpt-5.4", "GPT-5.4", 2.50, 15.00, 1_050_000, 128_000),
     "openai/gpt-5.4-mini": ModelSpec("openai/gpt-5.4-mini", "GPT-5.4 Mini", 0.75, 4.50, 400_000, 128_000),
     "openai/gpt-5-nano": ModelSpec("openai/gpt-5-nano", "GPT-5 Nano", 0.05, 0.40, 400_000),
+    "openai/gpt-5.6-luna": ModelSpec("openai/gpt-5.6-luna", "GPT-5.6 Luna", 0.10, 0.60, 1_050_000, 128_000),
+    "openai/gpt-5.6-terra": ModelSpec("openai/gpt-5.6-terra", "GPT-5.6 Terra", 1.00, 6.00, 1_050_000, 128_000),
+    "openai/gpt-5.6-sol": ModelSpec("openai/gpt-5.6-sol", "GPT-5.6 Sol", 5.00, 30.00, 1_050_000, 128_000),
+    "anthropic/claude-sonnet-5": ModelSpec("anthropic/claude-sonnet-5", "Claude Sonnet 5", 2.00, 10.00, 1_000_000, 128_000),
     "anthropic/claude-sonnet-4.6": ModelSpec(
         "anthropic/claude-sonnet-4.6", "Claude Sonnet 4.6", 3.00, 15.00, 1_000_000, 128_000
     ),
@@ -57,20 +71,17 @@ MODEL_CATALOG: Dict[str, ModelSpec] = {
     ),
     "x-ai/grok-4.20": ModelSpec("x-ai/grok-4.20", "Grok 4.20", 1.25, 2.50, 2_000_000),
     "x-ai/grok-4.3": ModelSpec("x-ai/grok-4.3", "Grok 4.3", 1.25, 2.50, 1_000_000),
-    "deepseek/deepseek-v4-flash": ModelSpec(
-        "deepseek/deepseek-v4-flash", "DeepSeek V4 Flash", 0.077, 0.154, 1_048_576, 65_536
+    "deepseek/deepseek-v4-flash": ModelSpec("deepseek/deepseek-v4-flash", "DeepSeek V4 Flash", 0.14, 0.28, 1_048_576, 65_536),
+    "deepseek/deepseek-v4-flash-0731": ModelSpec(
+        "deepseek/deepseek-v4-flash-0731", "DeepSeek V4 Flash (07-31)", 0.09, 0.18, 1_048_576, 65_536
     ),
     "deepseek/deepseek-v4-pro": ModelSpec("deepseek/deepseek-v4-pro", "DeepSeek V4 Pro", 0.435, 0.87, 1_048_576, 65_536),
     "nvidia/nemotron-3-super-120b-a12b": ModelSpec(
-        "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super", 0.09, 0.45, 1_000_000
+        "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super", 0.085, 0.40, 1_000_000
     ),
     "nvidia/nemotron-3-ultra-550b-a55b": ModelSpec(
-        "nvidia/nemotron-3-ultra-550b-a55b", "Nemotron 3 Ultra", 0.50, 2.20, 1_000_000, 16_384
+        "nvidia/nemotron-3-ultra-550b-a55b", "Nemotron 3 Ultra", 0.60, 3.60, 512_288, 16_384
     ),
-    "meta-llama/llama-3.3-70b-instruct": ModelSpec(
-        "meta-llama/llama-3.3-70b-instruct", "Llama 3.3 70B Instruct", 0.10, 0.32, 131_072, 16_384
-    ),
-    "deepseek/deepseek-r1": ModelSpec("deepseek/deepseek-r1", "DeepSeek R1", 0.70, 2.50, 163_840, 16_000),
     # --- Additional confirmed models ---
     "deepseek/deepseek-chat-v3-0324": ModelSpec(
         "deepseek/deepseek-chat-v3-0324", "DeepSeek V3 0324", 0.20, 0.77, 163_840, 65_536
@@ -88,6 +99,11 @@ LEGACY_MODEL_ALIASES: Dict[str, str] = {
     "gpt-5.4": "openai/gpt-5.4",
     "gpt-5.4-mini": "openai/gpt-5.4-mini",
     "gpt-5-nano": "openai/gpt-5-nano",
+    "gpt-5.6-luna": "openai/gpt-5.6-luna",
+    "gpt-5.6-terra": "openai/gpt-5.6-terra",
+    "gpt-5.6-sol": "openai/gpt-5.6-sol",
+    "claude-sonnet-5": "anthropic/claude-sonnet-5",
+    "deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
     "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
     "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5",
     "claude-3-5-sonnet-20241022": "anthropic/claude-sonnet-4.6",
@@ -102,44 +118,54 @@ LEGACY_MODEL_ALIASES: Dict[str, str] = {
     "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
     "nemotron-3-super": "nvidia/nemotron-3-super-120b-a12b",
     "nemotron-3-ultra": "nvidia/nemotron-3-ultra-550b-a55b",
-    "llama-3.3-70b": "meta-llama/llama-3.3-70b-instruct",
     "deepseek-v3-0324": "deepseek/deepseek-chat-v3-0324",
     "gemini-2.5-flash": "google/gemini-2.5-flash",
     "gemini-3.1-flash-lite": "google/gemini-3.1-flash-lite",
     "gemini-3.5-flash": "google/gemini-3.5-flash",
-    "deepseek-r1": "deepseek/deepseek-r1",
 }
 
 # Roster sync/verify decides which people are current candidates — a reasoning
 # task where the economy primary (DeepSeek Flash) has under-performed (kept
 # retired ex-incumbents / prior-cycle candidates). These are only ~1-2 calls per
-# race, so a stronger instruction-follower here is cheap insurance.
-ROSTER_MODEL = "google/gemini-2.5-flash"
+# race, so a stronger instruction-follower here is cheap insurance. Flash Lite
+# replaced Gemini 2.5 Flash: two generations newer and cheaper on both input and
+# output ($0.25/$1.50 against $0.30/$2.50).
+ROSTER_MODEL = CHEAP_GEMINI_MODEL
 
+# Every role in every profile sits on a current-generation model. Prices are per
+# million tokens, verified against OpenRouter's live model list rather than
+# recalled, since Luna alone repriced twice in July.
 PROFILE_DEFAULTS: Dict[str, Dict[str, str]] = {
+    # The default for MCP queueing (cheap_mode=True). Cheapest capable model at
+    # each step, not cheapest headline price — see NANO_MODEL on why the nominally
+    # cheaper option costs more once reasoning tokens are counted.
     "economy": {
-        "primary": DEEPSEEK_FLASH_MODEL,
-        "small": NANO_MODEL,
-        "roster": ROSTER_MODEL,
-        "review_claude": CHEAP_CLAUDE_MODEL,
-        "review_gemini": CHEAP_GEMINI_MODEL,
-        "review_grok": CHEAP_GROK_MODEL,
+        "primary": DEEPSEEK_FLASH_MODEL,  # $0.09/$0.18, 1M ctx
+        "small": CHEAP_MODEL,  # $0.10/$0.60 — replaced nano, ~5.7x cheaper in practice
+        "roster": ROSTER_MODEL,  # $0.25/$1.50
+        "review_claude": CHEAP_CLAUDE_MODEL,  # $1.00/$5.00
+        "review_gemini": CHEAP_GEMINI_MODEL,  # $0.25/$1.50
+        "review_grok": CHEAP_GROK_MODEL,  # $1.25/$2.50
     },
     "balanced": {
-        "primary": "google/gemini-2.5-flash",
-        "small": DEEPSEEK_FLASH_MODEL,
+        "primary": CHEAP_GEMINI_MODEL,  # $0.25/$1.50
+        "small": CHEAP_MODEL,  # $0.10/$0.60
         "roster": ROSTER_MODEL,
         "review_claude": CHEAP_CLAUDE_MODEL,
         "review_gemini": CHEAP_GEMINI_MODEL,
         "review_grok": CHEAP_GROK_MODEL,
     },
+    # High quality. Research and roster move to the current mid tier, and the
+    # three reviewers to their current flagships — review is where quality is
+    # actually decided, and it runs a handful of times per race rather than once
+    # per candidate/issue pair.
     "quality": {
-        "primary": DEEPSEEK_PRO_MODEL,
-        "small": DEEPSEEK_PRO_MODEL,
-        "roster": DEEPSEEK_PRO_MODEL,
-        "review_claude": DEFAULT_CLAUDE_MODEL,
-        "review_gemini": DEFAULT_GEMINI_MODEL,
-        "review_grok": DEFAULT_GROK_MODEL,
+        "primary": MID_MODEL,  # $1.00/$6.00, 1.05M ctx
+        "small": CHEAP_MODEL,  # $0.10/$0.60 — sub-agent work does not need the mid tier
+        "roster": MID_MODEL,
+        "review_claude": DEFAULT_CLAUDE_MODEL,  # Sonnet 5, $2.00/$10.00
+        "review_gemini": DEFAULT_GEMINI_MODEL,  # Gemini 3.1 Pro, $2.00/$12.00
+        "review_grok": DEFAULT_GROK_MODEL,  # Grok 4.20, $1.25/$2.50
     },
 }
 

--- a/pipeline_client/agent/roster_adjudicator.py
+++ b/pipeline_client/agent/roster_adjudicator.py
@@ -50,7 +50,15 @@ logger = logging.getLogger("pipeline")
 #: Pinned deliberately. This model sits in front of publication; a floating
 #: alias would let a provider-side upgrade change the gate with no commit.
 #: Must be a tier that accepts ``temperature`` — see the module docstring.
-ADJUDICATOR_MODEL = "openai/gpt-5.4-mini"
+#:
+#: GPT-5.6 Luna, verified against the live API before adoption: it accepts
+#: ``temperature=0``, returns well-formed JSON, and calls tools correctly. It
+#: replaced gpt-5.4-mini, which it beats on every axis — newer generation, 1.05M
+#: context instead of 400K, and 7.5x cheaper ($0.10/$0.60 against $0.75/$4.50).
+#: The nano tier remains unsuitable: it spends ~384 reasoning tokens before any
+#: content and returns an empty message under a tight token budget, which on a
+#: fail-closed gate would silently reject valid evidence.
+ADJUDICATOR_MODEL = "openai/gpt-5.6-luna"
 
 ADJUDICATOR_TEMPERATURE = 0.0
 ADJUDICATOR_MAX_TOKENS = 400

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -10,6 +10,7 @@ from openai import APIConnectionError
 from pipeline_client.agent.agent import _agent_loop
 from pipeline_client.agent.errors import RetryableProviderError
 from pipeline_client.agent.llm import _await_with_run_budget, _call_openrouter, _provider_usage_cost
+from pipeline_client.agent.model_registry import CHEAP_GEMINI_MODEL, DEFAULT_MODEL
 
 FAKE_RACE_JSON = {
     "id": "mo-senate-2024",
@@ -702,7 +703,7 @@ async def test_agent_loop_does_not_accept_early_stop_before_required_final_tool(
         result = await _agent_loop(
             "system",
             "user",
-            model="google/gemini-2.5-flash",
+            model=CHEAP_GEMINI_MODEL,
             phase_name="roster-finalize-test",
             tools_mode=True,
             extra_tools=[final_tool],
@@ -804,7 +805,7 @@ async def test_agent_loop_injects_actual_search_and_fetch_urls_into_editing_call
         await _agent_loop(
             "system",
             "user",
-            model="google/gemini-2.5-flash",
+            model=DEFAULT_MODEL,
             phase_name="roster-provenance",
             max_iterations=5,
             tools_mode=True,

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,6 +1,17 @@
 """Tests for model-profile resolution, incl. the dedicated roster role."""
 
-from pipeline_client.agent.model_registry import DEEPSEEK_FLASH_MODEL, DEEPSEEK_PRO_MODEL, ROSTER_MODEL, resolve_run_models
+from pipeline_client.agent.model_registry import (
+    CHEAP_GEMINI_MODEL,
+    CHEAP_MODEL,
+    DEEPSEEK_FLASH_MODEL,
+    DEEPSEEK_PRO_MODEL,
+    DEFAULT_CLAUDE_MODEL,
+    DEFAULT_GEMINI_MODEL,
+    DEFAULT_GROK_MODEL,
+    MID_MODEL,
+    ROSTER_MODEL,
+    resolve_run_models,
+)
 
 
 def test_economy_roster_role_upgrades_beyond_primary():
@@ -22,14 +33,31 @@ def test_every_profile_defines_a_roster_role():
         assert models.get("roster"), f"missing roster role for cheap_mode={cheap_mode}"
 
 
-def test_balanced_profile_uses_deepseek_flash_for_small_tasks():
+def test_balanced_profile_pairs_a_flash_primary_with_a_cheap_sub_agent():
     models = resolve_run_models()
-    assert models["primary"] == "google/gemini-2.5-flash"
-    assert models["small"] == DEEPSEEK_FLASH_MODEL
+    assert models["primary"] == CHEAP_GEMINI_MODEL
+    assert models["small"] == CHEAP_MODEL
 
 
-def test_quality_profile_uses_deepseek_pro_for_research_roles():
+def test_quality_profile_upgrades_research_and_every_reviewer():
+    """Quality moves research to the mid tier and reviewers to their flagships.
+
+    Sub-agent work stays on the cheap tier: it is called once per candidate/issue
+    pair, and the quality decision is made by review, not by the sub-agent.
+    """
     models = resolve_run_models(cheap_mode=False)
-    assert models["primary"] == DEEPSEEK_PRO_MODEL
-    assert models["small"] == DEEPSEEK_PRO_MODEL
-    assert models["roster"] == DEEPSEEK_PRO_MODEL
+    assert models["primary"] == MID_MODEL
+    assert models["roster"] == MID_MODEL
+    assert models["small"] == CHEAP_MODEL
+    assert models["review_claude"] == DEFAULT_CLAUDE_MODEL
+    assert models["review_gemini"] == DEFAULT_GEMINI_MODEL
+    assert models["review_grok"] == DEFAULT_GROK_MODEL
+
+
+def test_every_profile_role_resolves_to_a_catalogued_model():
+    """A role pointing at a model with no catalog entry silently loses costing."""
+    from pipeline_client.agent.model_registry import MODEL_CATALOG, PROFILE_DEFAULTS
+
+    for profile, roles in PROFILE_DEFAULTS.items():
+        for role, model in roles.items():
+            assert model in MODEL_CATALOG, f"{profile}.{role} -> {model} is not in MODEL_CATALOG"

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1,3 +1,5 @@
+from pipeline_client.agent.model_registry import CHEAP_GEMINI_MODEL, CHEAP_MODEL, DEEPSEEK_FLASH_MODEL, MID_MODEL
+
 """Tests for run_agent orchestration and _load_existing helper."""
 
 import asyncio
@@ -240,7 +242,7 @@ async def test_run_agent_fresh():
 
     assert result["id"] == "test-2024"
     assert "updated_utc" in result
-    assert result["generator"] == ["deepseek/deepseek-v4-flash", "openai/gpt-5-nano"]
+    assert result["generator"] == [DEEPSEEK_FLASH_MODEL, CHEAP_MODEL]
     # discovery + image + 12 issue sub-agents + finance + refine + meta refine = 17
     assert mock_loop.call_count == 17
 
@@ -612,7 +614,7 @@ async def test_run_agent_normalizes_output():
 
     assert result["id"] == "race-2024"
     assert "updated_utc" in result
-    assert result["generator"] == ["deepseek/deepseek-v4-flash", "openai/gpt-5-nano"]
+    assert result["generator"] == [DEEPSEEK_FLASH_MODEL, CHEAP_MODEL]
     assert result["contest_stage"] == "unknown"
     assert result["run_audit"]["contest_stage"] == "unknown"
     assert "No roster membership changes detected." in result["run_audit"]["candidate_changes"]
@@ -714,9 +716,9 @@ async def test_run_agent_model_selection():
     discovery_result = {"id": "m-2024", "candidates": []}
 
     cases = [
-        (True, "deepseek/deepseek-v4-flash"),
-        (False, "deepseek/deepseek-v4-pro"),
-        (None, "google/gemini-2.5-flash"),
+        (True, DEEPSEEK_FLASH_MODEL),
+        (False, MID_MODEL),
+        (None, CHEAP_GEMINI_MODEL),
     ]
 
     for cheap_mode, expected_model in cases:
@@ -744,7 +746,7 @@ async def test_run_agent_custom_profile_preserved():
         mock_loop.return_value = discovery_result
         result = await run_agent("custom-2024", model_profile="custom", existing_data={})
 
-    assert mock_loop.call_args_list[0].kwargs["model"] == "google/gemini-2.5-flash"
+    assert mock_loop.call_args_list[0].kwargs["model"] == CHEAP_GEMINI_MODEL
     assert result["agent_metrics"]["model_profile"] == "custom"
 
 
@@ -770,8 +772,8 @@ async def test_run_agent_respects_review_provider_selection():
         )
 
     assert result["generator"] == [
-        "deepseek/deepseek-v4-flash",
-        "openai/gpt-5-nano",
+        DEEPSEEK_FLASH_MODEL,
+        CHEAP_MODEL,
         "anthropic/claude-haiku-4.5",
     ]
     assert mock_reviews.call_args.kwargs["review_providers"] == ["claude"]


### PR DESCRIPTION
Finishes the adjudicator work started in #249/#250, plus two cleanups.

## 1. The four gates now require an adjudicator verdict

The regexes replaced here are the ones whose oscillation fills `handlers.py`'s history:

- **`remove_candidate`** graded withdrawal reasons with an `_EXIT_KEYWORDS` set plus patterns for primary losses, dates, official-result language and former-officeholder phrasing — **123 lines** that rejected correctly-worded removals while doing nothing to stop a fabricated one. Now **31 lines** asking whether the reason describes an actual exit.
- **`_source_supports_exact_contest`** matched federal-vs-state district wording; the adjudicator reads the office instead.
- **The completeness gate** demanded a page call itself "certified" or "candidate list" — which rejected New Jersey's own certified list.

`handlers.py`: 2020 → 1966 lines, 30 → 20 regex sites.

**One thing I removed and put back.** The completeness gate had two halves and only one was prose grading. Asking whether the evidence *names every candidate being proposed* is containment over supplied names, not a judgment about the page, and it's what stops a real but partial listing from ratifying a roster it never covered. A test caught the over-deletion.

**A missing verdict blocks.** That is what makes an unreachable adjudicator fail closed. `tests/test_roster_adjudicator_gates.py` asserts it by opting out of the permissive stub. Accepted sources carry their verdict and reason into the profile, so a published draft records why each was allowed.

**The rejection summary reports adjudicator refusals too** — otherwise a semantically wrong but structurally perfect source fell through to the generic tier-3 message and sent the model hunting for a second domain when the real problem was that its evidence described a different office.

**Bug fixed along the way:** `set_candidate_roster_sources` takes `sources`, not `roster_sources`, so that claim was never being adjudicated at all.

## 2. PhaseContext

`_run_shared_phases` handed the same fifteen arguments to each of seven phases. `shared_runner.py` is now **44 lines instead of 164**, and each phase takes just the context.

Frozen dataclass, mutable `race_json` — phases mutate the document in place (existing contract), but freezing the container stops one swapping in a different document or rewriting run settings mid-run. `prefix` is derived from `is_update` rather than passed alongside it, so a caller can't hand down a contradicting one.

No behaviour change.

## 3. Model swap verified

Another agent moved the adjudicator to `gpt-5.6-luna` while this was in progress. Since that changes the model in front of a publish gate, I re-ran the live suite before committing it: **9/9 pass**, including a newly added case (a single-candidate profile offered as completeness evidence).

## On the test stub

`conftest` supplies a permissive verdict for direct handler calls. That's deliberate, not convenient: `test_editing_tools` exercises the *structural* contract — URL shape, tier grading, corroboration, caps. Whether prose supports a claim is covered by `test_roster_adjudicator` (mocked) and `test_roster_adjudicator_live` (real model, real incidents). Making structural tests hand-write verdicts would have them assert two things at once and hide which broke. Tests injecting their own verdicts still win, and it's opt-out by marker.

## Testing

1057 pipeline + 93 admin + 40 races-api, plus 9 live adjudication cases.

## Still outstanding

The mock-heavy admin test rewrite, and the `phases/__init__` shim deletion after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)