### PR TITLE
Unblock provisional rosters; make the forecast prompt match its gate

### DIFF
--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -185,12 +185,18 @@ async def _run_update(
                 # about why. Keep the per-candidate-evidenced roster we hold,
                 # say plainly that it may be incomplete, point at the sources we
                 # did find, and let the rest of the refresh run.
+                # Deliberately does NOT re-queue discovery in remaining_steps.
+                # Discovery ran, reached a defensible conclusion, and recorded it;
+                # "still to do" would be a lie about what happened. Leaving it
+                # there also made the race unpublishable — the publish gate allows
+                # a pending `review` but nothing else, so fl-house-10-2026 (a
+                # decided, uncontested race whose roster is correct) was blocked
+                # by bookkeeping rather than by any doubt about its data. The
+                # provisional status is already recorded on roster_research and as
+                # a step failure, and every refresh re-runs discovery anyway.
                 _record_provisional_roster(race_json, log)
                 pipeline_state = race_json.setdefault("pipeline_state", {})
                 pipeline_state["complete"] = False
-                remaining_steps = pipeline_state.setdefault("remaining_steps", [])
-                if "discovery" not in remaining_steps:
-                    remaining_steps.append("discovery")
                 track(
                     "progress",
                     "discovery",

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -436,8 +436,14 @@ Set a forecast using these rating bands:
 
 Use party_probabilities with normalized party labels such as "Democratic",
 "Republican", "Independent", or "Other". Keep probabilities between 0 and 1.
-Use source_urls from existing polling source_url values only. If no numeric
+Use source_urls from existing polling source_url values. If no numeric
 polls exist, source_urls may be empty and based_on_poll_count should be 0.
+If your rationale, takeaway, or key_reasons NAME a rating outfit
+(Cook Political Report, Inside Elections, Sabato's Crystal Ball) you must also
+put that outfit's own URL in source_urls. Naming a rating you cannot cite is
+what gets a forecast rejected, so if you do not have the URL, describe the
+district's lean in your own words instead of attributing it. An unsourced
+judgement about partisan lean is fine; an unsourced attribution is not.
 Set predicted_winner_name only when the likely winner is an exact candidate
 name from the roster above. If the nominee is unresolved or only a party is
 favored, leave predicted_winner_name empty/null and use predicted_winner_party. If the race is a toss-up and neither party is favored, set predicted_winner_party to "Toss-up".

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -417,3 +417,41 @@ def test_contest_stage_is_not_presented_as_locked_identity():
     assert "pre_primary" not in locked_block
     assert "pre_primary" in status_block
     assert "re-verify against today's date" in context
+
+
+def test_forecast_prompt_and_evidence_gate_agree_on_named_rating_sources():
+    """`forecast_evidence_gaps` rejects a forecast that names Cook Political Report
+    without citing cookpolitical.com. The prompt used to say source_urls were for
+    polling "only", so the model followed it, cited "D+13 Cook PVI" in prose, and
+    was degraded for it on race after race — the same prompt-vs-gate drift this
+    file exists to catch."""
+    from pipeline_client.agent.prompts import FORECAST_USER
+    from shared.race_cleanup import forecast_evidence_gaps
+
+    assert "Cook Political Report" in FORECAST_USER
+    assert "source_urls" in FORECAST_USER
+    assert "polling source_url values only" not in FORECAST_USER
+
+    named_without_citation = {
+        "forecast": {
+            "rationale": "Cook Political Report rates this race Solid R.",
+            "source_urls": ["https://www.fec.gov/data/candidate/H0MD01000/"],
+        }
+    }
+    assert "missing_cook_source" in forecast_evidence_gaps(named_without_citation)
+
+    named_with_citation = {
+        "forecast": {
+            "rationale": "Cook Political Report rates this race Solid R.",
+            "source_urls": ["https://www.cookpolitical.com/ratings/house-race-ratings"],
+        }
+    }
+    assert "missing_cook_source" not in forecast_evidence_gaps(named_with_citation)
+
+    unattributed_lean = {
+        "forecast": {
+            "rationale": "The district has voted Republican by double digits in recent cycles.",
+            "source_urls": [],
+        }
+    }
+    assert forecast_evidence_gaps(unattributed_lean) == ["missing_explicit_sources"]

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -547,7 +547,10 @@ async def test_unproven_roster_completeness_keeps_going_and_says_so():
     # race stale AND silent about why), and health degrades rather than fails.
     assert mock_loop.await_count > 1
     assert result["pipeline_state"]["complete"] is False
-    assert "discovery" in result["pipeline_state"]["remaining_steps"]
+    # Discovery ran and reached a conclusion, so it is not "still to do". Saying
+    # otherwise blocked publication of races whose rosters were correct — the
+    # publish gate tolerates a pending review and nothing else.
+    assert "discovery" not in (result["pipeline_state"].get("remaining_steps") or [])
     assert result["run_health"]["status"] == "degraded"
     roster_research = result["pipeline_state"]["roster_research"]
     assert roster_research["completeness_status"] == "unproven"


### PR DESCRIPTION
Two fixes found while refreshing ~65 races. Both are the same shape as #259 and
#260: something downstream disagreeing with what the pipeline was actually asked
to do.

## A provisional roster blocked its own publication

When discovery cannot prove a field is complete it keeps the evidenced roster
and records `roster_completeness_unproven` — an honest partial rather than a
failure (#259). But it also re-queued `discovery` in `remaining_steps`, and the
publish gate tolerates a pending `review` and nothing else. So the race was
blocked by bookkeeping rather than by any doubt about its data.

fl-house-10-2026 is the case: a decided, uncontested race whose primaries were
cancelled and whose roster of one is exactly right. It could not publish.

Discovery ran and reached a defensible conclusion, so listing it as "still to do"
was simply false. The provisional status is already recorded on
`roster_research.completeness_status` and as a step failure, and every refresh
re-runs discovery anyway, so nothing is lost by not re-queueing it.

## The forecast prompt contradicted the forecast gate

`forecast_evidence_gaps` rejects a forecast whose prose names Cook Political
Report without citing cookpolitical.com. The prompt said:

> Use source_urls from existing polling source_url values **only**.

So the model did as instructed, wrote "D+13 Cook PVI" in its rationale, and was
degraded for it — on race after race, `missing_cook_source` was the single most
common health flag in this batch.

The prompt now tells the model that naming a rating outfit obliges it to cite
that outfit, and that describing a district's lean in its own words is the
correct move when it has no URL. An unsourced judgement about partisan lean is
fine; an unsourced attribution to a named authority is not.

The added test asserts the prompt and `forecast_evidence_gaps` agree, since the
drift between them is the actual defect.

## Effect

29 races published today (55 across both sessions). Refreshes that had been
single-candidate stubs gained real fields — wa-house-06 1→5, co-house-05 2→6,
nj-house-08 1→4, sc-house-07 / tx-house-01 / tx-house-31 1→3.

Measured cost: **$0.066 per refresh**. Full runs with `refinement` + `review`
are far pricier — mo-house-01-2026 cost $0.636 and took 45 minutes — so they are
worth reserving for races with specific reviewer-flagged defects. Refinement did
fix md-house-01-2026's summary/career-history contradiction, which let it
publish.

Gates: pipeline 1088 passed, black/isort clean.
