### PR TITLE
Import the Firestore collection names instead of retyping them

### DIFF
--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -673,7 +673,7 @@ def _get_other_state_candidates(race_id: str, state: str | None) -> set[str]:
             from google.cloud import firestore
 
             db = firestore.Client(project=project) if project else firestore.Client()
-            races_ref = db.collection("races").where("state", "==", state).stream()
+            races_ref = db.collection(FIRESTORE_RACES_COLLECTION).where("state", "==", state).stream()
             for doc in races_ref:
                 other_race_id = doc.id
                 if other_race_id == race_id:
@@ -686,7 +686,7 @@ def _get_other_state_candidates(race_id: str, state: str | None) -> set[str]:
             pass
     else:
         try:
-            from shared.config import local_paths
+            from shared.config import FIRESTORE_RACES_COLLECTION, local_paths
 
             prefix = race_id.split("-")[0].lower() if "-" in race_id else ""
             if not prefix:

--- a/pipeline_client/backend/firestore_logger.py
+++ b/pipeline_client/backend/firestore_logger.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 from pipeline_client.logging_utils import sanitize_log_data, sanitize_log_message, sanitize_log_message_with_metadata
-from shared.config import FIRESTORE_RUNS_COLLECTION
+from shared.config import FIRESTORE_RUN_LOGS_SUBCOLLECTION, FIRESTORE_RUNS_COLLECTION
 from shared.pipeline_config import RetentionConfig
 
 logger = logging.getLogger("pipeline")
@@ -135,10 +135,10 @@ class FirestoreLogger:
             if hasattr(db, "batch"):
                 batch = db.batch()
                 for doc_id, entry in pending:
-                    batch.set(run_ref.collection("logs").document(doc_id), entry)
+                    batch.set(run_ref.collection(FIRESTORE_RUN_LOGS_SUBCOLLECTION).document(doc_id), entry)
                 batch.commit()
             else:
-                logs = run_ref.collection("logs")
+                logs = run_ref.collection(FIRESTORE_RUN_LOGS_SUBCOLLECTION)
                 for doc_id, entry in pending:
                     logs.document(doc_id).set(entry)
         except Exception as exc:

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Deque, Dict, List, Optional, Set
 
 from pipeline_client.logging_utils import sanitize_log_message_with_metadata
-from shared.config import GCS_CHECKPOINTS_PREFIX, local_paths
+from shared.config import FIRESTORE_QUEUE_COLLECTION, GCS_CHECKPOINTS_PREFIX, local_paths
 from shared.pipeline_config import RetentionConfig
 
 
@@ -272,7 +272,7 @@ class AgentHandler:
                 db = _get_db()
                 if db is None:
                     return
-                doc = db.collection("pipeline_queue").document(queue_item_id).get()
+                doc = db.collection(FIRESTORE_QUEUE_COLLECTION).document(queue_item_id).get()
                 if doc.exists and (doc.to_dict() or {}).get("status") == "cancelled":
                     raise AgentCancelled(f"Run {run_id or ''} for {race_id} was cancelled")
             except AgentCancelled:
@@ -621,7 +621,7 @@ class AgentHandler:
                         "fetched_chars": cost_snapshot.get("fetched_chars", 0),
                         "page_budget_blocked": cost_snapshot.get("page_budget_blocked", 0),
                     }
-                db.collection("pipeline_queue").document(item_id).set(
+                db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id).set(
                     {
                         "id": item_id,
                         "race_id": current_race_id,

--- a/pipeline_client/backend/pipeline_metrics.py
+++ b/pipeline_client/backend/pipeline_metrics.py
@@ -13,7 +13,7 @@ import sqlite3
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
-from shared.config import local_paths
+from shared.config import FIRESTORE_METRICS_COLLECTION, local_paths
 
 logger = logging.getLogger("pipeline")
 
@@ -45,7 +45,7 @@ class PipelineMetricsStore:
         serper_calls      int
     """
 
-    _COLLECTION = "pipeline_metrics"
+    _COLLECTION = FIRESTORE_METRICS_COLLECTION
 
     def __init__(self) -> None:
         explicit_db_path = os.getenv("PIPELINE_METRICS_DB_PATH")

--- a/pipeline_client/backend/queue_processor.py
+++ b/pipeline_client/backend/queue_processor.py
@@ -25,6 +25,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
+from shared.config import FIRESTORE_QUEUE_COLLECTION, FIRESTORE_RACES_COLLECTION, FIRESTORE_RUNS_COLLECTION
 from shared.pipeline_config import RetentionConfig
 from shared.race_catalog import build_race_summary_fields, build_versioned_catalog_fields
 from shared.run_health import RunFailureReason, RunHealthStatus, classify_exception
@@ -69,7 +70,7 @@ def _lease_expired(data: Dict[str, Any], now: datetime) -> bool:
 
 def _set_race_if_current(db: Any, race_id: str, run_id: str, update: Dict[str, Any]) -> bool:
     """Update the race record only if this run still owns it (guards ghost writes)."""
-    race_ref = db.collection("races").document(race_id)
+    race_ref = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id)
     try:
         race_doc = race_ref.get()
         race_data = race_doc.to_dict() if getattr(race_doc, "exists", False) else {}
@@ -236,7 +237,7 @@ async def process_claimed_item(
     run_id = item_data.get("run_id") or uuid.uuid4().hex
     is_continuation = bool(item_data.get("is_continuation"))
     existing_data_gcs_path = item_data.get("existing_data_gcs_path")
-    item_ref = db.collection("pipeline_queue").document(item_id)
+    item_ref = db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id)
 
     if not race_id:
         item_ref.update(
@@ -250,7 +251,7 @@ async def process_claimed_item(
         )
         return
 
-    run_ref = db.collection("pipeline_runs").document(run_id)
+    run_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id)
     if not run_ref.get().exists:
         run_ref.set(
             {
@@ -272,7 +273,7 @@ async def process_claimed_item(
     else:
         run_ref.update({"status": "running", "queue_item_id": item_id})
 
-    db.collection("races").document(race_id).set(
+    db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).set(
         {"status": "running", "current_run_id": run_id, "race_id": race_id}, merge=True
     )
 
@@ -314,7 +315,7 @@ async def process_claimed_item(
                     failure_reason = RunFailureReason.BUDGET_EXHAUSTED
                     logger.warning(error_msg)
                     break
-                cont_ref = db.collection("pipeline_queue").document(exc.continuation_item_id)
+                cont_ref = db.collection(FIRESTORE_QUEUE_COLLECTION).document(exc.continuation_item_id)
                 cont_doc = cont_ref.get()
                 cont_data = cont_doc.to_dict() if getattr(cont_doc, "exists", False) else None
                 if not isinstance(cont_data, dict):
@@ -491,7 +492,9 @@ async def process_claimed_item(
         )
         draft_data = _load_gcs_json(gcs, bucket_name, f"drafts/{race_id}.json")
         if isinstance(draft_data, dict):
-            db.collection("races").document(race_id).set(_draft_catalog_update(race_id, draft_data), merge=True)
+            db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).set(
+                _draft_catalog_update(race_id, draft_data), merge=True
+            )
     else:
         reason = failure_reason or RunFailureReason.UNKNOWN_ERROR
         run_health = {

--- a/pipeline_client/backend/race_manager.py
+++ b/pipeline_client/backend/race_manager.py
@@ -21,13 +21,14 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
+from shared.config import FIRESTORE_RACE_RUNS_SUBCOLLECTION, FIRESTORE_RACES_COLLECTION
 from shared.pipeline_config import FreshnessConfig
 
 from .models import RunInfo, RunStatus
 
 logger = logging.getLogger("pipeline")
 
-_COLLECTION = "races"
+_COLLECTION = FIRESTORE_RACES_COLLECTION
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -199,7 +200,7 @@ class RaceManager:
                 if not doc_ref.get().exists:
                     return in_cache  # was in cache but not yet in Firestore
                 # Delete subcollection runs first
-                runs_ref = doc_ref.collection("runs")
+                runs_ref = doc_ref.collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
                 for run_doc in runs_ref.stream():
                     run_doc.reference.delete()
                 doc_ref.delete()
@@ -502,7 +503,13 @@ class RaceManager:
     def get_run(self, race_id: str, run_id: str) -> Optional[RunInfo]:
         if self._db is not None:
             try:
-                doc = self._db.collection(_COLLECTION).document(race_id).collection("runs").document(run_id).get()
+                doc = (
+                    self._db.collection(_COLLECTION)
+                    .document(race_id)
+                    .collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
+                    .document(run_id)
+                    .get()
+                )
                 if doc.exists:
                     run = RunInfo(**(doc.to_dict() or {}))
                     self._local_runs.setdefault(race_id, {})[run_id] = run  # populate cache
@@ -521,7 +528,7 @@ class RaceManager:
                 docs = (
                     self._db.collection(_COLLECTION)
                     .document(race_id)
-                    .collection("runs")
+                    .collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
                     .order_by("started_at", direction=Query.DESCENDING)
                     .limit(limit)
                     .stream()
@@ -561,7 +568,12 @@ class RaceManager:
 
         if self._db is not None:
             try:
-                doc_ref = self._db.collection(_COLLECTION).document(race_id).collection("runs").document(run_id)
+                doc_ref = (
+                    self._db.collection(_COLLECTION)
+                    .document(race_id)
+                    .collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
+                    .document(run_id)
+                )
                 if doc_ref.get().exists:
                     doc_ref.delete()
                     return True
@@ -769,7 +781,13 @@ class RaceManager:
             logger.debug("Skipping Firestore write for deleted run %s/%s", race_id, run_id)
             return
         try:
-            (self._db.collection(_COLLECTION).document(race_id).collection("runs").document(run_id).set(data))
+            (
+                self._db.collection(_COLLECTION)
+                .document(race_id)
+                .collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
+                .document(run_id)
+                .set(data)
+            )
         except Exception:
             logger.exception("Firestore write_run failed for %s/%s", race_id, run_id)
 

--- a/pipeline_client/worker.py
+++ b/pipeline_client/worker.py
@@ -31,6 +31,8 @@ from typing import Any, Set
 
 from dotenv import load_dotenv
 
+from shared.config import FIRESTORE_QUEUE_COLLECTION
+
 load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
 
 # Shared backends use FIRESTORE_PROJECT for mode detection, while workstation
@@ -131,7 +133,7 @@ def _pending_items(db: Any, runner: str, limit: int = 50):
     """
     from google.cloud.firestore_v1 import FieldFilter  # type: ignore
 
-    query = db.collection("pipeline_queue").where(filter=FieldFilter("runner", "==", runner))
+    query = db.collection(FIRESTORE_QUEUE_COLLECTION).where(filter=FieldFilter("runner", "==", runner))
     query = query.where(filter=FieldFilter("status", "==", "pending"))
     docs = list(query.limit(limit).stream())
     items = []
@@ -149,7 +151,7 @@ async def _process_one(
 
     async with sem:
         lease_owner = f"{os.getenv('HOSTNAME', 'local-worker')}:{uuid.uuid4()}"
-        item_ref = db.collection("pipeline_queue").document(item_id)
+        item_ref = db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id)
         claimed = await asyncio.to_thread(claim_item, db, item_ref, lease_owner, runner)
         if not claimed:
             return  # lost the race / already terminal
@@ -219,7 +221,7 @@ async def run_worker() -> None:
             capacity = _CONCURRENCY - len(in_flight)
             queue_item_id = os.getenv("QUEUE_ITEM_ID", "").strip()
             if _ONCE and queue_item_id:
-                doc = db.collection("pipeline_queue").document(queue_item_id).get()
+                doc = db.collection(FIRESTORE_QUEUE_COLLECTION).document(queue_item_id).get()
                 data = doc.to_dict() if getattr(doc, "exists", False) else None
                 items = [(queue_item_id, data)] if isinstance(data, dict) else []
             else:

--- a/services/races-api/analytics_store.py
+++ b/services/races-api/analytics_store.py
@@ -14,6 +14,8 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
+from shared.config import FIRESTORE_ANALYTICS_EVENTS_COLLECTION
+
 logger = logging.getLogger("races_api")
 
 _SQLITE_EVENT_LIMIT = 10_000
@@ -143,7 +145,7 @@ class AnalyticsStore:
                 "ip_hash": ip_hash,
                 "referer": referer,
             }
-            await self._client.collection("analytics_events").add(doc)
+            await self._client.collection(FIRESTORE_ANALYTICS_EVENTS_COLLECTION).add(doc)
         except Exception:
             logger.debug("Firestore log_request failed", exc_info=True)
 
@@ -183,7 +185,7 @@ class AnalyticsStore:
     async def _overview_firestore(self, hours: int) -> Dict[str, Any]:
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
         try:
-            query = self._client.collection("analytics_events").where("timestamp", ">=", cutoff)
+            query = self._client.collection(FIRESTORE_ANALYTICS_EVENTS_COLLECTION).where("timestamp", ">=", cutoff)
             docs = [doc.to_dict() async for doc in query.stream()]
             return _compute_overview(docs, hours)
         except Exception:
@@ -214,7 +216,7 @@ class AnalyticsStore:
     async def _race_stats_firestore(self, hours: int) -> List[Dict[str, Any]]:
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
         try:
-            query = self._client.collection("analytics_events").where("timestamp", ">=", cutoff)
+            query = self._client.collection(FIRESTORE_ANALYTICS_EVENTS_COLLECTION).where("timestamp", ">=", cutoff)
             docs = [doc.to_dict() async for doc in query.stream()]
             return _compute_race_stats([d for d in docs if d.get("race_id")])
         except Exception:
@@ -246,7 +248,7 @@ class AnalyticsStore:
     async def _timeseries_firestore(self, hours: int, bucket_minutes: int) -> List[Dict[str, Any]]:
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
         try:
-            query = self._client.collection("analytics_events").where("timestamp", ">=", cutoff)
+            query = self._client.collection(FIRESTORE_ANALYTICS_EVENTS_COLLECTION).where("timestamp", ">=", cutoff)
             docs = [doc.to_dict() async for doc in query.stream()]
             return _compute_timeseries(docs, hours, bucket_minutes)
         except Exception:

--- a/services/races-api/firestore_helpers.py
+++ b/services/races-api/firestore_helpers.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import HTTPException
 
+from shared.config import FIRESTORE_RACES_COLLECTION
 from shared.race_catalog import build_race_summary_fields, build_versioned_catalog_fields
 
 _FIRESTORE_PROJECT = os.getenv("FIRESTORE_PROJECT") or os.getenv("PROJECT_ID")
@@ -64,7 +65,7 @@ def _fs_update_race(race_id: str, fields: Dict[str, Any]) -> None:
         fields.setdefault("updated_at", SERVER_TIMESTAMP)
         if fields.get("race_id") is None:
             fields["race_id"] = race_id
-        _get_fs().collection("races").document(race_id).set(fields, merge=True)
+        _get_fs().collection(FIRESTORE_RACES_COLLECTION).document(race_id).set(fields, merge=True)
     except Exception as exc:
         logging.warning("Firestore race update %s failed: %s", race_id, exc)
 

--- a/services/races-api/pipeline_diagnostics.py
+++ b/services/races-api/pipeline_diagnostics.py
@@ -12,6 +12,12 @@ import gcs_helpers
 from config import DATA_DIR
 
 from pipeline_client.logging_utils import sanitize_log_data
+from shared.config import (
+    FIRESTORE_QUEUE_COLLECTION,
+    FIRESTORE_RACES_COLLECTION,
+    FIRESTORE_RUN_LOGS_SUBCOLLECTION,
+    FIRESTORE_RUNS_COLLECTION,
+)
 
 _DIAGNOSTICS_SCHEMA = "smartervote.pipeline-diagnostics.v1"
 _MISSING_STANCE_MARKERS = {"", "draft", "no public position found", "unknown", "n/a"}
@@ -125,21 +131,21 @@ def _draft_summary(draft: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
 
 def build_diagnostics_bundle(run_id: str, db: Any) -> Optional[Dict[str, Any]]:
     """Combine run, queue, logs, race state, and draft output into one export."""
-    run_ref = db.collection("pipeline_runs").document(run_id)
+    run_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id)
     run = _plain(run_ref.get())
     if run is None:
         return None
 
-    log_query = run_ref.collection("logs").order_by("__name__").limit(_MAX_DIAGNOSTIC_LOGS)
+    log_query = run_ref.collection(FIRESTORE_RUN_LOGS_SUBCOLLECTION).order_by("__name__").limit(_MAX_DIAGNOSTIC_LOGS)
     logs = [_plain(doc) for doc in log_query.stream()]
     logs = [entry for entry in logs if entry is not None]
 
     logs.sort(key=_log_sort_key)
-    queue_docs = db.collection("pipeline_queue").where("run_id", "==", run_id).limit(100).stream()
+    queue_docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", run_id).limit(100).stream()
     queue_items = [item for item in (_plain(doc) for doc in queue_docs) if item is not None]
 
     race_id = str(run.get("race_id") or (run.get("payload") or {}).get("race_id") or "")
-    race_record = _plain(db.collection("races").document(race_id).get()) if race_id else None
+    race_record = _plain(db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()) if race_id else None
     draft = _load_draft(race_id) if race_id else None
 
     level_counts = Counter(str(entry.get("level") or "info").lower() for entry in logs)

--- a/services/races-api/routers/pipeline.py
+++ b/services/races-api/routers/pipeline.py
@@ -9,6 +9,8 @@ import gcp_costs
 from auth import verify_token
 from fastapi import APIRouter, Depends, HTTPException
 
+from shared.config import FIRESTORE_METRICS_COLLECTION, FIRESTORE_RUNS_COLLECTION
+
 router = APIRouter()
 
 
@@ -266,7 +268,7 @@ async def get_pipeline_metrics(limit: int = 50) -> Dict[str, Any]:
 
     # Primary source: pipeline_metrics (includes tokens/cost/model fields).
     try:
-        docs = db.collection("pipeline_metrics").order_by("timestamp", direction="DESCENDING").limit(limit).stream()
+        docs = db.collection(FIRESTORE_METRICS_COLLECTION).order_by("timestamp", direction="DESCENDING").limit(limit).stream()
         for doc in docs:
             plain = firestore_helpers._doc_to_plain(doc)
             if plain is None:
@@ -281,7 +283,12 @@ async def get_pipeline_metrics(limit: int = 50) -> Dict[str, Any]:
     # populated but stale metrics collection does not make current rows look free.
     try:
         for timestamp_field in ("progress_updated_at", "completed_at", "updated_at", "started_at"):
-            docs = db.collection("pipeline_runs").order_by(timestamp_field, direction="DESCENDING").limit(limit).stream()
+            docs = (
+                db.collection(FIRESTORE_RUNS_COLLECTION)
+                .order_by(timestamp_field, direction="DESCENDING")
+                .limit(limit)
+                .stream()
+            )
             for doc in docs:
                 plain = firestore_helpers._doc_to_plain(doc)
                 if plain is None:
@@ -351,7 +358,7 @@ async def get_pipeline_metrics_summary(hours: Optional[int] = None) -> Dict[str,
     metric_query_ok = False
     run_query_ok = False
     try:
-        docs = db.collection("pipeline_metrics").order_by("timestamp", direction="DESCENDING").limit(5000).stream()
+        docs = db.collection(FIRESTORE_METRICS_COLLECTION).order_by("timestamp", direction="DESCENDING").limit(5000).stream()
         for doc in docs:
             plain = firestore_helpers._doc_to_plain(doc)
             if plain is None:
@@ -363,7 +370,7 @@ async def get_pipeline_metrics_summary(hours: Optional[int] = None) -> Dict[str,
         logging.warning("Failed to summarize pipeline_metrics: %s", exc)
 
     try:
-        docs = db.collection("pipeline_runs").limit(5000).stream()
+        docs = db.collection(FIRESTORE_RUNS_COLLECTION).limit(5000).stream()
         for doc in docs:
             plain = firestore_helpers._doc_to_plain(doc)
             if plain is None or not _has_pipeline_cost_data(plain):

--- a/services/races-api/routers/queue.py
+++ b/services/races-api/routers/queue.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from request_models import RaceQueueRequest, validate_race_id
 from routers.utils import _queue_ttl_at
 
+from shared.config import FIRESTORE_QUEUE_COLLECTION, FIRESTORE_RACES_COLLECTION, FIRESTORE_RUNS_COLLECTION
 from shared.pipeline_config import PIPELINE_STEP_LABELS, PIPELINE_STEP_ORDER, PIPELINE_STEP_WEIGHTS, RetentionConfig
 
 router = APIRouter()
@@ -42,11 +43,11 @@ def _dispatch_if_cloud_run(db: Any, item: Dict[str, Any]) -> Dict[str, Any] | No
     try:
         dispatch = dispatch_pipeline_job(str(item["id"]))
         update = {"dispatch_status": "submitted", **dispatch}
-        db.collection("pipeline_queue").document(str(item["id"])).update(update)
+        db.collection(FIRESTORE_QUEUE_COLLECTION).document(str(item["id"])).update(update)
         return update
     except Exception as exc:
         error = f"Cloud Run Job dispatch failed: {exc}"
-        db.collection("pipeline_queue").document(str(item["id"])).update(
+        db.collection(FIRESTORE_QUEUE_COLLECTION).document(str(item["id"])).update(
             {"status": "failed", "dispatch_status": "failed", "error": error, "ttl_at": _queue_ttl_at()}
         )
         firestore_helpers._fs_update_race(
@@ -57,7 +58,7 @@ def _dispatch_if_cloud_run(db: Any, item: Dict[str, Any]) -> Dict[str, Any] | No
 
 def _current_run_is_terminal_or_missing(db: Any, run_id: str) -> bool:
     try:
-        run_doc = db.collection("pipeline_runs").document(run_id).get()
+        run_doc = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id).get()
         run_data = firestore_helpers._doc_to_plain(run_doc)
     except Exception:
         return False
@@ -69,14 +70,14 @@ def _current_run_is_terminal_or_missing(db: Any, run_id: str) -> bool:
 def _is_run_actually_active(db: Any, run_id: str) -> bool:
     """Return True only when run + queue docs both indicate active work."""
     try:
-        run_doc = db.collection("pipeline_runs").document(str(run_id)).get()
+        run_doc = db.collection(FIRESTORE_RUNS_COLLECTION).document(str(run_id)).get()
         run_data = firestore_helpers._doc_to_plain(run_doc)
     except Exception:
         return False
     if not run_data or run_data.get("status") not in _ACTIVE_STATUSES:
         return False
     try:
-        queue_docs = db.collection("pipeline_queue").where("run_id", "==", str(run_id)).limit(20).stream()
+        queue_docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", str(run_id)).limit(20).stream()
         return any((doc.to_dict() or {}).get("status") in _ACTIVE_STATUSES for doc in queue_docs)
     except Exception:
         return False
@@ -119,9 +120,9 @@ def _normalize_continuation_ancestors(items: list[Dict[str, Any]]) -> list[Dict[
 
 def _normalize_terminal_run_items(db: Any, items: list[Dict[str, Any]]) -> list[Dict[str, Any]]:
     """Mirror authoritative run/race state onto stale active queue items."""
-    runs_ref = db.collection("pipeline_runs")
-    queue_ref = db.collection("pipeline_queue")
-    races_ref = db.collection("races")
+    runs_ref = db.collection(FIRESTORE_RUNS_COLLECTION)
+    queue_ref = db.collection(FIRESTORE_QUEUE_COLLECTION)
+    races_ref = db.collection(FIRESTORE_RACES_COLLECTION)
     normalized = []
     for item in items:
         next_item = dict(item)
@@ -181,7 +182,7 @@ async def get_queue(active_only: bool = False, limit: int = 200) -> Dict[str, An
     """
     db = firestore_helpers._get_fs()
     limit = max(1, min(limit, 500))
-    query = db.collection("pipeline_queue")
+    query = db.collection(FIRESTORE_QUEUE_COLLECTION)
     if active_only:
         query = query.where("status", "in", sorted(_ACTIVE_STATUSES))
     docs = query.order_by("created_at", direction="DESCENDING").limit(limit).stream()
@@ -227,7 +228,7 @@ async def queue_races(request: RaceQueueRequest) -> Dict[str, Any]:
         try:
             from google.cloud.firestore_v1 import SERVER_TIMESTAMP  # type: ignore
 
-            race_doc = db.collection("races").document(race_id).get()
+            race_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
             if getattr(race_doc, "exists", False) is True:
                 race_data = race_doc.to_dict() or {}
                 race_data = _self_heal_stale_active_race(db, race_id, race_data)
@@ -247,7 +248,7 @@ async def queue_races(request: RaceQueueRequest) -> Dict[str, Any]:
                 "runner": (options or {}).get("runner") or _default_runner(),
                 "created_at": SERVER_TIMESTAMP,
             }
-            db.collection("pipeline_queue").document(item_id).set(item)
+            db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id).set(item)
             firestore_helpers._fs_update_race(race_id, {"status": "queued", "current_run_id": run_id})
             dispatch = _dispatch_if_cloud_run(db, item)
             added.append(
@@ -272,7 +273,7 @@ async def clear_finished_queue() -> Dict[str, Any]:
     db = firestore_helpers._get_fs()
     finished_statuses = {"completed", "failed", "cancelled", "continued"}
     removed = 0
-    docs = db.collection("pipeline_queue").where("status", "in", sorted(finished_statuses)).limit(500).stream()
+    docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("status", "in", sorted(finished_statuses)).limit(500).stream()
     for doc in docs:
         doc.reference.delete()
         removed += 1
@@ -284,7 +285,7 @@ async def clear_pending_queue() -> Dict[str, Any]:
     """Cancel all pending (not yet started) queue items."""
     db = firestore_helpers._get_fs()
     removed = 0
-    docs = db.collection("pipeline_queue").where("status", "==", "pending").limit(500).stream()
+    docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("status", "==", "pending").limit(500).stream()
     for doc in docs:
         data = doc.to_dict() or {}
         doc.reference.update({"status": "cancelled", "lease_owner": None, "lease_expires_at": None, "ttl_at": _queue_ttl_at()})
@@ -304,7 +305,7 @@ async def remove_queue_item(item_id: str, force: bool = False) -> Dict[str, Any]
     for stuck queue items.
     """
     db = firestore_helpers._get_fs()
-    doc = db.collection("pipeline_queue").document(item_id).get()
+    doc = db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id).get()
     if not doc.exists:
         raise HTTPException(status_code=404, detail="Queue item not found")
     data = doc.to_dict() or {}

--- a/services/races-api/routers/races_admin/helpers.py
+++ b/services/races-api/routers/races_admin/helpers.py
@@ -15,6 +15,7 @@ import gcs_helpers
 from fastapi import HTTPException, Request
 from routers.utils import _coerce_datetime, _queue_ttl_at
 
+from shared.config import FIRESTORE_QUEUE_COLLECTION, FIRESTORE_RACES_COLLECTION, FIRESTORE_RUNS_COLLECTION
 from shared.pipeline_config import RetentionConfig
 from shared.race_catalog import build_race_summary_fields
 
@@ -138,7 +139,7 @@ def _backfill_catalog_from_storage(race_id: str) -> Dict[str, Any] | None:
 
 def _run_is_terminal_or_missing(db: Any, run_id: str) -> bool:
     try:
-        run_doc = db.collection("pipeline_runs").document(run_id).get()
+        run_doc = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id).get()
     except Exception:
         return False
     if not getattr(run_doc, "exists", False):
@@ -149,14 +150,14 @@ def _run_is_terminal_or_missing(db: Any, run_id: str) -> bool:
 
 def _is_run_actually_active(db: Any, run_id: str) -> bool:
     """Return True only when run + queue docs both indicate active work."""
-    run_ref = db.collection("pipeline_runs").document(str(run_id))
+    run_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(str(run_id))
     run_doc = run_ref.get()
     if not run_doc.exists:
         return False
     run_data = run_doc.to_dict() or {}
     if run_data.get("status") not in ("pending", "running"):
         return False
-    queue_docs = db.collection("pipeline_queue").where("run_id", "==", str(run_id)).stream()
+    queue_docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", str(run_id)).stream()
     return any((doc.to_dict() or {}).get("status") in ("pending", "running") for doc in queue_docs)
 
 
@@ -192,11 +193,11 @@ def _recheck_race_status(db: Any, race_id: str, race_data: Dict[str, Any]) -> tu
         run_ref = None
         now = datetime.now(timezone.utc)
         if run_id:
-            run_ref = db.collection("pipeline_runs").document(run_id)
+            run_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id)
             run_doc = run_ref.get()
             if run_doc.exists:
                 run_actually_active = _active_doc_is_fresh(run_doc.to_dict() or {}, now)
-                queue_docs = db.collection("pipeline_queue").where("run_id", "==", run_id).stream()
+                queue_docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", run_id).stream()
                 active_queue_docs = [doc for doc in queue_docs if _active_doc_is_fresh(doc.to_dict() or {}, now)]
                 # A current worker lease is stronger liveness evidence than a
                 # quiet pipeline_runs document during a long model/tool call.
@@ -214,7 +215,7 @@ def _recheck_race_status(db: Any, race_id: str, race_data: Dict[str, Any]) -> tu
                 )
             else:
                 # If pipeline_run doc doesn't exist yet (e.g. pending in queue), the run is active if the queue doc is active and fresh
-                queue_docs = db.collection("pipeline_queue").where("run_id", "==", run_id).stream()
+                queue_docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", run_id).stream()
                 active_queue_docs = [doc for doc in queue_docs if _active_doc_is_fresh(doc.to_dict() or {}, now)]
                 run_actually_active = bool(active_queue_docs)
         if not run_actually_active:
@@ -231,7 +232,7 @@ def _recheck_race_status(db: Any, race_id: str, race_data: Dict[str, Any]) -> tu
                 except Exception as exc:
                     logging.warning("Failed to mark stale run %s failed: %s", run_id, exc)
             if run_id:
-                for doc in db.collection("pipeline_queue").where("run_id", "==", run_id).stream():
+                for doc in db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", run_id).stream():
                     try:
                         data = doc.to_dict() or {}
                         if data.get("status") in ("pending", "running"):
@@ -272,7 +273,7 @@ def _recheck_race_status(db: Any, race_id: str, race_data: Dict[str, Any]) -> tu
             firestore_helpers._fs_update_race(race_id, update)
             updated = True
             reconciled_view = {**race_data, **update}
-    updated_doc = db.collection("races").document(race_id).get()
+    updated_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
     latest = firestore_helpers._doc_to_plain(updated_doc)
     if latest is not None and not latest.get("race_id"):
         latest["race_id"] = race_id
@@ -391,7 +392,7 @@ def _run_completed_at(data: Dict[str, Any]) -> datetime | None:
 def _pipeline_run_stats(db: Any) -> Dict[str, Dict[str, Any]]:
     """Aggregate run counts from canonical pipeline_runs docs for the races table."""
     stats: Dict[str, Dict[str, Any]] = {}
-    runs_ref = db.collection("pipeline_runs")
+    runs_ref = db.collection(FIRESTORE_RUNS_COLLECTION)
     used_projection = False
     try:
         selected_ref = runs_ref.select(["race_id", "status", "started_at", "completed_at", "updated_at", "payload.race_id"])

--- a/services/races-api/routers/races_admin/race_runs.py
+++ b/services/races-api/routers/races_admin/race_runs.py
@@ -8,6 +8,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from request_models import validate_race_id
 from routers.utils import _queue_ttl_at
 
+from shared.config import (
+    FIRESTORE_QUEUE_COLLECTION,
+    FIRESTORE_RACE_RUNS_SUBCOLLECTION,
+    FIRESTORE_RACES_COLLECTION,
+    FIRESTORE_RUNS_COLLECTION,
+)
+
 router = APIRouter()
 
 
@@ -18,9 +25,9 @@ async def list_race_runs(race_id: str, limit: int = 20) -> Dict[str, Any]:
     db = firestore_helpers._get_fs()
     limit = max(1, min(limit, 100))
     sub_docs = (
-        db.collection("races")
+        db.collection(FIRESTORE_RACES_COLLECTION)
         .document(race_id)
-        .collection("runs")
+        .collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
         .order_by("started_at", direction="DESCENDING")
         .limit(limit)
         .stream()
@@ -31,7 +38,7 @@ async def list_race_runs(race_id: str, limit: int = 20) -> Dict[str, Any]:
         if data:
             runs_by_id[str(data.get("run_id") or getattr(d, "id", ""))] = data
 
-    canonical_docs = db.collection("pipeline_runs").where("race_id", "==", race_id).stream()
+    canonical_docs = db.collection(FIRESTORE_RUNS_COLLECTION).where("race_id", "==", race_id).stream()
     for d in canonical_docs:
         data = firestore_helpers._doc_to_plain(d)
         if data:
@@ -53,11 +60,17 @@ async def get_race_run(race_id: str, run_id: str) -> Dict[str, Any]:
     """Get details of a specific run for a race."""
     validate_race_id(race_id)
     db = firestore_helpers._get_fs()
-    doc = db.collection("pipeline_runs").document(run_id).get()
+    doc = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id).get()
     data = firestore_helpers._doc_to_plain(doc)
     if data:
         return data
-    doc = db.collection("races").document(race_id).collection("runs").document(run_id).get()
+    doc = (
+        db.collection(FIRESTORE_RACES_COLLECTION)
+        .document(race_id)
+        .collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
+        .document(run_id)
+        .get()
+    )
     data = firestore_helpers._doc_to_plain(doc)
     if data is None:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -69,24 +82,29 @@ async def delete_race_run(race_id: str, run_id: str) -> Dict[str, Any]:
     """Cancel or delete a run for a race."""
     validate_race_id(race_id)
     db = firestore_helpers._get_fs()
-    run_ref = db.collection("pipeline_runs").document(run_id)
+    run_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id)
     run_doc = run_ref.get()
     if run_doc.exists:
         status = (run_doc.to_dict() or {}).get("status", "")
         if status in ("pending", "running"):
             run_ref.update({"status": "cancelled"})
-            for queue_doc in db.collection("pipeline_queue").where("run_id", "==", run_id).stream():
+            for queue_doc in db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", run_id).stream():
                 queue_data = queue_doc.to_dict() or {}
                 if queue_data.get("status") in ("pending", "running"):
                     queue_doc.reference.update({"status": "cancelled", "ttl_at": _queue_ttl_at()})
-            race_doc = db.collection("races").document(race_id).get()
+            race_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
             if race_doc.exists and (race_doc.to_dict() or {}).get("status") in ("running", "queued"):
                 firestore_helpers._fs_update_race(race_id, {"status": "cancelled"})
             return {"message": "Run cancelled", "run_id": run_id}
         else:
             run_ref.delete()
         return {"message": "Run deleted", "run_id": run_id}
-    sub_ref = db.collection("races").document(race_id).collection("runs").document(run_id)
+    sub_ref = (
+        db.collection(FIRESTORE_RACES_COLLECTION)
+        .document(race_id)
+        .collection(FIRESTORE_RACE_RUNS_SUBCOLLECTION)
+        .document(run_id)
+    )
     if sub_ref.get().exists:
         sub_ref.delete()
         return {"message": "Run deleted", "run_id": run_id}

--- a/services/races-api/routers/races_admin/records.py
+++ b/services/races-api/routers/races_admin/records.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from request_models import AssetAuditRequest, RepairPlanRequest, RunOptions, validate_race_id
 from routers.utils import _queue_ttl_at
 
+from shared.config import FIRESTORE_QUEUE_COLLECTION, FIRESTORE_RACES_COLLECTION, FIRESTORE_RUNS_COLLECTION
 from shared.repair_planner import build_repair_plan, summarize_repair_plans
 
 from .helpers import (
@@ -39,7 +40,7 @@ router = APIRouter()
 async def list_all_races(reconcile_active: bool = False) -> Dict[str, Any]:
     """List all race records from Firestore (admin view with catalog metadata)."""
     db = firestore_helpers._get_fs()
-    docs = db.collection("races").limit(10000).stream()
+    docs = db.collection(FIRESTORE_RACES_COLLECTION).limit(10000).stream()
     races = []
     for d in docs:
         plain = firestore_helpers._doc_to_plain(d)
@@ -81,7 +82,7 @@ async def list_all_races(reconcile_active: bool = False) -> Dict[str, Any]:
 async def list_draft_races() -> Dict[str, Any]:
     """List all draft race summaries from the Firestore race catalog."""
     db = firestore_helpers._get_fs()
-    docs = db.collection("races").limit(1000).stream()
+    docs = db.collection(FIRESTORE_RACES_COLLECTION).limit(1000).stream()
     races = []
     for doc in docs:
         data = firestore_helpers._doc_to_plain(doc)
@@ -97,7 +98,7 @@ async def list_draft_races() -> Dict[str, Any]:
 async def recheck_all_race_statuses(cursor: str | None = None, limit: int = 50) -> Dict[str, Any]:
     """Reconcile one bounded catalog page and return an opaque continuation cursor."""
     db = firestore_helpers._get_fs()
-    docs = db.collection("races").limit(10000).stream()
+    docs = db.collection(FIRESTORE_RACES_COLLECTION).limit(10000).stream()
     races: list[Dict[str, Any]] = []
     updated = 0
     docs_by_race_id: dict[str, Any] = {}
@@ -150,7 +151,7 @@ async def plan_race_repairs(request: RepairPlanRequest) -> Dict[str, Any]:
     plans = []
     missing_race_ids = []
     for race_id in request.race_ids:
-        catalog_doc = db.collection("races").document(race_id).get()
+        catalog_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
         catalog = firestore_helpers._doc_to_plain(catalog_doc) or {}
         _apply_catalog_view(catalog)
         race_data = gcs_helpers._gcs_get_race_json(race_id, "drafts")
@@ -282,7 +283,7 @@ async def audit_race_assets(request: AssetAuditRequest) -> Dict[str, Any]:
             }
             results.append(result)
             if request.persist:
-                db.collection("races").document(race_id).set(
+                db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).set(
                     {"asset_audit": result, "asset_audited_at": audited_at},
                     merge=True,
                 )
@@ -294,7 +295,7 @@ async def get_race_record(race_id: str, reconcile: bool = True) -> Dict[str, Any
     """Get a single race record from Firestore."""
     validate_race_id(race_id)
     db = firestore_helpers._get_fs()
-    doc = db.collection("races").document(race_id).get()
+    doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
     data = firestore_helpers._doc_to_plain(doc)
     if data is None:
         raise HTTPException(status_code=404, detail="Race not found")
@@ -318,7 +319,7 @@ async def delete_race_record(request: Request, race_id: str) -> Dict[str, Any]:
     gcs_helpers._gcs_delete_race_json(race_id, "drafts")
     gcs_helpers.update_gcs_summaries_json({race_id: None})
     try:
-        firestore_helpers._get_fs().collection("races").document(race_id).delete()
+        firestore_helpers._get_fs().collection(FIRESTORE_RACES_COLLECTION).document(race_id).delete()
     except Exception as exc:
         logging.warning("Firestore delete race %s failed: %s", race_id, exc)
     _clear_public_race_cache(request)
@@ -330,13 +331,13 @@ async def cancel_race(race_id: str) -> Dict[str, Any]:
     """Cancel a queued or running race by updating Firestore state."""
     validate_race_id(race_id)
     db = firestore_helpers._get_fs()
-    race_doc = db.collection("races").document(race_id).get()
+    race_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
     if not race_doc.exists:
         raise HTTPException(status_code=404, detail="Race not found")
     race_data = race_doc.to_dict() or {}
     if race_data.get("status") not in ("queued", "running"):
         raise HTTPException(status_code=400, detail="Race is not queued or running")
-    for doc in db.collection("pipeline_queue").where("race_id", "==", race_id).stream():
+    for doc in db.collection(FIRESTORE_QUEUE_COLLECTION).where("race_id", "==", race_id).stream():
         d = doc.to_dict() or {}
         if d.get("status") in ("pending", "running"):
             doc.reference.update(
@@ -344,7 +345,7 @@ async def cancel_race(race_id: str) -> Dict[str, Any]:
             )
     run_id = race_data.get("current_run_id")
     if run_id:
-        run_ref = db.collection("pipeline_runs").document(run_id)
+        run_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id)
         run_doc = run_ref.get()
         if run_doc.exists and (run_doc.to_dict() or {}).get("status") in ("pending", "running"):
             run_ref.update({"status": "cancelled"})
@@ -357,7 +358,7 @@ async def recheck_race_status(race_id: str) -> Dict[str, Any]:
     """Re-derive race status from GCS storage state and backfill missing race docs."""
     validate_race_id(race_id)
     db = firestore_helpers._get_fs()
-    race_doc = db.collection("races").document(race_id).get()
+    race_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
     if not race_doc.exists:
         update = _backfill_catalog_from_storage(race_id)
         if update is None:
@@ -376,7 +377,7 @@ async def run_race_pipeline(race_id: str, options: RunOptions | None = None) -> 
     from google.cloud.firestore_v1 import SERVER_TIMESTAMP  # type: ignore
 
     db = firestore_helpers._get_fs()
-    race_doc = db.collection("races").document(race_id).get()
+    race_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(race_id).get()
     if race_doc.exists:
         race_data = race_doc.to_dict() or {}
         race_data = _self_heal_stale_active_race(db, race_id, race_data)
@@ -395,16 +396,16 @@ async def run_race_pipeline(race_id: str, options: RunOptions | None = None) -> 
         "runner": opts.get("runner") or os.getenv("PIPELINE_DEFAULT_RUNNER", "local").strip().lower(),
         "created_at": SERVER_TIMESTAMP,
     }
-    db.collection("pipeline_queue").document(item_id).set(item)
+    db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id).set(item)
     firestore_helpers._fs_update_race(race_id, {"status": "queued", "current_run_id": run_id})
     dispatch = None
     if item["runner"] == "cloud_run":
         try:
             dispatch = dispatch_pipeline_job(item_id)
-            db.collection("pipeline_queue").document(item_id).update({"dispatch_status": "submitted", **dispatch})
+            db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id).update({"dispatch_status": "submitted", **dispatch})
         except Exception as exc:
             error = f"Cloud Run Job dispatch failed: {exc}"
-            db.collection("pipeline_queue").document(item_id).update(
+            db.collection(FIRESTORE_QUEUE_COLLECTION).document(item_id).update(
                 {"status": "failed", "dispatch_status": "failed", "error": error, "ttl_at": _queue_ttl_at()}
             )
             firestore_helpers._fs_update_race(

--- a/services/races-api/routers/runs.py
+++ b/services/races-api/routers/runs.py
@@ -16,6 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from pipeline_diagnostics import build_diagnostics_bundle
 from routers.utils import _coerce_datetime, _queue_ttl_at
 
+from shared.config import (
+    FIRESTORE_QUEUE_COLLECTION,
+    FIRESTORE_RACES_COLLECTION,
+    FIRESTORE_RUN_LOGS_SUBCOLLECTION,
+    FIRESTORE_RUNS_COLLECTION,
+)
 from shared.pipeline_config import RetentionConfig
 
 router = APIRouter()
@@ -145,7 +151,7 @@ def _is_stale_active_run(data: Dict[str, Any], now: datetime) -> bool:
 def _has_live_queue_lease(db: Any, run_id: str, now: datetime) -> bool:
     """Return True when a worker still owns an unexpired lease for this run."""
     try:
-        queue_docs = db.collection("pipeline_queue").where("run_id", "==", run_id).limit(20).stream()
+        queue_docs = db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", run_id).limit(20).stream()
         for queue_doc in queue_docs:
             data = queue_doc.to_dict() or {}
             lease_expires_at = _coerce_datetime(data.get("lease_expires_at"))
@@ -161,7 +167,7 @@ def _has_live_queue_lease(db: Any, run_id: str, now: datetime) -> bool:
 
 def _current_run_is_terminal_or_missing(db: Any, run_id: str) -> bool:
     try:
-        run_doc = db.collection("pipeline_runs").document(run_id).get()
+        run_doc = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id).get()
         run_data = firestore_helpers._doc_to_plain(run_doc)
     except Exception:
         logger.exception("Unable to read current run %s while reconciling state", run_id)
@@ -177,13 +183,13 @@ def _normalize_active_run(db: Any, run: Dict[str, Any], now: datetime) -> Dict[s
     if not run_id or run.get("status") not in _ACTIVE_STATUSES:
         return run
 
-    runs_ref = db.collection("pipeline_runs")
-    queue_ref = db.collection("pipeline_queue")
+    runs_ref = db.collection(FIRESTORE_RUNS_COLLECTION)
+    queue_ref = db.collection(FIRESTORE_QUEUE_COLLECTION)
     race_id = run.get("race_id") or (run.get("payload") or {}).get("race_id")
 
     if race_id:
         try:
-            race_doc = db.collection("races").document(str(race_id)).get()
+            race_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(str(race_id)).get()
             race_data = firestore_helpers._doc_to_plain(race_doc)
         except Exception:
             logger.exception("Unable to read race %s while normalizing run %s", race_id, run_id)
@@ -269,7 +275,7 @@ async def list_runs(limit: int = 50) -> Dict[str, Any]:
 
     def _ordered_runs(field: str) -> list[Dict[str, Any]]:
         try:
-            docs = db.collection("pipeline_runs").order_by(field, direction="DESCENDING").limit(limit).stream()
+            docs = db.collection(FIRESTORE_RUNS_COLLECTION).order_by(field, direction="DESCENDING").limit(limit).stream()
             return [r for r in (firestore_helpers._doc_to_plain(d) for d in docs) if r is not None]
         except Exception:
             return []
@@ -279,7 +285,7 @@ async def list_runs(limit: int = 50) -> Dict[str, Any]:
     for field in ("progress_updated_at", "completed_at", "updated_at", "started_at"):
         runs.extend(_ordered_runs(field))
 
-    active_docs = db.collection("pipeline_runs").where("status", "in", ["pending", "running"]).limit(500).stream()
+    active_docs = db.collection(FIRESTORE_RUNS_COLLECTION).where("status", "in", ["pending", "running"]).limit(500).stream()
     active_runs = [firestore_helpers._doc_to_plain(d) for d in active_docs]
     active_runs = [r for r in active_runs if r is not None]
     now = datetime.now(timezone.utc)
@@ -301,7 +307,7 @@ async def list_runs(limit: int = 50) -> Dict[str, Any]:
 async def list_active_runs() -> Dict[str, Any]:
     """List currently running or pending pipeline runs."""
     db = firestore_helpers._get_fs()
-    docs = db.collection("pipeline_runs").where("status", "in", ["pending", "running"]).limit(500).stream()
+    docs = db.collection(FIRESTORE_RUNS_COLLECTION).where("status", "in", ["pending", "running"]).limit(500).stream()
     runs = [firestore_helpers._doc_to_plain(d) for d in docs]
     runs = [r for r in runs if r is not None]
     now = datetime.now(timezone.utc)
@@ -314,7 +320,7 @@ async def list_active_runs() -> Dict[str, Any]:
 async def get_run(run_id: str) -> Dict[str, Any]:
     """Get details of a specific run from Firestore."""
     db = firestore_helpers._get_fs()
-    doc = db.collection("pipeline_runs").document(run_id).get()
+    doc = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id).get()
     data = firestore_helpers._doc_to_plain(doc)
     if data is None:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -345,7 +351,7 @@ async def get_run_logs(
     it is greater than zero.
     """
     db = firestore_helpers._get_fs()
-    logs_ref = db.collection("pipeline_runs").document(run_id).collection("logs")
+    logs_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id).collection(FIRESTORE_RUN_LOGS_SUBCOLLECTION)
     limit = max(1, min(limit, 5000))
 
     if cursor is not None or since == 0:
@@ -382,7 +388,7 @@ async def prune_runs() -> Dict[str, Any]:
     """Prune all terminal runs (completed, failed, cancelled, continued) from Firestore."""
     db = firestore_helpers._get_fs()
     terminal_statuses = ["completed", "failed", "cancelled", "continued"]
-    runs_ref = db.collection("pipeline_runs")
+    runs_ref = db.collection(FIRESTORE_RUNS_COLLECTION)
     docs = list(runs_ref.where("status", "in", terminal_statuses).limit(500).stream())
 
     batch = db.batch()
@@ -391,7 +397,7 @@ async def prune_runs() -> Dict[str, Any]:
 
     for doc in docs:
         # Delete logs subcollection first
-        logs_ref = doc.reference.collection("logs")
+        logs_ref = doc.reference.collection(FIRESTORE_RUN_LOGS_SUBCOLLECTION)
         log_docs = list(logs_ref.stream())
         for log_doc in log_docs:
             batch.delete(log_doc.reference)
@@ -420,7 +426,7 @@ async def prune_runs() -> Dict[str, Any]:
 async def cancel_or_delete_run(run_id: str) -> Dict[str, Any]:
     """Cancel an active run or delete a finished one from Firestore."""
     db = firestore_helpers._get_fs()
-    doc_ref = db.collection("pipeline_runs").document(run_id)
+    doc_ref = db.collection(FIRESTORE_RUNS_COLLECTION).document(run_id)
     doc = doc_ref.get()
     if not doc.exists:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -428,7 +434,7 @@ async def cancel_or_delete_run(run_id: str) -> Dict[str, Any]:
     status = data.get("status", "")
     if status in ("pending", "running"):
         doc_ref.update({"status": "cancelled"})
-        for queue_doc in db.collection("pipeline_queue").where("run_id", "==", run_id).limit(20).stream():
+        for queue_doc in db.collection(FIRESTORE_QUEUE_COLLECTION).where("run_id", "==", run_id).limit(20).stream():
             queue_data = queue_doc.to_dict() or {}
             if queue_data.get("status") in ("pending", "running"):
                 queue_doc.reference.update(
@@ -436,7 +442,7 @@ async def cancel_or_delete_run(run_id: str) -> Dict[str, Any]:
                 )
         race_id = data.get("race_id")
         if race_id:
-            race_doc = db.collection("races").document(str(race_id)).get()
+            race_doc = db.collection(FIRESTORE_RACES_COLLECTION).document(str(race_id)).get()
             race_data = firestore_helpers._doc_to_plain(race_doc) or {}
             if race_data.get("status") in ("queued", "running") and race_data.get("current_run_id") == run_id:
                 firestore_helpers._fs_update_race(race_id, {"status": "cancelled", "current_run_id": None})
@@ -445,7 +451,7 @@ async def cancel_or_delete_run(run_id: str) -> Dict[str, Any]:
         # Delete logs subcollection first
         batch = db.batch()
         op_count = 0
-        logs_ref = doc_ref.collection("logs")
+        logs_ref = doc_ref.collection(FIRESTORE_RUN_LOGS_SUBCOLLECTION)
         log_docs = list(logs_ref.stream())
         for log_doc in log_docs:
             batch.delete(log_doc.reference)

--- a/shared/config.py
+++ b/shared/config.py
@@ -6,27 +6,29 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-# These name real GCS prefixes and Firestore collections, but they are not the
-# only place those names appear: most call sites write the string inline —
-# `db.collection("pipeline_queue")`, `db.collection("races")` — rather than
-# importing from here. `pipeline_queue` and `races` in particular are spelled out
-# at roughly seventy call sites across pipeline_client and services/races-api and
-# imported from this module at none.
-#
-# So treat this as a register of the names in use, not as a single point of
-# control: renaming a collection means a repo-wide search, and changing a value
-# here alone would move only the handful of callers that do import it.
 GCS_DRAFTS_PREFIX = "drafts"
 GCS_RACES_PREFIX = "races"
 GCS_RETIRED_PREFIX = "retired"
 GCS_ARTIFACTS_PREFIX = "artifacts"
 GCS_CHECKPOINTS_PREFIX = "checkpoints"
 
+# Every Firestore collection the system reads or writes. Import these rather
+# than spelling the name inline: `tests/test_firestore_collection_names.py`
+# fails on a bare `collection("...")` anywhere in the tree, so the set below is
+# the whole vocabulary and a rename lands in one place.
 FIRESTORE_QUEUE_COLLECTION = "pipeline_queue"
 FIRESTORE_RUNS_COLLECTION = "pipeline_runs"
 FIRESTORE_RACES_COLLECTION = "races"
 FIRESTORE_SEARCH_CACHE_COLLECTION = "search_cache"
 FIRESTORE_PAGE_CACHE_COLLECTION = "page_cache"
+FIRESTORE_METRICS_COLLECTION = "pipeline_metrics"
+FIRESTORE_ANALYTICS_EVENTS_COLLECTION = "analytics_events"
+
+# Subcollections, nested under a document rather than at the root. Named apart
+# because `runs` is a child of a race document and is a different thing from the
+# top-level `pipeline_runs`; the two are easy to confuse at a call site.
+FIRESTORE_RACE_RUNS_SUBCOLLECTION = "runs"
+FIRESTORE_RUN_LOGS_SUBCOLLECTION = "logs"
 
 
 @dataclass(frozen=True)

--- a/tests/test_firestore_collection_names.py
+++ b/tests/test_firestore_collection_names.py
@@ -1,0 +1,103 @@
+"""Firestore collection names live in `shared/config.py` and nowhere else.
+
+They used to be written inline at ~100 call sites across pipeline_client and
+services/races-api while the constants naming them went unimported, so renaming
+a collection meant finding every literal by hand and the constants read as a
+single point of control they were not.
+
+This fails on a bare `collection("...")` anywhere in the tree, which is what
+keeps that from creeping back one call site at a time.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import pathlib
+
+import pytest
+
+from shared import config
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SEARCH_ROOTS = ("pipeline_client", "services/races-api", "shared", "smartervote_mcp")
+
+
+def _python_files():
+    for root in SEARCH_ROOTS:
+        for path in (REPO_ROOT / root).rglob("*.py"):
+            if "__pycache__" not in str(path):
+                yield path
+
+
+def _literal_collection_calls(path: pathlib.Path):
+    """Every `.collection("literal")` call, found via the AST.
+
+    Parsing rather than grepping so a mention inside a comment or docstring —
+    including the one in shared/config.py explaining this rule — is not a hit.
+    """
+    tree = ast.parse(io.open(path, encoding="utf-8").read())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "collection":
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                yield node.lineno, arg.value
+
+
+def test_no_collection_name_is_written_inline():
+    offenders = [
+        f"{path.relative_to(REPO_ROOT)}:{lineno} collection({name!r})"
+        for path in _python_files()
+        for lineno, name in _literal_collection_calls(path)
+    ]
+    assert not offenders, "import the name from shared.config instead:\n" + "\n".join(offenders)
+
+
+def test_the_scan_reaches_the_code_it_claims_to_cover():
+    """Guards the guard: a scan that silently found nothing would pass forever."""
+    files = list(_python_files())
+    assert len(files) > 100, f"only {len(files)} files scanned"
+    assert any("queue_processor" in str(f) for f in files)
+    assert any("races-api" in str(f) for f in files)
+
+
+def test_the_scan_would_catch_an_inline_name(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text('db.collection("pipeline_queue").document("x")\n', encoding="utf-8")
+    assert list(_literal_collection_calls(sample)) == [(1, "pipeline_queue")]
+
+
+def test_the_scan_ignores_a_name_in_a_comment(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text('# db.collection("pipeline_queue") is what this replaces\nx = 1\n', encoding="utf-8")
+    assert list(_literal_collection_calls(sample)) == []
+
+
+@pytest.mark.parametrize(
+    "constant, expected",
+    [
+        ("FIRESTORE_QUEUE_COLLECTION", "pipeline_queue"),
+        ("FIRESTORE_RUNS_COLLECTION", "pipeline_runs"),
+        ("FIRESTORE_RACES_COLLECTION", "races"),
+        ("FIRESTORE_SEARCH_CACHE_COLLECTION", "search_cache"),
+        ("FIRESTORE_PAGE_CACHE_COLLECTION", "page_cache"),
+        ("FIRESTORE_METRICS_COLLECTION", "pipeline_metrics"),
+        ("FIRESTORE_ANALYTICS_EVENTS_COLLECTION", "analytics_events"),
+        ("FIRESTORE_RACE_RUNS_SUBCOLLECTION", "runs"),
+        ("FIRESTORE_RUN_LOGS_SUBCOLLECTION", "logs"),
+    ],
+)
+def test_constants_still_name_the_deployed_collections(constant, expected):
+    """These are live Firestore collections; the value is the wire format, not a
+    label. Changing one migrates data, so it should take a deliberate edit here."""
+    assert getattr(config, constant) == expected
+
+
+def test_the_race_runs_subcollection_is_not_the_top_level_runs_collection():
+    """`runs` hangs off a race document; `pipeline_runs` is at the root. They are
+    different collections and the shorter name invites confusing them."""
+    assert config.FIRESTORE_RACE_RUNS_SUBCOLLECTION != config.FIRESTORE_RUNS_COLLECTION


### PR DESCRIPTION
Stacked on #266 — review that first; this targets its branch so the diff stays to just this change.

`shared/config.py` has named every Firestore collection since it was written, and almost nothing imported them. The names were spelled inline at **98 call sites** across `pipeline_client` and `services/races-api`, so the constants read as a single point of control while being nothing of the kind.

I deferred this during the audit as too large to do unattended; doing it now on request.

- `run_manager.py` already did it properly (`_COLLECTION = FIRESTORE_RUNS_COLLECTION`), so this is the rest of the codebase catching up with a pattern already here. `race_manager` and `pipeline_metrics` kept private `_COLLECTION` literals and now derive them too.
- Four collections had **no constant at all** and gained one: `pipeline_metrics`, `analytics_events`, and the two subcollections. Those are listed apart, because `runs` hangs off a race document and is a different collection from top-level `pipeline_runs` — a distinction the shorter name does nothing to protect.
- A test fails on a bare `collection("...")` anywhere in the tree. It walks the **AST** rather than grepping, so a name in a comment isn't a false hit, and it asserts it actually reached the code it claims to cover rather than passing on an empty scan.

**No values changed, so no data moves.** Verified: 1253 pipeline tests, 40 races-api, 93 admin, black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)