### PR TITLE
Treat CD-5 shorthand as naming the congressional contest

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -111,14 +111,22 @@ def _source_supports_exact_contest(source: Dict[str, Any], *, race_id: str) -> b
     district = str(int(match.group(1)))
     ordinal = _ordinal_word(int(match.group(1)))
     text = _roster_source_text(source)
+    # "CD5" / "CD-5" is congressional-district shorthand, so it establishes the
+    # office and the district at once. Counting it only toward the district half
+    # meant a source had to *also* spell out "Congress" somewhere, and headlines
+    # do not: az-house-05-2026 was blocked on "Mark Lamb wins Republican primary,
+    # Elizabeth Lee wins Democratic primary in Arizona CD5" — correct evidence for
+    # a correct two-nominee roster — and shipped missing the Democratic nominee.
+    cd_shorthand = bool(re.search(rf"\bcd\s*[-#]?\s*0*{re.escape(district)}\b", text))
     federal_house = bool(
-        re.search(r"\b(?:u\.?s\.?|united states)\s+(?:house|representative)", text)
+        cd_shorthand
+        or re.search(r"\b(?:u\.?s\.?|united states)\s+(?:house|representative)", text)
         or re.search(r"\bcongress(?:ional)?\b", text)
     )
     exact_district = bool(
-        re.search(rf"\b0*{re.escape(district)}(?:st|nd|rd|th)?\s+(?:congressional\s+)?district\b", text)
+        cd_shorthand
+        or re.search(rf"\b0*{re.escape(district)}(?:st|nd|rd|th)?\s+(?:congressional\s+)?district\b", text)
         or re.search(rf"\b(?:congressional\s+)?district\s*(?:no\.?\s*)?#?0*{re.escape(district)}\b", text)
-        or re.search(rf"\bcd\s*[-#]?\s*0*{re.escape(district)}\b", text)
         # Statewide certification documents commonly title the table
         # "Congressional Districts" and label each row only "District 2".
         or re.search(

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -2801,3 +2801,23 @@ def test_completeness_adjudication_is_asked_about_the_whole_proposed_roster():
     prompt = str(seen.get("messages"))
     for name in ("Andy Harris", "Dan Schwartz", "Edward Shlikas"):
         assert name in prompt, f"{name} missing from adjudicator prompt"
+
+
+def test_cd_shorthand_establishes_both_office_and_district():
+    """ "CD5" is congressional-district shorthand, so it names the office and the
+    district at once. Counting it only toward the district meant a source also had
+    to spell out "Congress" — which headlines do not. az-house-05-2026 was blocked
+    on "Mark Lamb wins Republican primary, Elizabeth Lee wins Democratic primary in
+    Arizona CD5" and published missing the Democratic nominee."""
+    from pipeline_client.agent.handlers import _source_supports_exact_contest
+
+    headline = {
+        "title": "",
+        "evidence": "Mark Lamb wins Republican primary, Elizabeth Lee wins Democratic primary in Arizona CD5",
+    }
+    assert _source_supports_exact_contest(headline, race_id="az-house-05-2026") is True
+
+    # The guards that make this check worth having must survive.
+    assert _source_supports_exact_contest(headline, race_id="az-house-07-2026") is False
+    state_leg = {"title": "", "evidence": "Arizona House District 5 state legislature race"}
+    assert _source_supports_exact_contest(state_leg, race_id="az-house-05-2026") is False


### PR DESCRIPTION
az-house-05-2026 published showing one of its two general-election nominees.
Mark Lamb was there; Elizabeth Lee, who won the Democratic primary with 64.5%,
was not.

The pipeline did not get this wrong. It found the right article, and called
`finalize_roster` with **both** nominees and a correct source for each:

```
finalize_roster(candidates=[
  {name: "Mark Lamb",     party: "Republican", roster_sources: [kjzz...]},
  {name: "Elizabeth Lee", party: "Democratic", roster_sources: [kjzz...]}],
  source_candidate_names=["Mark Lamb", "Elizabeth Lee"])

→ BLOCKED: evidence does not name this exact contest and district
```

The evidence was the article's headline — *"Mark Lamb wins Republican primary,
Elizabeth Lee wins Democratic primary in Arizona CD5"*.
`_source_supports_exact_contest` requires two things: a federal-House signal and
the district. `CD5` counted only toward the district, and the federal-House test
looks for the literal words "congress"/"congressional" or "U.S. House" — which
that headline does not contain. So a correct roster with correct evidence was
rejected on wording, and the race shipped missing a major-party nominee.

`CD5` is congressional-district shorthand. It establishes the office and the
district at the same time, so it now satisfies both halves.

The guards that make this check worth having are unchanged, and tested:

- `CD5` evidence against `az-house-07-2026` → still rejected
- "Arizona House District 5 state legislature race" against `az-house-05-2026` →
  still rejected, which is the same-number state-legislative contamination the
  function exists to catch

## The broader shape

This is the third time a deterministic string test has rejected authentic roster
evidence over phrasing: first "Second District" spelled out (#259), then
nicknames, where the fix was to hand identity matching to the adjudicator (#259),
and now an abbreviation. Each fix has enumerated one more way humans write
things.

`_source_supports_exact_contest` is the remaining place where that pattern lives,
and it is a reading judgment wearing a regex costume — the adjudicator already
asks whether a source names this exact office, district and cycle. Moving it
there is the real fix. It is deliberately not in this PR: that check also guards
against same-number state-legislative contamination, loosening it deserves its
own change with its own validation, and this one needed to ship first because a
live page was wrong.

az-house-05-2026 has been re-run and republished with both nominees.

Gates: pipeline 1089 passed, black/isort clean.
