### PR TITLE
Don't let a run that couldn't find the field delete someone from it

### DIFF
--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -357,6 +357,23 @@ def _candidate_names(data: Any) -> List[str]:
     return [c.get("name") for c in candidates if isinstance(c, dict) and c.get("name")]
 
 
+def _roster_completeness_unproven(data: Any) -> bool:
+    """Report whether the run said outright that it could not establish the full field.
+
+    Discovery records ``roster_completeness_unproven`` when no authoritative ballot or
+    qualified-candidate list was retrievable. The run is still useful — the candidates
+    it did evidence are real — but it has disclaimed knowing who else belongs.
+    """
+    if not isinstance(data, dict):
+        return False
+    health = data.get("run_health") if isinstance(data.get("run_health"), dict) else {}
+    if "roster_completeness_unproven" in {str(r) for r in health.get("reasons") or []}:
+        return True
+    roster = data.get("pipeline_state", {}) if isinstance(data.get("pipeline_state"), dict) else {}
+    research = roster.get("roster_research") if isinstance(roster.get("roster_research"), dict) else {}
+    return research.get("completeness_status") == "unproven"
+
+
 @mcp.tool(structured_output=False)
 async def audit_draft_vs_published(race_ids: List[str]) -> Dict[str, Any]:
     """Compare draft vs. published candidate rosters and validation grade for many races at once.
@@ -472,8 +489,10 @@ async def assess_publish_readiness(race_ids: List[str]) -> Dict[str, Any]:
 
     Checks draft presence, candidate roster, explicit validation pass, run health,
     pipeline completion, literal placeholder content, and draft-vs-published roster
-    changes. A race is ``ready`` only when it has no blockers. Warnings still require
-    human review but do not claim the API would reject publication.
+    changes — including blocking a draft that drops a published candidate without
+    being able to evidence the roster it kept. A race is ``ready`` only when it has
+    no blockers. Warnings still require human review but do not claim the API would
+    reject publication.
     """
     client = _client()
     rows: List[Dict[str, Any]] = []
@@ -537,6 +556,13 @@ async def assess_publish_readiness(race_ids: List[str]) -> Dict[str, Any]:
             warnings.append("first_publication")
         elif sorted(names) != sorted(published_names):
             warnings.append("candidate_roster_changes")
+            # Dropping a published candidate asserts they are not in this contest.
+            # A run that reported it could not establish the complete field has
+            # disclaimed exactly the knowledge that assertion needs, so let it add
+            # candidates but never quietly delete one. fl-house-11-2026 halved its
+            # roster to a single candidate on an unproven field and still read ready.
+            if set(published_names) - set(names) and _roster_completeness_unproven(draft):
+                blockers.append("roster_removal_on_unproven_field")
         rows.append(
             {
                 "race_id": race_id,

--- a/tests/test_smartervote_mcp_client.py
+++ b/tests/test_smartervote_mcp_client.py
@@ -408,6 +408,82 @@ async def test_assess_publish_readiness_blocks_failed_or_placeholder_drafts(monk
 
 
 @pytest.mark.asyncio
+async def test_assess_publish_readiness_blocks_roster_removal_on_unproven_field(monkeypatch):
+    """A run that could not confirm the field must not be trusted to shrink it.
+
+    fl-house-11-2026 refreshed from two published candidates down to one, on a run
+    whose own ``run_health`` said no authoritative ballot list was retrievable — and
+    still reported ready, because a roster change was only ever a warning.
+    """
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    unproven_health = {"status": "degraded", "reasons": ["roster_completeness_unproven"]}
+    responses = {
+        # Drops Shawn Bettis on a field the run admits it could not establish.
+        "/api/races/fl-house-11-2026/data": {
+            "candidates": [{"name": "Carey Baker"}],
+            "validation_grade": None,
+            "run_health": unproven_health,
+            "pipeline_state": {"complete": False, "remaining_steps": ["review"]},
+        },
+        "/races/fl-house-11-2026": {"candidates": [{"name": "Carey Baker"}, {"name": "Shawn Bettis"}]},
+        # Same unproven field, but only *adds* — nothing is being asserted away.
+        "/api/races/fl-house-12-2026/data": {
+            "candidates": [{"name": "Gus Bilirakis"}, {"name": "Newly Found"}],
+            "validation_grade": None,
+            "run_health": unproven_health,
+            "pipeline_state": {"complete": False, "remaining_steps": ["review"]},
+        },
+        "/races/fl-house-12-2026": {"candidates": [{"name": "Gus Bilirakis"}]},
+        # A removal is fine when the run actually established the field.
+        "/api/races/il-house-04-2026/data": {
+            "candidates": [{"name": "Patty Garcia"}, {"name": "Chris Getty"}],
+            "validation_grade": None,
+            "run_health": {"status": "healthy", "reasons": []},
+            "pipeline_state": {"complete": False, "remaining_steps": ["review"]},
+        },
+        "/races/il-house-04-2026": {"candidates": [{"name": "Patty Garcia"}, {"name": "Byron Sigcho-Lopez"}]},
+    }
+    monkeypatch.setattr(server, "_client", lambda: _StubRacesClient(responses))
+
+    result = await server.assess_publish_readiness(["fl-house-11-2026", "fl-house-12-2026", "il-house-04-2026"])
+
+    assert result["blocked_race_ids"] == ["fl-house-11-2026"]
+    assert "roster_removal_on_unproven_field" in result["rows"][0]["blockers"]
+    assert result["ready_race_ids"] == ["fl-house-12-2026", "il-house-04-2026"]
+
+
+@pytest.mark.asyncio
+async def test_assess_publish_readiness_reads_unproven_field_from_roster_research(monkeypatch):
+    """The flag also lives in ``pipeline_state.roster_research`` on older drafts."""
+    if find_spec("mcp") is None:
+        pytest.skip("MCP SDK is optional outside the local MCP environment")
+
+    from smartervote_mcp import server
+
+    responses = {
+        "/api/races/fl-house-11-2026/data": {
+            "candidates": [{"name": "Carey Baker"}],
+            "validation_grade": None,
+            "pipeline_state": {
+                "complete": False,
+                "remaining_steps": ["review"],
+                "roster_research": {"completeness_status": "unproven"},
+            },
+        },
+        "/races/fl-house-11-2026": {"candidates": [{"name": "Carey Baker"}, {"name": "Shawn Bettis"}]},
+    }
+    monkeypatch.setattr(server, "_client", lambda: _StubRacesClient(responses))
+
+    result = await server.assess_publish_readiness(["fl-house-11-2026"])
+
+    assert "roster_removal_on_unproven_field" in result["rows"][0]["blockers"]
+
+
+@pytest.mark.asyncio
 async def test_assess_publish_readiness_allows_unreviewed_maintenance_draft(monkeypatch):
     """A discovery/polling/forecast draft has no grade and the races-api still publishes it.
 


### PR DESCRIPTION
`fl-house-11-2026` refreshed from two published candidates down to one and
reported `ready: true`. Its own `run_health` said why it shouldn't have:

```
roster_completeness_unproven — "no authoritative qualified, certified, or
ballot list was retrievable, so others may be missing"
```

The run had disclaimed knowing who belongs in the contest, and then removed
someone from it. The draft contradicted itself on the way out, carrying
`active_candidate_count: 2` next to a one-name roster, and its polling step
declined a real FL-11 poll because the measured candidates "are not in the
current roster." Caught during a publish sweep; the draft was deleted and the
published version stands.

## Additions and removals are not the same claim

Readiness collapsed every roster difference into one warning,
`candidate_roster_changes`. But adding a candidate asserts *one more person is
running*, which that candidate's own `roster_sources` back. Removing one asserts
*a person is not running*, and nothing short of a complete field supports that.

So a removal now blocks when the run reported the field as unproven. The flag is
read from `run_health.reasons` and from
`pipeline_state.roster_research.completeness_status`, since older drafts only
carry the latter.

What still passes:

- **Additions on an unproven field** — a partial roster that grows is strictly
  better information, and the unproven note already tells readers it's partial.
- **Removals from an established field** — `il-house-04-2026` dropping Byron
  Sigcho-Lopez after his July 21 ballot disqualification is `healthy`, and
  published normally during the same sweep.

## On scope

The first version keyed off missing `roster_sources` instead: if you're dropping
people, show your work on who's left. The existing test fixture killed it
immediately — roughly 370 of ~460 races predate that field, so it would have
blocked most of the catalog from ever publishing again. The `unproven` flag is
the narrow signal that actually names the contradiction.

This is a readiness-gate change only. No pipeline behavior changes, and the
races-api publish endpoint is untouched — this tool is meant to *predict* that
endpoint, and it now refuses a case the endpoint would still accept, which is
the conservative direction for a batch-publish planner.

## Gates

`tests/test_smartervote_mcp_client.py` 31 passed · black/isort clean.

Two new tests cover the block, the additions-only case, the established-field
case, and the older `roster_research` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
