### PR TITLE
Cut the phases package to the names something actually uses

### DIFF
--- a/pipeline_client/agent/phases/__init__.py
+++ b/pipeline_client/agent/phases/__init__.py
@@ -1,166 +1,88 @@
 """Phase orchestration — discovery, issues, finance, refinement, iteration.
 
-This package is a decomposition of what used to be a single ~1,700-line
-``phases.py`` module. Each phase now lives in its own file:
+Each phase lives in its own module:
 
-- ``_common.py``           — shared constants/helpers (control-flow exception
-                              handling, run-budget-bounded awaits, pipeline
-                              unit-state bookkeeping).
-- ``discovery.py``         — deterministic roster sanitization rules and the
-                              advisory Ballotpedia roster sync.
+- ``_common.py``           — shared helpers (control-flow exception handling,
+                              run-budget-bounded awaits, unit-state bookkeeping).
+- ``context.py``           — ``PhaseContext``: the per-run state every phase reads.
+- ``discovery.py``         — deterministic roster sanitization and the advisory
+                              Ballotpedia roster sync.
 - ``image_resolution.py``  — Phase 1b: candidate image URL verification.
-- ``issues.py``            — Phase 2: per-candidate, per-issue sub-agent
-                              research (sequential and concurrent variants).
+- ``issues.py``            — Phase 2: per-candidate, per-issue sub-agent research.
 - ``finance.py``           — Phase 2b: donor & voting-record research.
 - ``refinement.py``        — Phase 3: per-candidate + meta refinement.
 - ``polling.py``           — Phase 4: polling refresh.
 - ``forecast.py``          — Phase 4b: race outcome forecast.
 - ``voter_resources.py``   — Phase 5: voter resource verification.
-- ``shared_runner.py``     — runs the phases above in order for both fresh
-                              and update runs.
+- ``shared_runner.py``     — runs the phases above in order for fresh and update runs.
 - ``fresh_run.py``         — ``_run_fresh``: discovery -> shared phases.
 - ``update_run.py``        — ``_run_update``: roster sync/meta -> shared phases.
 - ``iteration.py``         — ``_run_iteration_pass``: review-flag remediation.
 
-This ``__init__`` re-exports the full public surface the previous flat
-``phases.py`` module exposed, so every existing import site (production code
-and tests, including tests that patch e.g.
-``pipeline_client.agent.phases._agent_loop`` or
-``pipeline_client.agent.phases._sync_ballotpedia_roster``) keeps working
-unchanged. Phase modules that call one of those patched names do so via a
-lazy ``from . import <name>`` *inside* the calling function (not a top-level
-import) specifically so a monkeypatch applied to this package's namespace is
-still honored no matter which submodule performs the call — this mirrors the
-project's existing lazy-import convention for breaking circular dependencies.
+This module deliberately exports only two things:
+
+**What callers outside the package use.** ``agent.py`` drives runs through
+``_run_fresh``/``_run_update`` and a handful of helpers; those are re-exported
+here so it has one import site.
+
+**The monkeypatch seam.** Phase modules reach ``_agent_loop``,
+``_sync_ballotpedia_roster``, ``_candidate_source_hints``,
+``_ballotpedia_election_lookup`` and ``fetch_kalshi_market_signals`` through a
+lazy ``from . import <name>`` *inside* the calling function, not a top-level
+import. That indirection is what lets a test patch
+``pipeline_client.agent.phases.<name>`` and have every submodule honour it. Those
+five names must stay bound here or the patches silently stop taking effect —
+tests would still pass while exercising the real implementation.
+
+It used to re-export 110 names for backward compatibility. 100 of them were
+referenced nowhere, which made this file read as the package's API when it was
+mostly noise, and left three importable spellings for the same helper. Import
+from the owning module instead.
 """
 
-from .. import phase_state, roster  # noqa: F401 — re-exported for backward compat
+# --- the monkeypatch seam: patched as pipeline_client.agent.phases.<name> ---
 from ..ballotpedia import lookup_election_page as _ballotpedia_election_lookup
-from ..errors import PermanentProviderError, RetryableProviderError  # noqa: F401 — re-exported for backward compat
-from ..handlers import _make_editing_handlers  # noqa: F401 — re-exported for backward compat
-from ..images import resolve_candidate_images  # noqa: F401 — re-exported for backward compat
-from ..llm import _agent_loop, _ensure_dict, _normalize_candidate
+from ..llm import _agent_loop
 from ..market_data.kalshi import fetch_kalshi_market_signals
-from ..model_registry import CHEAP_MODEL, DEFAULT_MODEL, NANO_MODEL  # noqa: F401 — re-exported for backward compat
-from ..patches import (  # noqa: F401 — re-exported for backward compat
-    _apply_candidate_patch,
-    _apply_finance_patch,
-    _apply_issue_patch,
-    _apply_meta_patch,
-    _apply_refine_patch,
-    _deduplicate_donors,
-    _summarize_existing_stances,
-)
-from ..prompts import (  # noqa: F401 — re-exported for backward compat
-    CANONICAL_ISSUES,
-    DISCOVERY_SYSTEM,
-    DISCOVERY_USER,
-    FINANCE_VOTING_SYSTEM,
-    FINANCE_VOTING_USER,
-    FORECAST_SYSTEM,
-    FORECAST_USER,
-    ISSUE_SUBAGENT_SYSTEM,
-    ISSUE_SUBAGENT_USER,
-    ITERATE_META_USER,
-    ITERATE_SYSTEM,
-    ITERATE_USER,
-    POLLING_SYSTEM,
-    POLLING_USER,
-    REFINE_META_USER,
-    REFINE_SYSTEM,
-    REFINE_USER,
-    ROSTER_SYNC_SYSTEM,
-    ROSTER_SYNC_USER,
-    ROSTER_VERIFY_SYSTEM,
-    ROSTER_VERIFY_USER,
-    UPDATE_ISSUE_SUBAGENT_SYSTEM,
-    UPDATE_ISSUE_SUBAGENT_USER,
-    UPDATE_META_SYSTEM,
-    UPDATE_META_USER,
-    VOTER_RESOURCES_SYSTEM,
-    VOTER_RESOURCES_USER,
-)
+
+# --- the surface agent.py and tests import from this package ---
 from ..review_flags import format_review_flags as _format_review_flags
 from ..review_flags import has_actionable_flags as _has_actionable_flags
-from ..run_budget import RunBudget, RunBudgetExceeded  # noqa: F401 — re-exported for backward compat
-from ..selection import (  # noqa: F401 — re-exported for backward compat
-    _candidate_info_score,
-    _candidate_source_hints,
-    _scale_iterations,
-    _select_target_candidates,
-    plan_candidate_work,
-)
-from ..tools import (  # noqa: F401 — re-exported for backward compat
-    BACKGROUND_TOOLS,
-    CANDIDATE_TOOLS,
-    DESCRIPTION_TOOLS,
-    FORECAST_TOOLS,
-    ISSUE_TOOLS,
-    POLLING_TOOLS,
-    RACE_TOOLS,
-    READ_PROFILE_TOOL,
-    RECORD_TOOLS,
-    REMOVE_CANDIDATE_TOOL,
-    ROSTER_TOOLS,
-    VOTER_RESOURCE_TOOLS,
-)
-from ..utils import make_logger  # noqa: F401 — re-exported for backward compat
-from ..web_tools import _get_search_cache  # noqa: F401 — re-exported for backward compat
-from ._common import (
-    _CONTROL_FLOW_EXCEPTION_NAMES,
-    PipelineWorkRemaining,
-    RunFailureReason,
-    _await_with_run_budget,
-    _build_handoff_context,
-    _candidate_name,
-    _classify_exception,
-    _detect_empty_finance_output,
-    _is_control_flow_exception,
-    _issue_stance_is_complete,
-    _mark_pipeline_unit_complete,
-    _pipeline_completed_units,
-    _pipeline_issue_attempts,
-    _race_identity_context,
-    _record_step_failure,
-    logger,
-)
+from ..selection import _candidate_source_hints, _scale_iterations, _select_target_candidates
+from ._common import PipelineWorkRemaining
 from .discovery import (
-    _ROSTER_CAP,
-    _TERM_LIMITED_NON_CANDIDATE_RE,
     _add_candidates_from_authoritative_roster,
-    _backfill_source_timestamps,
-    _candidate_matches_any,
-    _candidate_roster_text,
     _cap_roster,
-    _names_likely_same,
-    _norm_name_for_match,
-    _normalize_candidate_entries,
-    _party_tag,
     _reconcile_candidates_with_authoritative_roster,
-    _remove_inactive_candidates,
-    _remove_ineligible_officeholders,
     _remove_known_ineligible_candidates,
     _sanitize_roster,
     _sync_ballotpedia_roster,
 )
 from .fresh_run import _run_fresh
-from .issues import _research_issue_unit, _run_issue_research_for_candidate
+from .issues import _research_issue_unit
 from .iteration import _run_iteration_pass
 from .shared_runner import _run_shared_phases
 from .update_run import _run_update
 
 __all__ = [
     "PipelineWorkRemaining",
-    "_run_fresh",
-    "_run_update",
-    "_run_shared_phases",
-    "_run_iteration_pass",
-    "_run_issue_research_for_candidate",
-    "_research_issue_unit",
-    "_sanitize_roster",
-    "_sync_ballotpedia_roster",
+    "_add_candidates_from_authoritative_roster",
+    "_format_review_flags",
+    "_reconcile_candidates_with_authoritative_roster",
+    "_agent_loop",
+    "_ballotpedia_election_lookup",
     "_candidate_source_hints",
+    "_cap_roster",
     "_has_actionable_flags",
+    "_remove_known_ineligible_candidates",
+    "_research_issue_unit",
+    "_run_fresh",
+    "_run_iteration_pass",
+    "_run_shared_phases",
+    "_run_update",
+    "_sanitize_roster",
     "_scale_iterations",
     "_select_target_candidates",
+    "_sync_ballotpedia_roster",
+    "fetch_kalshi_market_signals",
 ]

--- a/pipeline_client/agent/phases/discovery.py
+++ b/pipeline_client/agent/phases/discovery.py
@@ -97,21 +97,14 @@ def _remove_inactive_candidates(race_json: Dict[str, Any], log: Any | None = Non
             log("warning", "Removed inactive candidates from discovery roster: " + ", ".join(removed))
 
 
-def _norm_name_for_match(name: str) -> str:
-    return roster.normalize_name(name)
+def _candidate_matches_any(name: str, candidates: List[Dict[str, Any]]) -> bool:
+    """True when *name* matches any candidate in *candidates*.
 
-
-def _names_likely_same(left: str, right: str) -> bool:
-    return roster.names_likely_same(left, right)
-
-
-def _candidate_matches_any(name: str, roster: List[Dict[str, Any]]) -> bool:
-    return any(_names_likely_same(name, str(candidate.get("name") or "")) for candidate in roster)
-
-
-def _party_tag(party: Any) -> str:
-    """Normalize a party value to a simple tag for balance checks."""
-    return roster.party_tag(party)
+    The parameter was previously called ``roster``, which shadowed the imported
+    ``roster`` module inside this function — harmless only because the body did
+    not need the module.
+    """
+    return any(roster.names_likely_same(name, str(candidate.get("name") or "")) for candidate in candidates)
 
 
 def _reconcile_candidates_with_authoritative_roster(
@@ -132,7 +125,7 @@ def _reconcile_candidates_with_authoritative_roster(
         return
 
     # Collect the set of party tags present in the Ballotpedia roster.
-    authoritative_party_tags: set = {_party_tag(c.get("party")) for c in authoritative_candidates if isinstance(c, dict)}
+    authoritative_party_tags: set = {roster.party_tag(c.get("party")) for c in authoritative_candidates if isinstance(c, dict)}
 
     kept: List[Any] = []
     removed: List[str] = []
@@ -149,7 +142,7 @@ def _reconcile_candidates_with_authoritative_roster(
         # page is likely a single-party primary page, not the full general election
         # roster.  Keep candidates of the missing party to avoid stripping the other
         # side of the ballot.
-        tag = _party_tag(candidate.get("party"))
+        tag = roster.party_tag(candidate.get("party"))
         if tag not in authoritative_party_tags:
             if log:
                 log(

--- a/tests/test_phases_patch_seam.py
+++ b/tests/test_phases_patch_seam.py
@@ -1,0 +1,83 @@
+"""The phases package re-exports a monkeypatch seam; prove it still conducts.
+
+Phase submodules reach a few helpers through a lazy ``from . import <name>``
+*inside* the calling function rather than a top-level import. That indirection is
+the only reason patching ``pipeline_client.agent.phases.<name>`` reaches every
+submodule.
+
+This is the failure worth guarding: if one of these bindings is dropped from
+``__init__``, submodules fall back to their own import and the patch silently
+stops taking effect. Nothing fails — the suite goes green while exercising the
+real implementation, including real network calls. These tests assert the patch
+is actually observed.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PHASES_DIR = REPO_ROOT / "pipeline_client" / "agent" / "phases"
+
+
+def _lazily_imported_names() -> set[str]:
+    """Names any phase submodule pulls from the package namespace at call time."""
+    names: set[str] = set()
+    for path in PHASES_DIR.glob("*.py"):
+        if path.name == "__init__.py":
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            # `from . import x, y` -> module is None at level 1
+            if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module is None:
+                names.update(alias.name for alias in node.names)
+    return names
+
+
+def test_every_lazily_imported_name_is_bound_in_the_package():
+    """A submodule importing a name the package does not expose is an ImportError
+    waiting for the first run that reaches that line."""
+    from pipeline_client.agent import phases
+
+    missing = sorted(name for name in _lazily_imported_names() if not hasattr(phases, name))
+    assert not missing, f"phase submodules lazily import names the package does not bind: {missing}"
+
+
+def test_the_seam_is_not_empty():
+    """Guards against this file passing because the detector found nothing."""
+    assert len(_lazily_imported_names()) >= 4
+
+
+@pytest.mark.parametrize("name", sorted(_lazily_imported_names()))
+def test_patching_the_package_reaches_submodules(monkeypatch, name):
+    """Patch the package attribute; every submodule that uses it must see the patch."""
+    from pipeline_client.agent import phases
+
+    sentinel = object()
+    monkeypatch.setattr(phases, name, sentinel, raising=True)
+
+    # Re-run the same lazy import a submodule performs and confirm it resolves
+    # to the patched object rather than the original.
+    resolved = getattr(__import__("pipeline_client.agent.phases", fromlist=[name]), name)
+    assert resolved is sentinel, f"patching phases.{name} did not take effect"
+
+
+def test_declared_exports_all_resolve():
+    """__all__ must not promise a name the module does not actually bind."""
+    from pipeline_client.agent import phases
+
+    missing = [name for name in phases.__all__ if not hasattr(phases, name)]
+    assert not missing, f"__all__ lists unbound names: {missing}"
+
+
+def test_package_does_not_re_export_dead_weight():
+    """It carried 110 names, 100 referenced nowhere. Keep it to what is used."""
+    from pipeline_client.agent import phases
+
+    exported = {
+        name for name in vars(phases) if not name.startswith("__") and not isinstance(vars(phases)[name], type(pathlib))
+    }
+    assert len(exported) <= 30, f"re-export surface is growing again: {len(exported)} names"


### PR DESCRIPTION
Last item from the pipeline audit. Also corrects a claim I made earlier in that audit.

## The `__init__` re-export surface

It re-exported **110 names** for backward compatibility. **100 were referenced nowhere** — not by `agent.py`, not by tests, not by scripts. That made the file read as the package's API when it was mostly noise, and left up to three importable spellings for the same helper.

Now 34: what `agent.py` and tests import, plus the monkeypatch seam.

## The seam is the part that mattered

Phase submodules reach `_agent_loop`, `_sync_ballotpedia_roster`, `_candidate_source_hints`, `_ballotpedia_election_lookup` and `fetch_kalshi_market_signals` through a lazy `from . import <name>` *inside* the calling function. That indirection is the only reason patching `pipeline_client.agent.phases.<name>` reaches every submodule.

I identified those five by parsing the submodules rather than guessing — my first attempt at the trim dropped names a regex scan had missed, and `test_run_agent` failed on import.

`tests/test_phases_patch_seam.py` guards it, because **this failure is silent**: drop a binding and submodules fall back to their own import, the patch stops taking effect, and the suite stays green while exercising the real implementation — including real network calls. The test discovers the lazily-imported names by parsing rather than hardcoding, asserts each is bound, and asserts the detector found something so it can't pass vacuously.

## Smaller cleanups

`discovery.py`'s thin wrappers: `_norm_name_for_match` had no callers at all; `_party_tag` and `_names_likely_same` were used once or twice inside that one file. `_candidate_matches_any`'s parameter was named `roster`, shadowing the imported module — harmless only because the body never needed it.

**`_common.py`'s aliases are left alone deliberately.** `_candidate_name` has 38 call sites and the rest 11–14 each. Renaming ~90 call sites to remove a one-line indirection is churn with no benefit.

## Correction to the original audit

I claimed `test_races_api_admin.py` was mock-heavy to the point of being worthless — "452 mocks against 323 assertions", "would pass against broken code" — and proposed deleting ~2,000 lines.

**That was wrong.** I measured it properly before acting: of 93 tests, **zero** assert only on mock calls and **86 make no mock-call assertions at all**. The `MagicMock`s are Firestore and GCS doubles — substituting external cloud services, which is correct — while assertions are on real response codes, bodies and computed values, across 132 real `TestClient` requests.

I'd inferred that from a ratio without reading the file. No admin test rewrite is needed, and doing one would have destroyed working coverage of publish, queue and auth.

## Testing

1067 pipeline + 93 admin + 40 races-api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)