### PR TITLE
Put removal grounds under the contract too, and fix a stale docstring

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -33,6 +33,7 @@ from pipeline_client.agent.roster_contract import (
     SOURCE_CLASSES,
     classify_source_class,
     lacks_tier3_corroboration,
+    removal_grounds_sentence,
     tier_rejection_reason,
 )
 from pipeline_client.agent.source_types import normalize_source_type
@@ -931,13 +932,14 @@ def _make_editing_handlers(
             )
             return (
                 f"ERROR: remove_candidate blocked for '{name}'. {detail} "
-                "Use this tool only when the candidate has actually left the race — withdrew, "
-                "was disqualified, lost a completed primary or convention, or is a former "
-                "officeholder who is not a candidate this cycle — and say so plainly in the "
-                "reason. If instead you found no evidence this person was ever a candidate here, "
-                "call remove_candidate with not_on_roster=true and cite the roster listing for "
-                "this race that enumerates the field without them. Do NOT use this tool to fix "
-                "data quality issues."
+                # Same grounds the prompt states and the adjudicator is asked about,
+                # from one definition — restating them here is how the prompt and
+                # the handler drifted apart before.
+                f"Use this tool only when the candidate has actually left the race: {removal_grounds_sentence()}. "
+                "Say which, plainly, in the reason. If instead you found no evidence this person "
+                "was ever a candidate here, call remove_candidate with not_on_roster=true and cite "
+                "the roster listing for this race that enumerates the field without them. Do NOT "
+                "use this tool to fix data quality issues."
             )
 
         if is_structural_garbage:

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -10,7 +10,7 @@ Optionally followed by OpenRouter-backed multi-model **review**.
 
 from shared.models import CanonicalIssue
 
-from .roster_contract import render_completeness_rules, render_membership_rules, render_roster_cap_rules
+from .roster_contract import render_completeness_rules, render_membership_rules, render_removal_rules, render_roster_cap_rules
 
 CANONICAL_ISSUES = [e.value for e in CanonicalIssue]
 
@@ -1109,39 +1109,13 @@ STEP 2 — Make corrections using your tools:
 
 @@MEMBERSHIP_EVIDENCE_RULES@@
 
-IMPORTANT — remove_candidate rules:
-- ONLY call remove_candidate when you have a specific, verifiable source showing
-  the candidate is no longer actively competing: they withdrew, were disqualified,
-  or were eliminated in a completed primary or convention.
-- Do NOT use remove_candidate to fix data quality issues, biography errors,
-  incorrect facts, or anything else related to the candidate's profile data.
-- Do NOT remove a candidate without a credible source (news article, official
-  election results, Ballotpedia page) confirming they are no longer competing.
-- For primary/runoff/convention outcomes, search for "[state] [party] primary
-  results" with the election year from {current_date}, then verify any removal
-  against official/certified results or multiple credible dated sources. If the
-  result is uncertain or only inferred from an incomplete page, keep the
-  candidate.
-- After a party primary has officially concluded, include only that party's
-  nominee(s) who advanced. Remove other candidates from that party only when you
-  can cite a dated source showing they lost or did not advance.
-- If you're unsure whether someone was eliminated, search specifically for their
-  name + primary results before deciding, and keep them if uncertainty remains.
-- Do NOT infer winners or losers from an empty/stale Ballotpedia page, a missing
-  candidate listing, or a generated Ballotpedia URL that fails to load.
-- If a name in the profile has no evidence of candidacy anywhere AND your best
-  roster listing for this exact race lists the other candidates without them,
-  remove them with not_on_roster=true and cite that listing. This is the correct
-  path for phantom entries — do not force it into a withdrawal reason, and do not
-  use it when the listing failed to load, came back empty, or was truncated.
+@@REMOVAL_RULES@@
 - Treat articles and candidate pages published before a completed primary as
   historical evidence, not proof that the person remains active as of
   {current_date}. Verify primary outcomes before adding anyone from an older
   candidate list.
-- Never infer the result of an election scheduled after {current_date}. Keep all
-  verified runoff participants until that runoff has actually concluded.
-- Data corrections (wrong biography, bad sources, etc.) are handled in later
-  pipeline phases — ignore them here.
+- Keep all verified runoff participants until that runoff has actually concluded
+  as of {current_date}.
 
 STEP 2.6 — Record the CURRENT contest stage:
 Contest stage is a statement about the calendar as of {current_date}, not a
@@ -1204,6 +1178,7 @@ for _token, _rendered in (
     ("@@MEMBERSHIP_EVIDENCE_RULES@@", render_membership_rules()),
     ("@@COMPLETENESS_EVIDENCE_RULES@@", render_completeness_rules()),
     ("@@ROSTER_CAP_RULES@@", render_roster_cap_rules()),
+    ("@@REMOVAL_RULES@@", render_removal_rules()),
 ):
     if _token not in ROSTER_SYNC_USER:  # pragma: no cover - guards against silent drift
         raise RuntimeError(f"ROSTER_SYNC_USER is missing the {_token} slot")

--- a/pipeline_client/agent/roster_adjudicator.py
+++ b/pipeline_client/agent/roster_adjudicator.py
@@ -26,11 +26,11 @@ Determinism: pinned model, temperature 0, and an in-process cache keyed by
 :data:`ADJUDICATOR_MODEL` is pinned to an explicit version rather than a floating
 alias — a silent upgrade would move a publish gate with no commit to point at.
 
-Note the model choice is deliberate: the nano tier is cheaper, but OpenRouter
-rejects a ``temperature`` parameter for it, so a nano adjudicator could not be
-pinned to 0 and its run-to-run variance would land directly on a publish gate.
-The mini tier costs slightly more per call and there are only a handful of calls
-per run, which is the right trade for a gate.
+The tier choice is deliberate and is explained at :data:`ADJUDICATOR_MODEL`.
+The short version: the nano tier is unusable here because OpenRouter rejects a
+``temperature`` parameter for it, so the gate could not be pinned to 0, and it
+returns empty content under a tight token budget — which on a fail-closed gate
+reads as a rejection of valid evidence.
 
 Availability: this gate **fails closed**. If the provider is unreachable, out of
 quota, or returns something unparseable, the claim is rejected with a reason

--- a/pipeline_client/agent/roster_contract.py
+++ b/pipeline_client/agent/roster_contract.py
@@ -297,6 +297,47 @@ page cannot be distinguished from a truncated one.
 - When nothing else lists the full field, fetch the Ballotpedia race page."""
 
 
+#: What counts as a candidate genuinely leaving the race. Stated once because it
+#: is asserted in three places — the prompt that instructs the model, the error
+#: the tool returns when it refuses, and the question the adjudicator is asked.
+#: Three hand-written copies is how the prompt and the handler drifted apart in
+#: the first place.
+REMOVAL_GROUNDS: tuple[str, ...] = (
+    "withdrew or dropped out",
+    "was disqualified",
+    "lost a completed primary, runoff, or convention",
+    "is a former officeholder who is not a candidate this cycle",
+)
+
+
+def removal_grounds_sentence() -> str:
+    """The grounds as one clause, for embedding in an error or a prompt line."""
+    return ", ".join(REMOVAL_GROUNDS[:-1]) + f", or {REMOVAL_GROUNDS[-1]}"
+
+
+def render_removal_rules() -> str:
+    """Render the rules for taking a candidate off the roster."""
+    grounds = "\n".join(f"  - {ground}" for ground in REMOVAL_GROUNDS)
+    return f"""\
+IMPORTANT — remove_candidate rules:
+- Call remove_candidate only when the candidate has actually left this race:
+{grounds}
+  State which one plainly in the reason. The tool judges the reason you give, so
+  write what happened rather than a formula — it is read, not pattern-matched.
+- Do NOT use remove_candidate to fix data quality issues, biography errors, or
+  anything else about the candidate's profile. Those are handled in later phases.
+- Absence from a page is not an exit. If you found no evidence this person was
+  ever a candidate here, call remove_candidate with not_on_roster=true and cite
+  the roster listing for this exact race that enumerates the field without them.
+  Do not force that into a withdrawal reason.
+- Do NOT infer a result from an empty or stale page, a missing listing, or a
+  generated URL that failed to load, and never infer the result of an election
+  scheduled after the current date.
+- If you are unsure whether someone was eliminated, search their name plus the
+  primary result before deciding, and keep them if uncertainty remains. A stale
+  candidate is a smaller error than a deleted real one."""
+
+
 def render_roster_cap_rules() -> str:
     """Render the roster size cap, sourced from the same constant that enforces it."""
     per_major_party = ROSTER_CAP // 2

--- a/tests/test_roster_contract.py
+++ b/tests/test_roster_contract.py
@@ -160,3 +160,36 @@ def test_completeness_tiers_exclude_snippets():
     """A snippet of a list page is indistinguishable from a truncated one."""
     snippet_tiers = {tier.tier for tier in MEMBERSHIP_TIERS if tier.retrieval_status == "snippet"}
     assert not (COMPLETENESS_TIERS & snippet_tiers)
+
+
+# --- removal grounds: stated once, asserted in three places -------------------
+
+
+def test_prompt_and_handler_state_the_same_removal_grounds():
+    """The prompt instructs, the tool refuses, and the adjudicator judges — all
+    from REMOVAL_GROUNDS. Three hand-written copies is how they drifted before."""
+    from pipeline_client.agent.roster_contract import REMOVAL_GROUNDS, removal_grounds_sentence
+
+    rendered = ROSTER_SYNC_USER.casefold()
+    for ground in REMOVAL_GROUNDS:
+        assert ground.casefold() in rendered, f"prompt omits removal ground: {ground!r}"
+
+    sentence = removal_grounds_sentence().casefold()
+    for ground in REMOVAL_GROUNDS:
+        assert ground.casefold() in sentence
+
+
+def test_removal_grounds_are_not_empty():
+    """Guards against the assertions above passing vacuously."""
+    from pipeline_client.agent.roster_contract import REMOVAL_GROUNDS
+
+    assert len(REMOVAL_GROUNDS) >= 3
+
+
+def test_adjudicator_withdrawal_question_covers_the_same_grounds():
+    """The judge must be asked about the grounds the caller was told to cite."""
+    from pipeline_client.agent.roster_adjudicator import _CLAIM_QUESTIONS, Claim
+
+    question = _CLAIM_QUESTIONS[Claim.WITHDRAWAL].casefold()
+    for keyword in ("withdraw", "disqualified", "primary", "former officeholder"):
+        assert keyword in question, f"withdrawal question omits {keyword!r}"


### PR DESCRIPTION
Two loose ends from the adjudicator work that I flagged and hadn't gone back to.

## The withdrawal policy was still stated three times by hand

The prompt that instructs the model, the error the tool returns when it refuses, and the question the adjudicator is asked — all written independently. That's exactly the arrangement `roster_contract` exists to prevent. It was the one claim I never brought under it, so the drift risk quietly reopened in that corner while the other four were closed.

`REMOVAL_GROUNDS` now states them once. The prompt renders from it, the handler's refusal quotes it, and a test asserts the adjudicator's question still covers the same ground.

`ROSTER_SYNC_USER` drops 34 hand-written lines for a rendered block plus the two rules that genuinely need `{current_date}` — 221 → 214 lines.

## A docstring that argued the opposite of the code

The adjudicator module docstring still justified the mini tier on the grounds that it "costs slightly more per call... which is the right trade." That was written before the model moved to Luna, which is **7.5x cheaper** than what it replaced — so the docstring contradicted the comment on `ADJUDICATOR_MODEL` twenty lines below it.

Replaced with a pointer to that comment plus the part still true: nano can't be pinned to `temperature=0` and returns empty content under a tight budget, which a fail-closed gate reads as rejecting valid evidence.

## Testing

1070 pipeline + 93 admin + 40 races-api. Live suite re-run after the prompt change: **9/9**.

## One thing left for you

The orphaned `admin-agent-dev@smartervote.iam.gserviceaccount.com` still exists in GCP. I removed it from terraform state (which unblocked deploys) but deleting the identity itself was gated — reasonably, it's destructive. Re-verified unused: 0 Cloud Run services, 0 IAM bindings, 0 terraform state entries.

```
gcloud iam service-accounts delete admin-agent-dev@smartervote.iam.gserviceaccount.com --project smartervote
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)