### PR TITLE
Stop grading a refresh on issue research it never ran

### DIFF
--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -919,6 +919,7 @@ async def run_agent(
                 metrics_sink=review_metrics,
                 review_cache=review_cache,
                 run_budget=run_budget,
+                issues_step_ran=_step_enabled("issues"),
             )
             race_json["reviews"] = reviews
             # Log review results to live logs
@@ -1006,6 +1007,7 @@ async def run_agent(
                         metrics_sink=review_metrics,
                         review_cache=review_cache,
                         run_budget=run_budget,
+                        issues_step_ran=_step_enabled("issues"),
                     )
                     reviewed_packet = updated_packet
                     race_json["reviews"] = reviews

--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -549,8 +549,17 @@ def _implausible_incumbency_claim(race_json: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def check_profile_quality(race_json: Dict[str, Any]) -> Dict[str, Any]:
-    """Run deterministic checks for important quality failures reviewers may miss."""
+def check_profile_quality(race_json: Dict[str, Any], *, issues_step_ran: bool = True) -> Dict[str, Any]:
+    """Run deterministic checks for important quality failures reviewers may miss.
+
+    ``issues_step_ran`` says whether issue research was in scope for this run. A
+    lightweight refresh deliberately skips it, and grading such a run on stances
+    it was never asked to collect measures the wrong thing: md-house-01-2026 was
+    approved by 3/3 reviewers at an average of 93 and still landed on grade C,
+    because the absent stances capped the score at 79 and blocked publication.
+    The gap is still reported — it is real, and the race does need issue research
+    eventually — but as ``info`` so it does not fail a run that was never trying.
+    """
     flags = []
     try:
         RaceJSON.model_validate(race_json)
@@ -660,8 +669,10 @@ def check_profile_quality(race_json: Dict[str, Any]) -> Dict[str, Any]:
                 {
                     "field": f"candidates[{index}].issues",
                     "concern": f"Candidate is missing canonical issues: {', '.join(missing_issues)}.",
-                    "suggestion": "Complete all canonical issue stances before final review.",
-                    "severity": "error",
+                    "suggestion": "Complete all canonical issue stances before final review."
+                    if issues_step_ran
+                    else "Issue research was not part of this run; queue the issues step when depth is wanted.",
+                    "severity": "error" if issues_step_ran else "info",
                 }
             )
         summary = candidate.get("summary")
@@ -763,6 +774,7 @@ async def run_reviews(
     metrics_sink: Optional[Dict[str, Any]] = None,
     review_cache: Optional[Dict[str, Any]] = None,
     run_budget: RunBudget | None = None,
+    issues_step_ran: bool = True,
 ) -> List[Dict[str, Any]]:
     """Run review roles in parallel through OpenRouter."""
     import os
@@ -827,7 +839,7 @@ async def run_reviews(
                     f"Removed {removed_dead_sources} candidate source occurrence(s) confirmed dead by HTTP status.",
                 )
             link_review = await check_profile_links(race_json, on_log=on_log, run_budget=run_budget)
-        quality_review = check_profile_quality(race_json)
+        quality_review = check_profile_quality(race_json, issues_step_ran=issues_step_ran)
         cached_deterministic = {
             "link_review": copy.deepcopy(link_review),
             "quality_review": copy.deepcopy(quality_review),

--- a/tests/test_models_review.py
+++ b/tests/test_models_review.py
@@ -820,3 +820,37 @@ async def test_verify_url_marks_tls_failure_permanent():
         _reason, permanent = await _verify_url(AsyncMock(), "https://www.sos.alabama.gov/doc.pdf")
 
     assert permanent is True
+
+
+def test_missing_issues_does_not_fail_a_run_that_skipped_issue_research():
+    """A lightweight refresh does not collect issue stances, so grading it on their
+    absence measures the wrong thing. md-house-01-2026 was approved by 3/3
+    reviewers at an average of 93 and still graded C, because the missing stances
+    capped the score at 79 and blocked publication. The gap is still reported, as
+    info, because the race does eventually need issue research."""
+    from pipeline_client.agent.review import check_profile_quality, compute_validation_grade
+
+    profile = _valid_review_profile()
+    for candidate in profile["candidates"]:
+        candidate["issues"] = {}
+
+    scoped_out = check_profile_quality(profile, issues_step_ran=False)
+    missing = [f for f in scoped_out["flags"] if f["field"].endswith(".issues")]
+    assert missing, "the gap must still be reported"
+    assert all(f["severity"] == "info" for f in missing)
+
+    in_scope = check_profile_quality(profile, issues_step_ran=True)
+    assert any(f["severity"] == "error" for f in in_scope["flags"] if f["field"].endswith(".issues"))
+
+    approvals = [
+        {"model": "anthropic/claude-haiku-4.5", "verdict": "approved", "score": 92, "flags": []},
+        {"model": "google/gemini-3.1-flash-lite", "verdict": "approved", "score": 96, "flags": []},
+        {"model": "x-ai/grok-4.3", "verdict": "approved", "score": 92, "flags": []},
+    ]
+    refreshed = compute_validation_grade(approvals + [scoped_out])
+    assert refreshed["passed"] is True, refreshed["summary"]
+    assert refreshed["grade"] in {"A", "B"}
+
+    researched = compute_validation_grade(approvals + [in_scope])
+    assert researched["passed"] is False
+    assert researched["score"] == 79


### PR DESCRIPTION
Follow-on to #259, which merged while this was still in flight.

A lightweight refresh deliberately skips issue research, but
`check_profile_quality` flagged every missing canonical stance as
`severity: error`. Warning-or-higher flags cap the validation score at 79, so a
refreshed race could not clear the 80 needed to publish no matter how good it
was.

md-house-01-2026 is the case that surfaced it:

```
grade C, score 79, passed: false
"3/3 reviewers approved, average score capped at 79/100
 because 1 warning-or-higher quality flag(s) remain"

anthropic/claude-haiku-4.5    approved  92
google/gemini-3.1-flash-lite  approved  96
x-ai/grok-4.3                 approved  92
automated-profile-quality     flagged   [error] candidates[2].issues:
                                        missing canonical issues: ...
```

Every reviewer approved it, averaging 93. The only thing holding it under the
bar was the absence of data the run was never asked to collect.

This also made the gate incoherent in a way that punished doing more work: a
race with **no** validation grade publishes fine, so running `review` on a
shallow race moved it from publishable to blocked. The 26 races published on
2026-08-03 cleared precisely because they had never been reviewed.

`check_profile_quality` now takes `issues_step_ran`, threaded from
`_step_enabled("issues")` at both review call sites. When issue research was out
of scope the flag drops to `info` — still reported, because the gap is real and
those races do want research eventually, but no longer scoring a run against
work it never attempted. Default stays `True`, so full runs are unchanged.

Verified on the same race afterwards: `automated-profile-quality` returns zero
blocking flags. It is still blocked, but now for a genuine reason a reviewer
found — the summary says Schwartz "worked for over 14 years" at CSBS while
`career_history` records `start_year: 2024`. That is the gate doing its job.

Gates: pipeline 1087 passed, black/isort clean.
