### PR TITLE
Judge roster evidence by reading it; bundle phase run state

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -22,6 +22,7 @@ from pipeline_client.agent.images import _is_valid_image_url
 from pipeline_client.agent.polling_quality import polling_semantic_problem
 from pipeline_client.agent.prompts import CANONICAL_ISSUES
 from pipeline_client.agent.roster import ROSTER_CAP
+from pipeline_client.agent.roster_adjudicator import Claim as _Claim
 from pipeline_client.agent.roster_contract import (
     COMPLETENESS_SOURCE_CLASSES,
     COMPLETENESS_TIERS,
@@ -37,6 +38,12 @@ from pipeline_client.agent.roster_contract import (
 from pipeline_client.agent.source_types import normalize_source_type
 
 _CANONICAL_ISSUE_SET = set(CANONICAL_ISSUES)
+
+ADJ_MEMBERSHIP = _Claim.MEMBERSHIP
+ADJ_OMISSION = _Claim.OMISSION
+ADJ_WRONG_CONTEST = _Claim.WRONG_CONTEST
+ADJ_COMPLETENESS = _Claim.COMPLETENESS
+ADJ_WITHDRAWAL = _Claim.WITHDRAWAL
 
 # The roster-evidence contract lives in roster_contract so that the prompt text
 # the model reads and the checks enforced here cannot drift apart. Do not
@@ -193,9 +200,7 @@ def _source_proves_different_contest(source: Dict[str, Any], *, candidate_name: 
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         return False
     text = _roster_source_text(source)
-    if not _source_names_candidate(text, candidate_name):
-        return False
-    return _source_is_current_cycle(source, race_id=race_id, text=text)
+    return _source_names_candidate(text, candidate_name)
 
 
 def _source_omits_candidate_from_roster(
@@ -413,8 +418,6 @@ def _roster_source_rejection_reason(source: Dict[str, Any], *, candidate_name: s
         return "source needs a title"
     if not source.get("evidence"):
         return "source needs an 'evidence' (or 'text') quote naming the candidate and contest"
-    if not _source_supports_exact_contest(source, race_id=race_id):
-        return "evidence does not name this exact federal contest and district"
     name_words = re.findall(r"[a-z0-9]+", candidate_name.lower())
     evidence_text = f"{source.get('title', '')} {source.get('evidence', '')}".lower()
     if not name_words or not all(word in evidence_text for word in name_words):
@@ -444,6 +447,8 @@ def _qualifying_candidate_addition_sources(
     candidate_name: str,
     race_id: str,
     require_corroboration: bool = True,
+    args: Dict[str, Any] | None = None,
+    claim: str = ADJ_MEMBERSHIP,
 ) -> list[Dict[str, Any]]:
     """Return qualifying sources, enforcing corroboration for non-authoritative snippets.
 
@@ -458,19 +463,40 @@ def _qualifying_candidate_addition_sources(
         for source in normalized
         if _source_supports_candidate_addition(source, candidate_name=candidate_name, race_id=race_id)
     ]
+    # Structure is settled above; whether the text actually names this candidate
+    # in this exact contest is a reading judgment. ``args`` is None only for
+    # direct callers outside the agent loop.
+    if args is not None:
+        qualifying = [source for source in qualifying if _adjudicator_supports(args, claim, source.get("url"))]
     if require_corroboration and lacks_tier3_corroboration(qualifying):
         return []
     return qualifying
 
 
-def _roster_source_rejection_summary(sources: Any, *, candidate_name: str, race_id: str) -> str:
-    """Summarize per-source rejection reasons for a blocked roster edit."""
+def _roster_source_rejection_summary(
+    sources: Any,
+    *,
+    candidate_name: str,
+    race_id: str,
+    args: Dict[str, Any] | None = None,
+    claim: str = ADJ_MEMBERSHIP,
+) -> str:
+    """Summarize per-source rejection reasons for a blocked roster edit.
+
+    Adjudicator refusals are reported alongside structural ones. Without that a
+    source that is structurally perfect but semantically wrong falls through to
+    the generic tier-3 corroboration message, which sends the model hunting for
+    a second domain when the real problem was that its evidence described a
+    different office.
+    """
     normalized = [src for src in (_normalize_roster_source(source, race_id=race_id) for source in sources or []) if src]
     if not normalized:
         return "no usable source objects were supplied"
     reasons = []
     for index, source in enumerate(normalized, start=1):
         reason = _roster_source_rejection_reason(source, candidate_name=candidate_name, race_id=race_id)
+        if reason is None and args is not None and not _adjudicator_supports(args, claim, source.get("url")):
+            reason = _adjudicator_reason(args, claim, source.get("url"))
         if reason:
             reasons.append(f"source {index} ({source.get('url') or 'no url'}): {reason}")
     if not reasons:
@@ -487,6 +513,7 @@ def _roster_completeness_source_rejection_reason(
     race_id: str,
     identity: Dict[str, Any],
     roster_names: list[str] | None = None,
+    args: Dict[str, Any] | None = None,
 ) -> str | None:
     """Validate evidence that describes the roster as a whole, not one member.
 
@@ -507,6 +534,24 @@ def _roster_completeness_source_rejection_reason(
         return "evidence does not name this exact contest and district"
     if source.get("retrieval_status") != "content" or source.get("evidence_tier") not in COMPLETENESS_TIERS:
         return "completeness evidence must come from retrieved page content, not a search snippet"
+    # Whether the page presents the whole field, rather than mentioning a couple
+    # of names in passing, is a reading judgment. The phrase match this replaced
+    # rejected New Jersey's own certified list for not saying "candidate list".
+    if args is not None and not _adjudicator_supports(args, ADJ_COMPLETENESS, source.get("url")):
+        return _adjudicator_reason(args, ADJ_COMPLETENESS, source.get("url"))
+
+    # Structural cross-check, kept deliberately. The prose half of the old gate —
+    # demanding the page call itself "certified"/"candidate list" — is gone,
+    # because it rejected New Jersey's own certified list for wording. This half
+    # is different: it asks whether the evidence actually mentions every
+    # candidate being proposed, which is a containment test over supplied names
+    # rather than a judgment about the page, and it is what stops a real but
+    # partial listing from ratifying a roster it never covered.
+    if roster_names:
+        text = _roster_source_text(source)
+        missing = [name for name in roster_names if not _source_names_candidate(text, name)]
+        if missing:
+            return f"completeness evidence does not name every proposed candidate; missing: {', '.join(missing)}"
 
     text = _roster_source_text(source)
     # Real election authorities do not use one fixed phrase. New Jersey publishes
@@ -519,16 +564,6 @@ def _roster_completeness_source_rejection_reason(
     # of the kind that rejected New Jersey's own certified list and Ballotpedia's
     # standard full-field sentence. Phrasing stays a valid alternative for lists
     # that assert completeness without enumerating inline.
-    enumerates_full_roster = bool(roster_names) and all(_source_names_candidate(text, name) for name in roster_names)
-    if not enumerates_full_roster and not re.search(
-        r"\b(?:qualified|certified|official list|official ballot|candidate list|list of candidates"
-        r"|candidates? running|vote for one)\b",
-        text,
-    ):
-        return (
-            "evidence neither names every candidate on the proposed roster nor identifies itself as a "
-            "qualified, certified, ballot, or complete candidate list"
-        )
 
     primary_status = str(identity.get("primary_status") or "")
     if "special" in primary_status.casefold():
@@ -732,12 +767,16 @@ def _make_editing_handlers(
             race_id=race_id,
             research_trace=args.get("_research_trace"),
         )
-        roster_sources = _qualifying_candidate_addition_sources(supplied_sources, candidate_name=name, race_id=race_id)
+        roster_sources = _qualifying_candidate_addition_sources(
+            supplied_sources, candidate_name=name, race_id=race_id, args=args
+        )
+        for source in roster_sources:
+            _record_verdict_on_source(source, args, ADJ_MEMBERSHIP)
         if not roster_sources:
             if isinstance(args.get("_research_trace"), dict) and not supplied_sources:
                 detail = "none of the cited URLs appeared in this run's actual search/fetch trace"
             else:
-                detail = _roster_source_rejection_summary(supplied_sources, candidate_name=name, race_id=race_id)
+                detail = _roster_source_rejection_summary(supplied_sources, candidate_name=name, race_id=race_id, args=args)
             log("warning", f"    add_candidate('{name}') BLOCKED: {detail}")
             return (
                 f"Blocked adding '{name}': {detail}. "
@@ -822,6 +861,11 @@ def _make_editing_handlers(
                         race_id=race_id,
                         other_roster_names=other_roster_names,
                     )
+                    # Structural check above proves the listing is real and current;
+                    # the adjudicator reads whether it actually enumerates this field
+                    # without the candidate. A blocked or truncated page reads as
+                    # absence to a regex and as nothing to a reader.
+                    and _adjudicator_supports(args, ADJ_OMISSION, source.get("url"))
                 ]
                 if not proof:
                     return (
@@ -837,6 +881,7 @@ def _make_editing_handlers(
                     source
                     for source in normalized_sources
                     if _source_proves_different_contest(source, candidate_name=name, race_id=race_id)
+                    and _adjudicator_supports(args, ADJ_WRONG_CONTEST, source.get("url"))
                 ]
                 if not proof:
                     return (
@@ -864,127 +909,35 @@ def _make_editing_handlers(
                 return f"Removed {label} candidate '{name}' from the active roster."
             return f"Candidate '{name}' not found - no action taken."
 
-        # Guard: reject removals that are clearly data-quality fixes rather than
-        # actual race withdrawals. Withdrawal reasons must mention a concrete
-        # race exit, not merely absence from a page or a generic "lost primary"
-        # phrase that models frequently hallucinate during roster repair.
-        _EXIT_KEYWORDS = {
-            "withdrew",
-            "withdrawal",
-            "dropped out",
-            "drop out",
-            "suspended",
-            "disqualified",
-            "disqualification",
-            "ended campaign",
-            "exited race",
-            "no longer running",
-            "not running",
-            "retired from race",
-        }
-        reason_lower = reason.lower()
-        has_exit_signal = any(kw in reason_lower for kw in _EXIT_KEYWORDS)
-        has_primary_loss_signal = bool(
-            re.search(
-                r"\b(lost|defeated|eliminated|did not advance)\b.{0,80}\b(primary|runoff|convention)\b",
-                reason_lower,
-            )
-            or re.search(
-                r"\b(primary|runoff|convention)\b.{0,80}\b(lost|defeated|eliminated|did not advance)\b",
-                reason_lower,
-            )
-        )
-        has_specific_date = bool(
-            re.search(
-                r"\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|"
-                r"aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2},\s+\d{4}\b",
-                reason_lower,
-            )
-            or re.search(r"\b20\d{2}-\d{2}-\d{2}\b", reason_lower)
-        )
-        has_official_result_signal = bool(
-            re.search(
-                r"\b(official|certified|results?|election authority|secretary of state|board of elections)\b",
-                reason_lower,
-            )
-        )
-        # A retired/departed former officeholder or an explicit prior-cycle
-        # candidate who is not running THIS cycle is a legitimate removal even
-        # without a withdrawal event — they never entered this race. Require a
-        # positive "former"/"prior-cycle" statement AND a "not a current
-        # candidate" signal, so this does not reopen the "merely absent from a
-        # page" hole the guard exists to close.
-        has_former_status_signal = bool(
-            re.search(
-                r"\bformer\s+(u\.?s\.?\s+)?"
-                r"(representative|congress\w*|senator|governor|lieutenant governor|"
-                r"officeholder|member of congress|incumbent)\b",
-                reason_lower,
-            )
-            or re.search(r"\bleft office\b", reason_lower)
-            or re.search(r"\bretired\b.{0,40}\b(20\d{2}|congress|office|house|senate)\b", reason_lower)
-            or re.search(r"\b(prior|previous)[- ]cycle\b", reason_lower)
-        )
-        has_not_current_signal = any(
-            token in reason_lower
-            for token in (
-                "not a candidate",
-                "not a current candidate",
-                "not running",
-                "not seeking",
-                "did not file",
-                "has not filed",
-                "no longer",
-                "not on the ballot",
-            )
-        )
-        has_former_officeholder_signal = has_former_status_signal and has_not_current_signal
-        # Evidence outranks phrasing. The keyword scans below grade English prose,
-        # which reliably rejects correct removals that happen to be worded
-        # differently. When the caller cites a real, current-cycle source that names
-        # this candidate, that citation is the stronger signal — accept it and let
-        # the reason text be prose rather than an incantation.
-        cited_race_id = str(race_json.get("id") or "").strip()
-        observed_cited_sources = _normalize_observed_roster_sources(
-            args.get("sources"), race_id=cited_race_id, research_trace=args.get("_research_trace")
-        )
-        has_cited_evidence = any(
-            _source_proves_different_contest(source, candidate_name=name, race_id=cited_race_id)
-            for source in observed_cited_sources
-        )
-        has_withdrawal_signal = (
-            has_cited_evidence
-            or has_exit_signal
-            or has_former_officeholder_signal
-            # A specific date *or* an explicit official-result citation is enough
-            # corroboration for a primary loss; requiring both rejected reasons like
-            # "Lost the Democratic primary on June 30, 2026." — a specific dated
-            # primary result — just because it didn't also say the word "official".
-            or (has_primary_loss_signal and (has_specific_date or has_official_result_signal))
-        )
+        # Whether a stated reason describes an actual race exit is reading
+        # comprehension. This used to be a keyword scan over the prose — an
+        # _EXIT_KEYWORDS set plus regexes for primary losses, specific dates,
+        # official-result language, and former-officeholder phrasing — and it
+        # reliably rejected correct removals whose wording differed while doing
+        # nothing to stop a model that wanted to fabricate one. The adjudicator
+        # judges the same sentence and reports why in its own words.
+        withdrawal_ok = _adjudicator_supports(args, ADJ_WITHDRAWAL)
 
-        # Special case: structurally invalid entries (e.g. a metadata key like
-        # "updated_utc" accidentally stored as a candidate name) should be
-        # physically deleted rather than marked withdrawn.
+        # Structurally invalid entries (e.g. a metadata key like "updated_utc"
+        # stored as a candidate name) are a data-shape problem, not a claim about
+        # the race, so they are deleted outright without consulting a model.
         is_structural_garbage = bool(_METADATA_KEY_RE.match(name))
 
-        if not has_withdrawal_signal and not is_structural_garbage:
+        if not withdrawal_ok and not is_structural_garbage:
+            detail = _adjudicator_reason(args, ADJ_WITHDRAWAL)
             log(
                 "warning",
-                f"    ⚠️ remove_candidate('{name}') BLOCKED — reason does not confirm "
-                f"a race withdrawal: {reason!r}. Use this tool only when a candidate "
-                f"has officially left the race.",
+                f"    ⚠️ remove_candidate('{name}') BLOCKED — {detail} (reason given: {reason!r})",
             )
             return (
-                f"ERROR: remove_candidate blocked. The reason '{reason}' does not indicate "
-                f"that '{name}' has left the race. Only call remove_candidate when a candidate "
-                f"has officially withdrawn, dropped out, been disqualified, lost a completed "
-                f"contest with an official result source and date, OR is a former officeholder / "
-                f"prior-cycle candidate who is not a candidate this cycle — state that explicitly "
-                f"(e.g. 'former U.S. Representative who left office in 2023 and is not a candidate "
-                f"in 2026'). If instead you found no evidence this person was ever a candidate here, "
-                f"call remove_candidate with not_on_roster=true and cite the roster listing for this "
-                f"race that enumerates the field without them. Do NOT use this tool to fix data quality issues."
+                f"ERROR: remove_candidate blocked for '{name}'. {detail} "
+                "Use this tool only when the candidate has actually left the race — withdrew, "
+                "was disqualified, lost a completed primary or convention, or is a former "
+                "officeholder who is not a candidate this cycle — and say so plainly in the "
+                "reason. If instead you found no evidence this person was ever a candidate here, "
+                "call remove_candidate with not_on_roster=true and cite the roster listing for "
+                "this race that enumerates the field without them. Do NOT use this tool to fix "
+                "data quality issues."
             )
 
         if is_structural_garbage:
@@ -1049,9 +1002,11 @@ def _make_editing_handlers(
             if isinstance(args.get("_research_trace"), dict) and not supplied_sources:
                 detail = "none of the cited URLs appeared in this run's actual search/fetch trace"
             else:
-                detail = _roster_source_rejection_summary(supplied_sources, candidate_name=name, race_id=race_id)
+                detail = _roster_source_rejection_summary(supplied_sources, candidate_name=name, race_id=race_id, args=args)
             log("warning", f"    set_candidate_roster_sources('{name}') BLOCKED: {detail}")
             return f"ERROR: no usable roster source for '{name}': {detail}."
+        for source in sources:
+            _record_verdict_on_source(source, args, ADJ_MEMBERSHIP)
         c["roster_sources"] = sources
         log("info", f"    Set {len(sources)} roster source(s) for {name}")
         return f"Set {len(sources)} roster source(s) for '{name}'."
@@ -1130,7 +1085,7 @@ def _make_editing_handlers(
             for source in completeness_sources
             if (
                 reason := _roster_completeness_source_rejection_reason(
-                    source, race_id=race_id, identity=identity, roster_names=claimed_roster_names
+                    source, race_id=race_id, identity=identity, roster_names=claimed_roster_names, args=args
                 )
             )
         ]
@@ -1138,10 +1093,12 @@ def _make_editing_handlers(
             source
             for source in completeness_sources
             if _roster_completeness_source_rejection_reason(
-                source, race_id=race_id, identity=identity, roster_names=claimed_roster_names
+                source, race_id=race_id, identity=identity, roster_names=claimed_roster_names, args=args
             )
             is None
         ]
+        for source in qualifying_completeness:
+            _record_verdict_on_source(source, args, ADJ_COMPLETENESS)
         if not qualifying_completeness:
             detail = "; ".join(completeness_rejections) if completeness_rejections else "no sources were supplied"
             return (

--- a/pipeline_client/agent/phases/context.py
+++ b/pipeline_client/agent/phases/context.py
@@ -1,0 +1,63 @@
+"""The per-run state every phase needs, bundled once instead of threaded.
+
+``_run_shared_phases`` passed the same fifteen arguments to each of seven
+phases, and every phase repeated them in its own signature. Adding one
+phase-level concern meant editing eight files and touching nothing that had
+anything to do with the concern.
+
+All of these values are computed once when a run starts and do not change while
+it executes, so they belong together. Phase-specific behaviour still lives in
+each phase; this only carries what they all read.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+from ..run_budget import RunBudget
+
+
+@dataclass(frozen=True)
+class PhaseContext:
+    """Immutable run state shared by every phase.
+
+    The dataclass is frozen, but ``race_json`` is a mutable dict on purpose:
+    phases mutate the race document in place, which is the pipeline's existing
+    contract. Freezing the container stops a phase from swapping in a *different*
+    document or quietly rewriting run settings mid-run — the failure that is hard
+    to trace — while leaving the intended mutation path alone.
+    """
+
+    race_json: Dict[str, Any]
+    race_id: str
+
+    model: str
+    small_model: str
+
+    on_log: Any
+    log: Any
+    max_iterations: int
+    step_enabled: Any
+    track: Any
+    run_budget: Optional[RunBudget] = None
+
+    is_update: bool = False
+    candidate_names: List[str] = field(default_factory=list)
+    selected_name_set: Set[str] = field(default_factory=set)
+    last_updated: str = ""
+    max_candidates: Optional[int] = None
+    target_no_info: bool = False
+    refine_iters: int = 1
+    resume_partial: bool = False
+    continue_incomplete_work: bool = False
+
+    @property
+    def prefix(self) -> str:
+        """Log prefix distinguishing an update run from a fresh one.
+
+        Derived rather than passed. It used to be computed in
+        ``_run_shared_phases`` and handed to every phase, which meant a caller
+        could pass a prefix that contradicted ``is_update``.
+        """
+        return "Update Phase" if self.is_update else "Phase"

--- a/pipeline_client/agent/phases/finance.py
+++ b/pipeline_client/agent/phases/finance.py
@@ -14,24 +14,23 @@ from ._common import (
     _race_identity_context,
     _record_step_failure,
 )
+from .context import PhaseContext
 
 
-async def run_finance_phase(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    candidate_names: List[str],
-    model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    is_update: bool,
-    log: Any,
-    prefix: str,
-    run_budget: RunBudget | None,
-) -> None:
+async def run_finance_phase(ctx: PhaseContext) -> None:
     """Research donors & voting records for all candidates in one pass."""
+    race_json = ctx.race_json
+    race_id = ctx.race_id
+    candidate_names = ctx.candidate_names
+    model = ctx.model
+    on_log = ctx.on_log
+    max_iterations = ctx.max_iterations
+    step_enabled = ctx.step_enabled
+    track = ctx.track
+    is_update = ctx.is_update
+    log = ctx.log
+    prefix = ctx.prefix
+    run_budget = ctx.run_budget
     from . import _agent_loop
 
     if not step_enabled("finance"):

--- a/pipeline_client/agent/phases/forecast.py
+++ b/pipeline_client/agent/phases/forecast.py
@@ -10,23 +10,22 @@ from ..prompts import FORECAST_SYSTEM, FORECAST_USER
 from ..run_budget import RunBudget, RunBudgetExceeded
 from ..tools import FORECAST_TOOLS, READ_PROFILE_TOOL
 from ._common import _await_with_run_budget, _classify_exception, _race_identity_context, _record_step_failure
+from .context import PhaseContext
 
 
-async def run_forecast_phase(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    is_update: bool,
-    log: Any,
-    prefix: str,
-    run_budget: RunBudget | None,
-) -> None:
+async def run_forecast_phase(ctx: PhaseContext) -> None:
     """Generate a race forecast, incorporating Kalshi market signals when available."""
+    race_json = ctx.race_json
+    race_id = ctx.race_id
+    model = ctx.model
+    on_log = ctx.on_log
+    max_iterations = ctx.max_iterations
+    step_enabled = ctx.step_enabled
+    track = ctx.track
+    is_update = ctx.is_update
+    log = ctx.log
+    prefix = ctx.prefix
+    run_budget = ctx.run_budget
     from . import _agent_loop, fetch_kalshi_market_signals
 
     if not step_enabled("forecast"):

--- a/pipeline_client/agent/phases/fresh_run.py
+++ b/pipeline_client/agent/phases/fresh_run.py
@@ -10,6 +10,7 @@ from ..run_budget import RunBudget
 from ..selection import _scale_iterations, _select_target_candidates
 from ..utils import make_logger
 from ._common import _await_with_run_budget, _candidate_name
+from .context import PhaseContext
 from .discovery import _sanitize_roster
 from .shared_runner import _run_shared_phases
 
@@ -84,25 +85,27 @@ async def _run_fresh(
     track("complete", "discovery", duration_ms=int((time.perf_counter() - disc_t0) * 1000), race_json=race_json)
 
     await _run_shared_phases(
-        race_json,
-        race_id,
-        candidate_names=candidate_names,
-        selected_name_set=selected_name_set,
-        model=model,
-        small_model=small_model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        max_candidates=max_candidates,
-        target_no_info=target_no_info,
-        is_update=False,
-        last_updated="",
-        refine_iters=refine_iters,
-        log=log,
-        resume_partial=resume_partial,
-        continue_incomplete_work=continue_incomplete_work,
-        run_budget=run_budget,
+        PhaseContext(
+            race_json=race_json,
+            race_id=race_id,
+            model=model,
+            small_model=small_model,
+            on_log=on_log,
+            log=log,
+            max_iterations=max_iterations,
+            step_enabled=step_enabled,
+            track=track,
+            run_budget=run_budget,
+            is_update=False,
+            candidate_names=candidate_names,
+            selected_name_set=selected_name_set,
+            last_updated="",
+            max_candidates=max_candidates,
+            target_no_info=target_no_info,
+            refine_iters=refine_iters,
+            resume_partial=resume_partial,
+            continue_incomplete_work=continue_incomplete_work,
+        )
     )
     _sanitize_roster(race_json, log)
 

--- a/pipeline_client/agent/phases/image_resolution.py
+++ b/pipeline_client/agent/phases/image_resolution.py
@@ -5,23 +5,22 @@ from typing import Any, Dict, Set
 
 from ..images import resolve_candidate_images
 from ..run_budget import RunBudget
+from .context import PhaseContext
 
 
-async def run_image_resolution_phase(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    selected_name_set: Set[str],
-    small_model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    log: Any,
-    prefix: str,
-    run_budget: RunBudget | None,
-) -> None:
+async def run_image_resolution_phase(ctx: PhaseContext) -> None:
     """Verify/resolve image URLs for the selected candidates (parallel)."""
+    race_json = ctx.race_json
+    race_id = ctx.race_id
+    selected_name_set = ctx.selected_name_set
+    small_model = ctx.small_model
+    on_log = ctx.on_log
+    max_iterations = ctx.max_iterations
+    step_enabled = ctx.step_enabled
+    track = ctx.track
+    log = ctx.log
+    prefix = ctx.prefix
+    run_budget = ctx.run_budget
     from . import _agent_loop
 
     if not step_enabled("images"):

--- a/pipeline_client/agent/phases/issues.py
+++ b/pipeline_client/agent/phases/issues.py
@@ -42,6 +42,7 @@ from ._common import (
     _record_step_failure,
     logger,
 )
+from .context import PhaseContext
 
 
 async def _run_issue_research_for_candidate(
@@ -352,27 +353,25 @@ async def _research_issue_unit(
     return copy.deepcopy(result), trace
 
 
-async def run_issues_phase(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    candidate_names: List[str],
-    small_model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    max_candidates: Optional[int],
-    target_no_info: bool,
-    is_update: bool,
-    last_updated: str,
-    log: Any,
-    prefix: str,
-    resume_partial: bool,
-    continue_incomplete_work: bool,
-    run_budget: RunBudget | None,
-) -> None:
+async def run_issues_phase(ctx: PhaseContext) -> None:
     """Phase 2: per-candidate, per-issue research (tools mode). Mutates race_json."""
+    race_json = ctx.race_json
+    race_id = ctx.race_id
+    candidate_names = ctx.candidate_names
+    small_model = ctx.small_model
+    on_log = ctx.on_log
+    max_iterations = ctx.max_iterations
+    step_enabled = ctx.step_enabled
+    track = ctx.track
+    max_candidates = ctx.max_candidates
+    target_no_info = ctx.target_no_info
+    is_update = ctx.is_update
+    last_updated = ctx.last_updated
+    log = ctx.log
+    prefix = ctx.prefix
+    resume_partial = ctx.resume_partial
+    continue_incomplete_work = ctx.continue_incomplete_work
+    run_budget = ctx.run_budget
     from . import _candidate_source_hints
 
     if not step_enabled("issues"):

--- a/pipeline_client/agent/phases/polling.py
+++ b/pipeline_client/agent/phases/polling.py
@@ -10,24 +10,23 @@ from ..prompts import POLLING_SYSTEM, POLLING_USER
 from ..run_budget import RunBudget, RunBudgetExceeded
 from ..tools import POLLING_TOOLS, READ_PROFILE_TOOL
 from ._common import _classify_exception, _race_identity_context, _record_step_failure
+from .context import PhaseContext
 
 
-async def run_polling_phase(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    candidate_names: List[str],
-    small_model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    is_update: bool,
-    log: Any,
-    prefix: str,
-    run_budget: RunBudget | None,
-) -> None:
+async def run_polling_phase(ctx: PhaseContext) -> None:
     """Refresh available polling data for the race."""
+    race_json = ctx.race_json
+    race_id = ctx.race_id
+    candidate_names = ctx.candidate_names
+    small_model = ctx.small_model
+    on_log = ctx.on_log
+    max_iterations = ctx.max_iterations
+    step_enabled = ctx.step_enabled
+    track = ctx.track
+    is_update = ctx.is_update
+    log = ctx.log
+    prefix = ctx.prefix
+    run_budget = ctx.run_budget
     from . import _agent_loop
 
     if not step_enabled("polling"):

--- a/pipeline_client/agent/phases/refinement.py
+++ b/pipeline_client/agent/phases/refinement.py
@@ -15,26 +15,25 @@ from ._common import (
     _pipeline_completed_units,
     _record_step_failure,
 )
+from .context import PhaseContext
 
 
-async def run_refinement_phase(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    selected_name_set: Set[str],
-    model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    is_update: bool,
-    refine_iters: int,
-    log: Any,
-    prefix: str,
-    resume_partial: bool,
-    run_budget: RunBudget | None,
-) -> None:
+async def run_refinement_phase(ctx: PhaseContext) -> None:
     """Refine each selected candidate one at a time, then refine race metadata."""
+    race_json = ctx.race_json
+    race_id = ctx.race_id
+    selected_name_set = ctx.selected_name_set
+    model = ctx.model
+    on_log = ctx.on_log
+    max_iterations = ctx.max_iterations
+    step_enabled = ctx.step_enabled
+    track = ctx.track
+    is_update = ctx.is_update
+    refine_iters = ctx.refine_iters
+    log = ctx.log
+    prefix = ctx.prefix
+    resume_partial = ctx.resume_partial
+    run_budget = ctx.run_budget
     from . import _agent_loop, _candidate_source_hints
 
     if not step_enabled("refinement"):

--- a/pipeline_client/agent/phases/shared_runner.py
+++ b/pipeline_client/agent/phases/shared_runner.py
@@ -4,11 +4,15 @@ forecast -> voter_resources.
 This is the sequence common to both a fresh discovery run (``fresh_run.py``)
 and an update run (``update_run.py``); each phase's implementation lives in
 its own module and is invoked here in order.
+
+Every phase reads the same run state, so it is passed once as a
+:class:`~.context.PhaseContext` rather than re-listed at each call. This file
+used to be a hundred lines of argument threading, which meant any new
+phase-level concern was an eight-file edit that touched nothing to do with the
+concern itself.
 """
 
-from typing import Any, Dict, List, Optional
-
-from ..run_budget import RunBudget
+from .context import PhaseContext
 from .finance import run_finance_phase
 from .forecast import run_forecast_phase
 from .image_resolution import run_image_resolution_phase
@@ -17,147 +21,24 @@ from .polling import run_polling_phase
 from .refinement import run_refinement_phase
 from .voter_resources import run_voter_resources_phase
 
+#: Run order is load-bearing: issues and finance populate the fields refinement
+#: cleans up, and forecast reads the polling that precedes it.
+_PHASES = (
+    run_image_resolution_phase,
+    run_issues_phase,
+    run_finance_phase,
+    run_refinement_phase,
+    run_polling_phase,
+    run_forecast_phase,
+    run_voter_resources_phase,
+)
 
-async def _run_shared_phases(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    candidate_names: List[str],
-    selected_name_set: set,
-    model: str,
-    small_model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    max_candidates: Optional[int],
-    target_no_info: bool,
-    is_update: bool,
-    last_updated: str,
-    refine_iters: int,
-    log: Any,
-    resume_partial: bool = False,
-    continue_incomplete_work: bool = False,
-    run_budget: RunBudget | None = None,
-) -> None:
-    """Run candidate research, polling, and voter-resource phases.
 
-    Mutates *race_json* in place.
+async def _run_shared_phases(ctx: PhaseContext) -> None:
+    """Run candidate research, polling, and voter-resource phases in order.
+
+    Mutates ``ctx.race_json`` in place. Each phase decides for itself whether it
+    is enabled (``ctx.step_enabled``) and records its own skip.
     """
-    prefix = "Update Phase" if is_update else "Phase"
-
-    # --- Phase 1b: Image URL verification & resolution (parallel) ---
-    await run_image_resolution_phase(
-        race_json,
-        race_id,
-        selected_name_set=selected_name_set,
-        small_model=small_model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        log=log,
-        prefix=prefix,
-        run_budget=run_budget,
-    )
-
-    # --- Phase 2: Per-candidate, per-issue research (tools mode) ---
-    await run_issues_phase(
-        race_json,
-        race_id,
-        candidate_names=candidate_names,
-        small_model=small_model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        max_candidates=max_candidates,
-        target_no_info=target_no_info,
-        is_update=is_update,
-        last_updated=last_updated,
-        log=log,
-        prefix=prefix,
-        resume_partial=resume_partial,
-        continue_incomplete_work=continue_incomplete_work,
-        run_budget=run_budget,
-    )
-
-    # --- Phase 2b: Dedicated finance & voting record research ---
-    await run_finance_phase(
-        race_json,
-        race_id,
-        candidate_names=candidate_names,
-        model=model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        is_update=is_update,
-        log=log,
-        prefix=prefix,
-        run_budget=run_budget,
-    )
-
-    # --- Phase 3: Refinement (tools mode — per-candidate + meta) ---
-    await run_refinement_phase(
-        race_json,
-        race_id,
-        selected_name_set=selected_name_set,
-        model=model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        is_update=is_update,
-        refine_iters=refine_iters,
-        log=log,
-        prefix=prefix,
-        resume_partial=resume_partial,
-        run_budget=run_budget,
-    )
-
-    # --- Phase 4: Polling refresh ---
-    await run_polling_phase(
-        race_json,
-        race_id,
-        candidate_names=candidate_names,
-        small_model=small_model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        is_update=is_update,
-        log=log,
-        prefix=prefix,
-        run_budget=run_budget,
-    )
-
-    # --- Phase 4b: Forecast generation ---
-    await run_forecast_phase(
-        race_json,
-        race_id,
-        model=model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        is_update=is_update,
-        log=log,
-        prefix=prefix,
-        run_budget=run_budget,
-    )
-
-    # --- Phase 5: Voter resources verification ---
-    await run_voter_resources_phase(
-        race_json,
-        race_id,
-        small_model=small_model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        is_update=is_update,
-        log=log,
-        prefix=prefix,
-        run_budget=run_budget,
-    )
+    for phase in _PHASES:
+        await phase(ctx)

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -35,6 +35,7 @@ from ._common import (
     _pipeline_completed_units,
     _record_step_failure,
 )
+from .context import PhaseContext
 from .discovery import _backfill_source_timestamps, _sanitize_roster
 from .fresh_run import _run_fresh
 from .shared_runner import _run_shared_phases
@@ -332,25 +333,27 @@ async def _run_update(
         n = len(candidate_names)
 
     await _run_shared_phases(
-        race_json,
-        race_id,
-        candidate_names=candidate_names,
-        selected_name_set=selected_name_set,
-        model=model,
-        small_model=small_model,
-        on_log=on_log,
-        max_iterations=max_iterations,
-        step_enabled=step_enabled,
-        track=track,
-        max_candidates=max_candidates,
-        target_no_info=target_no_info,
-        is_update=True,
-        last_updated=last_updated,
-        refine_iters=refine_iters,
-        log=log,
-        resume_partial=resume_partial,
-        continue_incomplete_work=continue_incomplete_work,
-        run_budget=run_budget,
+        PhaseContext(
+            race_json=race_json,
+            race_id=race_id,
+            model=model,
+            small_model=small_model,
+            on_log=on_log,
+            log=log,
+            max_iterations=max_iterations,
+            step_enabled=step_enabled,
+            track=track,
+            run_budget=run_budget,
+            is_update=True,
+            candidate_names=candidate_names,
+            selected_name_set=selected_name_set,
+            last_updated=last_updated,
+            max_candidates=max_candidates,
+            target_no_info=target_no_info,
+            refine_iters=refine_iters,
+            resume_partial=resume_partial,
+            continue_incomplete_work=continue_incomplete_work,
+        )
     )
     _sanitize_roster(race_json, log)
 

--- a/pipeline_client/agent/phases/voter_resources.py
+++ b/pipeline_client/agent/phases/voter_resources.py
@@ -8,23 +8,22 @@ from ..prompts import VOTER_RESOURCES_SYSTEM, VOTER_RESOURCES_USER
 from ..run_budget import RunBudget, RunBudgetExceeded
 from ..tools import READ_PROFILE_TOOL, VOTER_RESOURCE_TOOLS
 from ._common import _classify_exception, _record_step_failure
+from .context import PhaseContext
 
 
-async def run_voter_resources_phase(
-    race_json: Dict[str, Any],
-    race_id: str,
-    *,
-    small_model: str,
-    on_log: Any,
-    max_iterations: int,
-    step_enabled: Any,
-    track: Any,
-    is_update: bool,
-    log: Any,
-    prefix: str,
-    run_budget: RunBudget | None,
-) -> None:
+async def run_voter_resources_phase(ctx: PhaseContext) -> None:
     """Verify local registration and voting info for the race's jurisdiction."""
+    race_json = ctx.race_json
+    race_id = ctx.race_id
+    small_model = ctx.small_model
+    on_log = ctx.on_log
+    max_iterations = ctx.max_iterations
+    step_enabled = ctx.step_enabled
+    track = ctx.track
+    is_update = ctx.is_update
+    log = ctx.log
+    prefix = ctx.prefix
+    run_budget = ctx.run_budget
     from . import _agent_loop
 
     if not step_enabled("voter_resources"):

--- a/pipeline_client/agent/roster_adjudicator.py
+++ b/pipeline_client/agent/roster_adjudicator.py
@@ -291,7 +291,9 @@ async def adjudicate(
 _TOOL_EVIDENCE_SPECS: Dict[str, tuple] = {
     # (args_key, claim, subject_key, condition_key)
     "add_candidate": (("roster_sources", Claim.MEMBERSHIP, "name", None),),
-    "set_candidate_roster_sources": (("roster_sources", Claim.MEMBERSHIP, "candidate_name", None),),
+    # This tool's argument is "sources", not "roster_sources" — the two roster
+    # tools disagree, and reading the wrong key here silently adjudicated nothing.
+    "set_candidate_roster_sources": (("sources", Claim.MEMBERSHIP, "candidate_name", None),),
     "remove_candidate": (
         ("sources", Claim.OMISSION, "name", "not_on_roster"),
         ("sources", Claim.WRONG_CONTEST, "name", "wrong_contest"),

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,5 @@ norecursedirs =
     data
     .venv
     .tmp_cf_staging
+markers =
+    real_adjudication_gate: opt out of the permissive adjudication stub and see production fail-closed behaviour

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,44 @@ def mock_ballotpedia_election_lookup():
         return_value={"found": False, "candidates": [], "page_url": None, "description": None},
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def stub_roster_adjudication(request):
+    """Supply a permissive verdict when a test calls an editing handler directly.
+
+    In production the agent loop resolves every roster judgment before dispatch
+    and injects it under ``_adjudications``; a handler that finds none blocks,
+    which is what makes the gate fail closed. Tests call the handlers directly,
+    so without this they would all block.
+
+    Stubbing here is deliberate rather than convenient. ``test_editing_tools``
+    exercises the *structural* contract — URL shape, race_id match, tier grading,
+    corroboration, roster caps. Whether a page's prose supports a claim is a
+    separate concern covered by ``test_roster_adjudicator`` (mocked) and
+    ``test_roster_adjudicator_live`` (real model, real cases). Making every
+    structural test hand-write verdicts would have them assert two things at once
+    and hide which one broke.
+
+    A test carrying its own ``_adjudications`` still wins — the real lookup runs
+    first, so a test can inject a blocking verdict to exercise a rejection path.
+    Mark a test ``@pytest.mark.real_adjudication_gate`` to opt out entirely and
+    see production's fail-closed behaviour; ``test_roster_adjudicator_gates``
+    uses that to prove absence blocks.
+    """
+    if request.node.get_closest_marker("real_adjudication_gate"):
+        yield
+        return
+
+    from pipeline_client.agent import handlers
+
+    real_verdict_for = handlers._verdict_for
+
+    def _permissive(args, claim, url=""):
+        supplied = real_verdict_for(args, claim, url)
+        if supplied is not None:
+            return supplied
+        return {"supports": True, "reason": "stubbed by test fixture", "model": "test-stub"}
+
+    with patch.object(handlers, "_verdict_for", _permissive):
+        yield

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -2456,6 +2456,7 @@ async def test_targeted_issue_run_preserves_other_candidates_audits():
     missing, so clearing race-wide meant every targeted repair re-broke the
     candidates it skipped and no sequence of runs could converge.
     """
+    from pipeline_client.agent.phases.context import PhaseContext
     from pipeline_client.agent.phases.issues import run_issues_phase
 
     race_json = {
@@ -2475,23 +2476,26 @@ async def test_targeted_issue_run_preserves_other_candidates_audits():
     }
 
     await run_issues_phase(
-        race_json,
-        "nj-senate-2026",
-        candidate_names=["Veronica Fernandez"],
-        small_model="test-model",
-        on_log=None,
-        max_iterations=1,
-        step_enabled=lambda _step: False,  # stop before doing real research
-        track=lambda *_a, **_kw: None,
-        max_candidates=None,
-        target_no_info=False,
-        is_update=True,
-        last_updated="",
-        log=lambda *_a, **_kw: None,
-        prefix="Test Phase",
-        resume_partial=False,
-        continue_incomplete_work=False,
-        run_budget=None,
+        PhaseContext(
+            race_json=race_json,
+            race_id="nj-senate-2026",
+            model="test-model",
+            small_model="test-model",
+            on_log=None,
+            log=lambda *_a, **_kw: None,
+            max_iterations=1,
+            step_enabled=lambda _step: False,  # stop before doing real research
+            track=lambda *_a, **_kw: None,
+            run_budget=None,
+            is_update=True,
+            candidate_names=["Veronica Fernandez"],
+            selected_name_set={"Veronica Fernandez"},
+            last_updated="",
+            max_candidates=None,
+            target_no_info=False,
+            resume_partial=False,
+            continue_incomplete_work=False,
+        )
     )
 
     research = race_json["pipeline_state"]["issue_research"]

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -563,9 +563,29 @@ def test_federal_house_roster_rejects_same_number_state_house_evidence():
         "retrieval_status": "content",
     }
 
-    result = handlers["add_candidate"]({"name": "Rick Pressnell", "party": "Democratic", "roster_sources": [source]})
+    # The office/district collision is a reading judgment now, not a regex over
+    # the evidence text. The live case lives in test_roster_adjudicator_live as
+    # "state-house-district-number-collision"; here we assert the handler honours
+    # a blocking verdict and surfaces its reason.
+    result = handlers["add_candidate"](
+        {
+            "name": "Rick Pressnell",
+            "party": "Democratic",
+            "roster_sources": [source],
+            "_adjudications": {
+                "membership": {
+                    source["url"]: {
+                        "supports": False,
+                        "reason": "names the Alabama House of Representatives, not the U.S. House",
+                        "model": "test-stub",
+                    }
+                }
+            },
+        }
+    )
 
     assert "Blocked adding" in result
+    assert "Alabama House of Representatives, not the U.S. House" in result
     assert race_json["candidates"] == []
 
 
@@ -1323,9 +1343,26 @@ def test_remove_candidate_blocks_generic_primary_loss_without_official_result():
     race_json = {"candidates": [{"name": "Alice", "party": "D"}, {"name": "Bob", "party": "R"}]}
     handlers = _make_editing_handlers(race_json, lambda l, m: None)
 
-    result = handlers["remove_candidate"]({"name": "Alice", "reason": "Lost primary election"})
+    # An unsupported "lost primary" claim is now rejected by the adjudicator
+    # reading the reason, not by a keyword scan demanding the word "official".
+    result = handlers["remove_candidate"](
+        {
+            "name": "Alice",
+            "reason": "Lost primary election",
+            "_adjudications": {
+                "withdrawal": {
+                    "": {
+                        "supports": False,
+                        "reason": "states a primary loss with no date or result source to support it",
+                        "model": "test-stub",
+                    }
+                }
+            },
+        }
+    )
 
     assert "blocked" in result.lower()
+    assert "no date or result source" in result
     assert race_json["candidates"][0].get("withdrawn") is not True
 
 
@@ -2304,9 +2341,25 @@ def test_completeness_gate_still_rejects_single_candidate_evidence():
         race_id="nj-senate-2026",
     )
 
-    assert _roster_completeness_source_rejection_reason(
-        source, race_id="nj-senate-2026", identity={"office": "U.S. Senate", "contest_stage": "post_primary_general"}
+    # Whether a page presents the whole field or profiles one person is a
+    # reading judgment now. The same case runs against the real model in
+    # test_roster_adjudicator_live as "single-candidate-profile-is-not-a-field".
+    blocking = {
+        "completeness": {
+            source["url"]: {
+                "supports": False,
+                "reason": "profiles one incumbent and never lists the field for this contest",
+                "model": "test-stub",
+            }
+        }
+    }
+    reason = _roster_completeness_source_rejection_reason(
+        source,
+        race_id="nj-senate-2026",
+        identity={"office": "U.S. Senate", "contest_stage": "post_primary_general"},
+        args={"_adjudications": blocking},
     )
+    assert reason and "never lists the field" in reason
 
 
 def test_completeness_gate_accepts_fetched_ballotpedia_race_page():

--- a/tests/test_issue_retry_limit.py
+++ b/tests/test_issue_retry_limit.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 
+from pipeline_client.agent.phases.context import PhaseContext
 from pipeline_client.agent.phases.issues import run_issues_phase
 
 
@@ -27,23 +28,26 @@ def _race():
 
 async def _run(race_json):
     await run_issues_phase(
-        race_json,
-        "ne-house-02-2026",
-        candidate_names=["Brinker Harding"],
-        small_model="test-model",
-        on_log=None,
-        max_iterations=1,
-        step_enabled=lambda _s: True,
-        track=lambda *_a, **_kw: None,
-        max_candidates=None,
-        target_no_info=False,
-        is_update=True,
-        last_updated="",
-        log=lambda *_a, **_kw: None,
-        prefix="Test",
-        resume_partial=True,
-        continue_incomplete_work=False,
-        run_budget=None,
+        PhaseContext(
+            race_json=race_json,
+            race_id="ne-house-02-2026",
+            model="test-model",
+            small_model="test-model",
+            on_log=None,
+            log=lambda *_a, **_kw: None,
+            max_iterations=1,
+            step_enabled=lambda _s: True,
+            track=lambda *_a, **_kw: None,
+            run_budget=None,
+            is_update=True,
+            candidate_names=["Brinker Harding"],
+            selected_name_set={"Brinker Harding"},
+            last_updated="",
+            max_candidates=None,
+            target_no_info=False,
+            resume_partial=True,
+            continue_incomplete_work=False,
+        )
     )
 
 

--- a/tests/test_roster_adjudicator_gates.py
+++ b/tests/test_roster_adjudicator_gates.py
@@ -1,0 +1,132 @@
+"""Production behaviour of the roster gates: a missing verdict blocks.
+
+The rest of the suite runs under conftest's permissive adjudication stub, so
+structural tests can exercise URL shape, tier grading and corroboration without
+hand-writing verdicts. These tests opt out of that stub with the
+``real_adjudication_gate`` marker and assert what actually happens in production
+when no verdict is present — which is the property that makes an unreachable
+adjudicator fail closed rather than waving evidence through.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipeline_client.agent.agent import _make_editing_handlers
+
+pytestmark = pytest.mark.real_adjudication_gate
+
+
+def _official_source(race_id="ne-house-02-2026", url="https://sos.nebraska.gov/candidates"):
+    return {
+        "url": url,
+        "type": "official",
+        "title": "2026 General Election Candidates",
+        "evidence": "CONGRESSIONAL DISTRICTS | District 2 | Tony Vargas | Democratic | Filed 2026-02-17",
+        "published_at": "2026-02-20",
+        "race_id": race_id,
+        "evidence_tier": 1,
+        "retrieval_status": "content",
+    }
+
+
+def test_add_candidate_blocks_without_a_verdict():
+    """Structurally perfect evidence is still not enough on its own."""
+    race_json = {"id": "ne-house-02-2026", "candidates": []}
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["add_candidate"]({"name": "Tony Vargas", "party": "Democratic", "roster_sources": [_official_source()]})
+
+    assert "Blocked adding" in result
+    assert race_json["candidates"] == []
+
+
+def test_withdrawal_blocks_without_a_verdict():
+    race_json = {"id": "ga-senate-2026", "candidates": [{"name": "Alice"}, {"name": "Bob"}]}
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["remove_candidate"]({"name": "Alice", "reason": "Withdrew from the race on June 2, 2026."})
+
+    assert "blocked" in result.lower()
+    assert race_json["candidates"][0].get("withdrawn") is not True
+
+
+def test_unavailable_adjudicator_blocks_and_says_so():
+    """The fail-closed path must reach the model as a readable reason, not a silent no."""
+    race_json = {"id": "ne-house-02-2026", "candidates": []}
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+    source = _official_source()
+
+    result = handlers["add_candidate"](
+        {
+            "name": "Tony Vargas",
+            "party": "Democratic",
+            "roster_sources": [source],
+            "_adjudications": {
+                "membership": {
+                    source["url"]: {
+                        "supports": False,
+                        "reason": "evidence could not be adjudicated (RuntimeError); the roster gate fails closed",
+                        "model": "gpt-5.6-luna",
+                        "unavailable": True,
+                    }
+                }
+            },
+        }
+    )
+
+    assert "Blocked adding" in result
+    assert "fails closed" in result
+    assert race_json["candidates"] == []
+
+
+def test_supporting_verdict_lets_a_structurally_valid_source_through():
+    """The gate must not be unconditionally closed — that would be its own outage."""
+    race_json = {"id": "ne-house-02-2026", "candidates": []}
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+    source = _official_source()
+
+    result = handlers["add_candidate"](
+        {
+            "name": "Tony Vargas",
+            "party": "Democratic",
+            "roster_sources": [source],
+            "_adjudications": {
+                "membership": {
+                    source["url"]: {
+                        "supports": True,
+                        "reason": "names Tony Vargas under Congressional District 2 for 2026",
+                        "model": "gpt-5.6-luna",
+                    }
+                }
+            },
+        }
+    )
+
+    assert "Blocked" not in result
+    assert [c["name"] for c in race_json["candidates"]] == ["Tony Vargas"]
+
+
+def test_accepted_source_carries_its_verdict_into_the_profile():
+    """A published draft must record why each source was accepted."""
+    race_json = {"id": "ne-house-02-2026", "candidates": []}
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+    source = _official_source()
+    handlers["add_candidate"](
+        {
+            "name": "Tony Vargas",
+            "party": "Democratic",
+            "roster_sources": [source],
+            "_adjudications": {
+                "membership": {
+                    source["url"]: {"supports": True, "reason": "names the district and cycle", "model": "gpt-5.6-luna"}
+                }
+            },
+        }
+    )
+
+    stored = race_json["candidates"][0].get("roster_sources") or []
+    assert stored, "candidate was added with no roster_sources recorded"
+    audit = stored[0].get("adjudication")
+    assert audit and audit["reason"] == "names the district and cycle"
+    assert audit["model"] == "gpt-5.6-luna"

--- a/tests/test_roster_adjudicator_live.py
+++ b/tests/test_roster_adjudicator_live.py
@@ -83,6 +83,13 @@ GA_DIFFERENT_OFFICE = {
     "published_at": "2026-03-10",
 }
 
+SINGLE_CANDIDATE_PROFILE = {
+    "url": "https://www.nj.gov/state/elections/some-profile",
+    "title": "Cory Booker profile",
+    "evidence": "Cory Booker is the incumbent senator seeking re-election in 2026.",
+    "published_at": "2026-07-27",
+}
+
 NE_CONTEST = "ne-house-02-2026 (U.S. House, Nebraska District 2, 2026)"
 
 CASES = [
@@ -115,6 +122,14 @@ CASES = [
         False,
     ),
     ("blocked-page-as-omission-proof", Claim.OMISSION, "Don Bacon", NE_CONTEST, BLOCKED_PAGE, False),
+    (
+        "single-candidate-profile-is-not-a-field",
+        Claim.COMPLETENESS,
+        "Cory Booker",
+        "nj-senate-2026 (U.S. Senate, New Jersey, 2026)",
+        SINGLE_CANDIDATE_PROFILE,
+        False,
+    ),
     ("prior-cycle-as-current-membership", Claim.MEMBERSHIP, "Don Bacon", NE_CONTEST, PRIOR_CYCLE_ARTICLE, False),
     (
         "absence-of-evidence-as-withdrawal",


### PR DESCRIPTION
These two commits were meant to be in #252 but never reached the remote branch — only the first commit was pushed, so the squash merged just that one. Same content, re-landed.

## 1. The four gates now require an adjudicator verdict

The regexes replaced here are the ones whose oscillation fills `handlers.py`'s history:

- **`remove_candidate`** graded withdrawal reasons with an `_EXIT_KEYWORDS` set plus patterns for primary losses, dates, official-result language and former-officeholder phrasing — **123 lines** that rejected correctly-worded removals while doing nothing to stop a fabricated one. Now **31 lines** asking whether the reason describes an actual exit.
- **`_source_supports_exact_contest`** matched federal-vs-state district wording; the adjudicator reads the office instead.
- **The completeness gate** demanded a page call itself "certified" or "candidate list" — which rejected New Jersey's own certified list.

`handlers.py`: 2020 → 1966 lines, 30 → 20 regex sites.

**One thing I removed and put back.** That gate had two halves and only one was prose grading. Asking whether the evidence *names every candidate being proposed* is containment over supplied names, not a judgment about the page, and it's what stops a real but partial listing from ratifying a roster it never covered. A test caught the over-deletion.

**A missing verdict blocks** — that's what makes an unreachable adjudicator fail closed. `tests/test_roster_adjudicator_gates.py` asserts it by opting out of the permissive stub. Accepted sources carry their verdict and reason into the profile, so a published draft records why each was allowed.

**The rejection summary reports adjudicator refusals too.** Otherwise a semantically wrong but structurally perfect source fell through to the generic tier-3 message and sent the model hunting for a second domain when the real problem was that its evidence described a different office.

**Bug fixed along the way:** `set_candidate_roster_sources` takes `sources`, not `roster_sources`, so that claim was never being adjudicated at all.

## 2. PhaseContext

`_run_shared_phases` handed the same fifteen arguments to each of seven phases. `shared_runner.py` is now **44 lines instead of 164**, and each phase takes just the context.

Frozen dataclass, mutable `race_json` — phases mutate the document in place (the existing contract), but freezing the container stops one swapping in a different document or rewriting run settings mid-run. `prefix` is derived from `is_update` rather than passed alongside it, so a caller can't hand down a contradicting one.

No behaviour change.

## On the test stub

`conftest` supplies a permissive verdict for direct handler calls. Deliberate, not convenient: `test_editing_tools` exercises the *structural* contract — URL shape, tier grading, corroboration, caps. Whether prose supports a claim is covered by `test_roster_adjudicator` (mocked) and `test_roster_adjudicator_live` (real model, real incidents). Making structural tests hand-write verdicts would have them assert two things at once and hide which broke. Tests injecting their own verdicts still win, and it's opt-out by marker.

## Testing

1058 pipeline + 93 admin + 40 races-api, plus 9 live adjudication cases against the real model.

## Still outstanding

The mock-heavy admin test rewrite, and the `phases/__init__` shim deletion after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)