### PR TITLE
Project the seat split the model actually predicts

### DIFF
--- a/shared/forecast_summary.py
+++ b/shared/forecast_summary.py
@@ -319,18 +319,21 @@ def summarize_chamber(
     competitive_race_notes: list[tuple[int, str]] = []
 
     rep_holdovers = 0
+    holdover_seats = 0
     if chamber == "senate":
         for state, parties in SENATE_HOLDOVERS.items():
             seats = parties[:1] if state in active_states else parties
             for party in seats:
                 projected[party] += 1
                 expected[party] += 1
+                holdover_seats += 1
                 if party == "Republican":
                     rep_holdovers += 1
     elif chamber == "governors":
         for party in GOVERNOR_HOLDOVERS.values():
             projected[party] += 1
             expected[party] += 1
+            holdover_seats += 1
             if party == "Republican":
                 rep_holdovers += 1
 
@@ -411,6 +414,27 @@ def summarize_chamber(
             key = f"{r_seats}R-{d_seats}D"  # tie split
         if prob > 0.0005:  # Keep only non-trivial probabilities to limit payload size
             seat_distribution[key] = round(prob, 4)
+
+    # Projected seats is the single most likely joint outcome — the peak of the
+    # distribution above — rather than the sum of each race's most likely winner.
+    # Those are different statistics: summing per-race modes gives the mode of the
+    # marginals, which need not be the mode of the joint distribution. The Senate
+    # reported a 50-50 projection while its distribution actually peaked at
+    # 51D-49R, which contradicted a Democratic control call derived from the same
+    # probabilities and made the forecast unpublishable.
+    #
+    # This only holds when every seat is accounted for, because the non-Republican
+    # side is derived by subtraction. With a partial race set that subtraction
+    # would hand every unrepresented seat to the Democrats, so fall back to the
+    # per-race tally, which only ever counts seats it actually saw.
+    if holdover_seats + len(races) == total_chamber_seats:
+        mode_index = max(range(len(dp)), key=lambda index: dp[index])
+        mode_republican = rep_holdovers + mode_index
+        projected = {
+            "Democratic": total_chamber_seats - mode_republican,
+            "Republican": mode_republican,
+            "Other": 0,
+        }
 
     dem_control_probability = max(0.01, min(0.99, dem_control_probability))
     republican_probability = max(0.01, min(0.99, republican_probability))

--- a/tests/test_forecast_summary.py
+++ b/tests/test_forecast_summary.py
@@ -86,10 +86,14 @@ def test_chamber_forecast_counts_senate_tie_in_republican_probability():
             "title": f"{state} Senate",
             "office": "United States Senate",
             "state": state,
+            # Tuned so the seat distribution actually peaks at 18 Republican race
+            # wins, which lands on 50-50 once the 32 Republican holdovers are added.
+            # projected_seats reports that peak, so a fixture that merely gives
+            # Republicans more favored races is not enough to produce the tie.
             "forecast": {
-                "predicted_winner_party": "Democratic" if index < 15 else "Republican",
+                "predicted_winner_party": "Democratic" if index < 13 else "Republican",
                 "win_probability": 0.65,
-                "rating": "lean_d" if index < 15 else "lean_r",
+                "rating": "lean_d" if index < 13 else "lean_r",
             },
         }
         for index, state in enumerate(active_states)
@@ -101,6 +105,9 @@ def test_chamber_forecast_counts_senate_tie_in_republican_probability():
     assert senate["projected_seats"]["Democratic"] + senate["projected_seats"]["Republican"] == 100
     assert senate["projected_seats"]["Democratic"] == 50
     assert senate["projected_seats"]["Republican"] == 50
+    # The point of the fixture: an exact 50-50 is Republican control via the VP.
+    assert senate["control_party"] == "Republican"
+    assert senate["vp_tiebreak_party"] == "Republican"
     assert senate["outcome_probabilities"]["Republican"] >= senate["outcome_probabilities"]["tie_50_50"]
     assert "50-50 Senate" in senate["narrative"]
     assert senate["competitive_race_count"] >= len(senate["competitive_races"])
@@ -163,7 +170,15 @@ def test_chamber_forecast_control_party_tracks_control_probability():
 
     senate = build_chamber_forecasts(summaries)["chambers"]["senate"]
 
-    assert senate["projected_seats"] == {"Democratic": 49, "Republican": 51, "Other": 0}
+    # Republicans are favored in 19 of the 33 races to the Democrats' 14, so a
+    # per-race tally would project 51R-49D. The joint distribution peaks the other
+    # way, because winning 19 near-coin-flips is far less likely than the tally
+    # implies, and projected_seats reports that peak.
+    assert senate["projected_seats"] == {"Democratic": 51, "Republican": 49, "Other": 0}
+    mode_key = max(senate["seat_distribution"], key=senate["seat_distribution"].get)
+    assert mode_key == "51D-49R"
+    # control_party is still derived from control probability, never from the
+    # projected split.
     assert senate["outcome_probabilities"]["Democratic"] > senate["outcome_probabilities"]["Republican"]
     assert senate["control_party"] == "Democratic"
     assert senate["control_probability"] == senate["outcome_probabilities"]["Democratic"]
@@ -253,6 +268,34 @@ def test_default_chamber_story_names_competitive_races():
     assert "Georgia Senate" in senate["narrative"]
     assert "Texas Senate" in senate["opposing_party_path"]
     assert "competitive races to reach" not in senate["opposing_party_path"]
+
+
+def test_projected_seats_falls_back_to_tally_when_seats_are_unaccounted():
+    """A partial race set must not hand every unrepresented seat to one party.
+
+    projected_seats derives the non-Republican side by subtracting from the
+    chamber total, which is only sound when holdovers plus races cover every
+    seat. With a single governor race on the books, subtraction would report ~42
+    Democratic seats; the per-race tally reports only what it actually saw.
+    """
+    summaries = [
+        {
+            "id": "ga-governor-2026",
+            "office": "Governor",
+            "state": "Georgia",
+            "forecast": {
+                "predicted_winner_party": "Democratic",
+                "win_probability": 0.60,
+                "rating": "lean_d",
+                "party_probabilities": {"Democratic": 0.60, "Republican": 0.40},
+            },
+        }
+    ]
+
+    governors = build_chamber_forecasts(summaries)["chambers"]["governors"]
+
+    assert sum(governors["projected_seats"].values()) < 50
+    assert governors["projected_seats"]["Democratic"] < 42
 
 
 def test_governor_forecast_other_party_resolves_from_party_probabilities():


### PR DESCRIPTION
The Senate chamber forecast could not be published:

```
400  Senate 50-50 projected split must result in Republican control
```

Both halves of that conflict were individually correct. `control_party` came
from control probability, where Democrats led 50.7% to 49.3%. `projected_seats`
came from summing each race's most likely winner, which landed on 50-50 — and a
50-50 Senate is Republican control via the VP tie-break. The guard is right to
reject that pair.

## The projection was the wrong number

Summing per-race winners gives the mode of the *marginals*, which is not the
mode of the *joint* distribution — and the page already publishes that joint
distribution directly beside the projection. Its peak:

```
51D-49R   0.1979   <-- most likely single outcome
50R-50D   0.1965
```

The site was reporting a seat split that its own distribution disagreed with.
`projected_seats` is now that peak, so the headline, the control call, and the
distribution chart all derive from one calculation.

`control_party` is unchanged and still comes from control probability, never
from the projected split. The two can still legitimately diverge on a skewed
distribution; this only removes the divergence that was an artifact.

## Guarded on complete data

The non-Republican side is derived by subtraction from the chamber total, which
is only sound when holdovers plus races cover every seat. With a partial race
set that subtraction hands every unrepresented seat to the Democrats — a single
governor race projected 42 Democratic seats. It now falls back to the per-race
tally, which only counts seats it actually saw, with a test pinning that.

## The tie-break fixture was retuned, not deleted

`test_chamber_forecast_counts_senate_tie_in_republican_probability` exists to
verify that an exact 50-50 resolves to Republican control. Under the corrected
math its old 15D/18R split no longer produces a tie, so the test would have
silently stopped covering the tie-break path. It is tightened to 13D/20R, which
does produce a genuine 50-50, and now asserts `control_party == "Republican"`
and `vp_tiebreak_party == "Republican"` explicitly rather than inferring it from
narrative text.

## Note on live effect

`summarize_chamber` runs inside the deployed races-api, so the forecast page
does not change until this ships and the chamber forecasts are regenerated and
republished.

## Gates

pipeline `1093 passed, 9 skipped` · races-api `40 passed` · black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
