### PR TITLE
Let advisory flags cost points instead of vetoing publication

### DIFF
--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -58,6 +58,13 @@ _REVIEWABLE_RACE_FIELDS = tuple(field for field in RaceJSON.model_fields if fiel
 _REVIEWABLE_CANDIDATE_FIELDS = tuple(Candidate.model_fields)
 _STALE_ACCESS_THRESHOLD = timedelta(days=365)
 
+# A race must reach this to publish.
+PASSING_SCORE = 80
+# What each warning-severity flag costs. Warnings are advisory, so they scale
+# rather than veto: at 3 points a race reviewed in the 90s survives two or three
+# of them, while one scraping by in the low 80s does not.
+WARNING_SCORE_PENALTY = 3
+
 
 def build_semantic_review_packet(race_json: Dict[str, Any]) -> Dict[str, Any]:
     """Return the complete semantic RaceJSON surface without operational metadata."""
@@ -410,12 +417,28 @@ async def check_profile_links(
     for url, path, err in check_results:
         if err:
             reason, permanent = err
+            # Severity tracks what the check actually establishes. A 404, a 410,
+            # an unresolvable host or a bad certificate is real evidence the
+            # citation is gone. A timeout, a connection reset or a 5xx says only
+            # that the host misbehaved during this one scan, which is a weaker
+            # claim — reporting both as warnings let a single flaky fetch speak
+            # with the authority of a confirmed dead link. 401/403/429 never
+            # reach here at all; _is_access_restricted_response already treats
+            # bot-blocking as no evidence either way.
             flags.append(
                 {
                     "field": path,
-                    "concern": f"Cited source URL ({url}) returned a dead link: {reason}.",
-                    "suggestion": "Verify the URL, find a replacement source, and update the stance.",
-                    "severity": "warning",
+                    "concern": (
+                        f"Cited source URL ({url}) returned a dead link: {reason}."
+                        if permanent
+                        else f"Cited source URL ({url}) was unreachable during this check: {reason}."
+                    ),
+                    "suggestion": (
+                        "Verify the URL, find a replacement source, and update the stance."
+                        if permanent
+                        else "Re-check the URL; this may be a transient outage rather than a broken citation."
+                    ),
+                    "severity": "warning" if permanent else "info",
                     # Machine-readable so deterministic cleanup does not have to
                     # parse these back out of prose. Recovering the URL by regex
                     # truncated any address containing parentheses — which covers
@@ -426,9 +449,14 @@ async def check_profile_links(
                 }
             )
 
-    verdict = "flagged" if flags else "approved"
-    summary = f"Scanned {len(urls_to_check)} source links. Found {len(flags)} dead link(s)."
-    log("info", f"  Link Validator: {verdict} ({len(flags)} dead links found)")
+    confirmed = sum(1 for flag in flags if flag.get("permanent_failure"))
+    unreachable = len(flags) - confirmed
+    verdict = "flagged" if confirmed else "approved"
+    summary = (
+        f"Scanned {len(urls_to_check)} source links. Found {confirmed} dead link(s) "
+        f"and {unreachable} that were unreachable without confirming they are gone."
+    )
+    log("info", f"  Link Validator: {verdict} ({confirmed} dead, {unreachable} unreachable)")
 
     return {
         "model": "automated-link-validator",
@@ -867,14 +895,24 @@ def compute_validation_grade(reviews: List[Dict[str, Any]]) -> Optional[Dict[str
 
     avg = round(sum(scores) / len(scores))
     avg = max(0, min(100, avg))
-    blocking_flags = [
-        flag
-        for review in reviews
-        for flag in (review.get("flags") or [])
-        if isinstance(flag, dict) and flag.get("severity") in {"warning", "error"}
-    ]
-    if blocking_flags:
-        avg = min(avg, 79)
+    flags = [flag for review in reviews for flag in (review.get("flags") or []) if isinstance(flag, dict)]
+    error_flags = [flag for flag in flags if flag.get("severity") == "error"]
+    warning_flags = [flag for flag in flags if flag.get("severity") == "warning"]
+
+    # An error means something is demonstrably wrong — a placeholder candidate
+    # name, an issue stance the pipeline was asked to research and did not. Those
+    # still pin the grade below the pass mark however well the race scored.
+    if error_flags:
+        avg = min(avg, PASSING_SCORE - 1)
+
+    # Warnings are advisory, and used to pin the score to the same place. Against
+    # a pass mark of 80 that made a single warning an unconditional veto: a race
+    # three models approved at an average of 93 graded C over three unsourced
+    # stances and one dead link, and no further research could lift it, because
+    # every surviving warning re-applied the identical cap. They now cost a fixed
+    # amount each, so a strong review absorbs a couple and a weak one carrying
+    # many still fails.
+    avg = max(0, avg - WARNING_SCORE_PENALTY * len(warning_flags))
 
     if avg >= 90:
         grade = "A"
@@ -887,18 +925,25 @@ def compute_validation_grade(reviews: List[Dict[str, Any]]) -> Optional[Dict[str
     else:
         grade = "F"
 
-    passed = avg >= 80
+    passed = avg >= PASSING_SCORE
     verdicts = [r.get("verdict", "") for r in eligible_reviews]
     approved_count = sum(1 for v in verdicts if v == "approved")
     total = len(eligible_reviews)
 
-    if blocking_flags:
+    deduction = (
+        f"after a {WARNING_SCORE_PENALTY * len(warning_flags)}-point deduction for {len(warning_flags)} warning flag(s)"
+    )
+    if error_flags:
         summary = (
-            f"Below quality threshold - {approved_count}/{total} reviewers approved, average score capped at {avg}/100 "
-            f"because {len(blocking_flags)} warning-or-higher quality flag(s) remain."
+            f"Below quality threshold - {approved_count}/{total} reviewers approved, but {len(error_flags)} "
+            f"error-severity flag(s) block publication (scored {avg}/100)."
         )
+    elif passed and warning_flags:
+        summary = f"Validated by {approved_count}/{total} reviewers at {avg}/100 {deduction}."
     elif passed:
         summary = f"Validated by {approved_count}/{total} reviewers with an average score of {avg}/100."
+    elif warning_flags:
+        summary = f"Below quality threshold - {approved_count}/{total} reviewers approved, {avg}/100 {deduction}."
     else:
         summary = f"Below quality threshold - {approved_count}/{total} reviewers approved, average score {avg}/100."
 

--- a/services/races-api/chamber_narratives.py
+++ b/services/races-api/chamber_narratives.py
@@ -10,6 +10,7 @@ from shared.forecast_summary import (
     build_chamber_context,
     election_cycle_year,
     get_chamber_forecast_system_prompt,
+    get_chamber_narrative_review_prompt,
     is_chamber_control_race,
     summarize_chamber,
 )
@@ -78,7 +79,53 @@ async def generate_chamber_analysis(
     return {key: str(parsed[key]).strip() for key in REQUIRED_ANALYSIS_KEYS}
 
 
-async def generate_chamber_analyses(summaries: list[dict[str, Any]], *, model: str) -> Dict[Chamber, dict[str, str]]:
+async def review_chamber_analysis(
+    chamber_name: str,
+    context_text: str,
+    analysis: dict[str, str],
+    *,
+    model: str,
+    goal: str | None = None,
+) -> tuple[dict[str, str], list[str]]:
+    """Re-read a drafted analysis against its own data and correct contradictions.
+
+    Returns the analysis and the corrections applied. On any failure the draft
+    comes back untouched: a review pass that cannot run is not a reason to lose
+    an otherwise usable narrative.
+    """
+    messages = [
+        {"role": "system", "content": get_chamber_narrative_review_prompt(chamber_name, goal)},
+        {
+            "role": "user",
+            "content": (
+                f"Authoritative forecast data for the {chamber_name}:\n\n{context_text}\n\n"
+                f"Drafted analysis to review:\n\n{json.dumps(analysis, indent=2)}"
+            ),
+        },
+    ]
+    try:
+        data = await _call_openrouter(messages, model=model)
+        content = str(data["choices"][0]["message"]["content"]).strip()
+        parsed = json.loads(_strip_markdown_code_fence(content))
+        if not isinstance(parsed, dict):
+            raise ValueError("chamber narrative review response must be a JSON object")
+        missing = [key for key in REQUIRED_ANALYSIS_KEYS if not parsed.get(key)]
+        if missing:
+            raise ValueError(f"chamber narrative review missing required keys: {missing}")
+    except (httpx.HTTPError, ValueError, KeyError, json.JSONDecodeError):
+        return analysis, []
+
+    corrections = [str(item).strip() for item in (parsed.get("corrections") or []) if str(item).strip()]
+    return {key: str(parsed[key]).strip() for key in REQUIRED_ANALYSIS_KEYS}, corrections
+
+
+async def generate_chamber_analyses(
+    summaries: list[dict[str, Any]],
+    *,
+    model: str,
+    review: bool = False,
+    goal: str | None = None,
+) -> Dict[Chamber, dict[str, str]]:
     chamber_names: Dict[Chamber, str] = {"senate": "US Senate", "house": "US House", "governors": "Governors"}
     cycle_year = election_cycle_year(summaries)
     analyses: Dict[Chamber, dict[str, str]] = {}
@@ -86,5 +133,10 @@ async def generate_chamber_analyses(summaries: list[dict[str, Any]], *, model: s
         races = races_for_chamber(summaries, chamber)
         summary = summarize_chamber(summaries, chamber)
         context = build_chamber_context(races, name, summary)
-        analyses[chamber] = await generate_chamber_analysis(name, context, model=model, cycle_year=cycle_year)
+        analysis = await generate_chamber_analysis(name, context, model=model, cycle_year=cycle_year)
+        if review:
+            analysis, corrections = await review_chamber_analysis(name, context, analysis, model=model, goal=goal)
+            if corrections:
+                analysis = {**analysis, "review_corrections": corrections}
+        analyses[chamber] = analysis
     return analyses

--- a/services/races-api/routers/races_admin/forecasts.py
+++ b/services/races-api/routers/races_admin/forecasts.py
@@ -20,6 +20,21 @@ DEFAULT_CHAMBER_FORECAST_MODEL = "google/gemini-3.6-flash"
 
 class GenerateForecastsRequest(BaseModel):
     model: str = Field(default=DEFAULT_CHAMBER_FORECAST_MODEL)
+    review: bool = Field(
+        default=False,
+        description=(
+            "Run a second pass that re-reads each drafted narrative against the same forecast data and rewrites "
+            "claims that contradict it, such as describing a seat as defended by the party that does not hold it. "
+            "Costs one extra LLM call per chamber."
+        ),
+    )
+    goal: str | None = Field(
+        default=None,
+        description=(
+            "Optional editorial steer applied during the review pass, e.g. 'lead with the tipping-point races' or "
+            "'keep it under three sentences'. Factual corrections always take precedence. Requires review=true."
+        ),
+    )
 
 
 @router.get("/api/races/chamber_forecasts/draft", dependencies=[Depends(verify_token)])
@@ -47,7 +62,7 @@ async def generate_chamber_forecasts_endpoint(
         raise HTTPException(status_code=500, detail=f"Invalid summaries from publish service: {type(summaries)}")
 
     try:
-        analyses = await generate_chamber_analyses(summaries, model=payload.model)
+        analyses = await generate_chamber_analyses(summaries, model=payload.model, review=payload.review, goal=payload.goal)
     except Exception as exc:
         logging.error("Error generating chamber forecast analyses using model %s: %s", payload.model, exc, exc_info=True)
         raise HTTPException(status_code=502, detail=f"LLM chamber forecast generation failed: {exc}") from exc
@@ -67,6 +82,12 @@ async def generate_chamber_forecasts_endpoint(
         "message": "Draft chamber forecasts generated successfully",
         "updated_at": forecast_data["updated_at"],
         "model": payload.model,
+        "reviewed": payload.review,
+        "review_corrections": {
+            chamber: analysis["review_corrections"]
+            for chamber, analysis in analyses.items()
+            if analysis.get("review_corrections")
+        },
         "forecast": forecast_data,
     }
 

--- a/services/races-api/test_races_api.py
+++ b/services/races-api/test_races_api.py
@@ -598,3 +598,85 @@ def test_generate_chamber_forecasts_fails_without_saving_when_llm_fails(client, 
 
     draft_resp = client.get("/api/races/chamber_forecasts/draft")
     assert draft_resp.status_code == 404
+
+
+def _stub_analysis(chamber_name):
+    return {
+        "narrative": f"{chamber_name} narrative",
+        "bottom_line": f"{chamber_name} bottom line",
+        "why_party_favored": f"{chamber_name} why favored",
+        "opposing_party_path": f"{chamber_name} opposing path",
+        "key_uncertainty": f"{chamber_name} uncertainty",
+    }
+
+
+def test_generate_chamber_forecasts_skips_review_by_default(client, monkeypatch):
+    """The review pass costs an extra call per chamber, so it stays opt-in."""
+    reviewed = []
+
+    async def fake_generate(chamber_name, context_text, *, model, cycle_year=None):
+        return _stub_analysis(chamber_name)
+
+    async def fake_review(chamber_name, context_text, analysis, *, model, goal=None):
+        reviewed.append(chamber_name)
+        return analysis, []
+
+    import chamber_narratives
+
+    monkeypatch.setattr(chamber_narratives, "generate_chamber_analysis", fake_generate)
+    monkeypatch.setattr(chamber_narratives, "review_chamber_analysis", fake_review)
+
+    resp = client.post("/api/races/chamber_forecasts/generate", json={})
+
+    assert resp.status_code == 200
+    assert reviewed == []
+    assert resp.json()["reviewed"] is False
+
+
+def test_generate_chamber_forecasts_review_applies_corrections_and_forwards_goal(client, monkeypatch):
+    """review=true rewrites the draft and reports what it actually corrected."""
+    seen_goals = []
+
+    async def fake_generate(chamber_name, context_text, *, model, cycle_year=None):
+        return _stub_analysis(chamber_name)
+
+    async def fake_review(chamber_name, context_text, analysis, *, model, goal=None):
+        seen_goals.append(goal)
+        corrected = {**analysis, "narrative": f"{chamber_name} corrected narrative"}
+        return corrected, [f"{chamber_name}: called a Republican-held seat a Democratic defense"]
+
+    import chamber_narratives
+
+    monkeypatch.setattr(chamber_narratives, "generate_chamber_analysis", fake_generate)
+    monkeypatch.setattr(chamber_narratives, "review_chamber_analysis", fake_review)
+
+    resp = client.post(
+        "/api/races/chamber_forecasts/generate",
+        json={"review": True, "goal": "lead with the tipping-point races"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["reviewed"] is True
+    assert seen_goals == ["lead with the tipping-point races"] * 3
+    assert body["forecast"]["senate"] == "US Senate corrected narrative"
+    assert "Republican-held seat" in body["review_corrections"]["senate"][0]
+    # Operator-facing only: the published payload must not carry it.
+    assert "review_corrections" not in body["forecast"]["chambers"]["senate"]
+
+
+@pytest.mark.asyncio
+async def test_review_chamber_analysis_returns_the_draft_when_the_pass_fails(monkeypatch):
+    """A review that cannot run is not a reason to lose a usable narrative."""
+    import chamber_narratives
+
+    async def failing_call(messages, *, model):
+        raise ValueError("provider unavailable")
+
+    monkeypatch.setattr(chamber_narratives, "_call_openrouter", failing_call)
+
+    draft = _stub_analysis("US Senate")
+    result, corrections = await chamber_narratives.review_chamber_analysis("US Senate", "context", draft, model="test/model")
+
+    assert result == draft
+    assert corrections == []

--- a/shared/forecast_summary.py
+++ b/shared/forecast_summary.py
@@ -604,6 +604,22 @@ def build_chamber_forecasts(
     }
 
 
+def _seat_control_note(race: Dict[str, Any]) -> str:
+    """Describe who holds the seat now, so a hold can be told apart from a flip.
+
+    Without this the context carried only a rating and a probability, which
+    cannot distinguish the two. The published Senate narrative listed Maine among
+    the seats Democrats had to "defend" at 64%, when the seat is Susan Collins's
+    and a Democratic win there would be a pickup.
+    """
+    for candidate in race.get("candidates") or []:
+        if not isinstance(candidate, dict) or not candidate.get("incumbent"):
+            continue
+        party = normalize_party(candidate.get("party"))
+        return f"currently {party}-held" if party != "Other" else "currently held by an independent"
+    return "open seat, no incumbent running"
+
+
 def build_chamber_context(races: list[dict[str, Any]], name: str, summary: dict[str, Any]) -> str:
     if not races:
         return f"No published races found for the {name}."
@@ -620,21 +636,27 @@ def build_chamber_context(races: list[dict[str, Any]], name: str, summary: dict[
         title = race.get("title") or race.get("id")
         if "toss-up" in rating or "tossup" in rating:
             toss_ups += 1
-            competitive_list.append(f"- {title}: Toss-up (Win Prob: {prob * 100:.1f}%)")
+            competitive_list.append(f"- {title}: Toss-up (Win Prob: {prob * 100:.1f}%, {_seat_control_note(race)})")
         elif "tilt" in rating:
-            competitive_list.append(f"- {title}: Tilt {winner_party.upper()} (Win Prob: {prob * 100:.1f}%)")
+            competitive_list.append(
+                f"- {title}: Tilt {winner_party.upper()} (Win Prob: {prob * 100:.1f}%, {_seat_control_note(race)})"
+            )
             if "democrat" in winner_party:
                 dem_wins += 1
             elif "republican" in winner_party or "gop" in winner_party:
                 gop_wins += 1
         elif "lean" in rating:
-            competitive_list.append(f"- {title}: Lean {winner_party.upper()} (Win Prob: {prob * 100:.1f}%)")
+            competitive_list.append(
+                f"- {title}: Lean {winner_party.upper()} (Win Prob: {prob * 100:.1f}%, {_seat_control_note(race)})"
+            )
             if "democrat" in winner_party:
                 dem_wins += 1
             elif "republican" in winner_party or "gop" in winner_party:
                 gop_wins += 1
         elif "likely" in rating:
-            competitive_list.append(f"- {title}: Likely {winner_party.upper()} (Win Prob: {prob * 100:.1f}%)")
+            competitive_list.append(
+                f"- {title}: Likely {winner_party.upper()} (Win Prob: {prob * 100:.1f}%, {_seat_control_note(race)})"
+            )
             if "democrat" in winner_party:
                 dem_wins += 1
             elif "republican" in winner_party or "gop" in winner_party:
@@ -692,6 +714,44 @@ def build_chamber_context(races: list[dict[str, Any]], name: str, summary: dict[
     return "\n".join(lines)
 
 
+def get_chamber_narrative_review_prompt(chamber_name: str, goal: str | None = None) -> str:
+    """Prompt for the pass that re-reads a drafted narrative against its own data.
+
+    The generator writes prose from a context block nothing holds it to, so
+    claims drift from the numbers printed beside them — a seat described as
+    defended by the party that does not hold it, a total that does not match the
+    authoritative projection. This pass rewrites only what contradicts the data.
+    """
+    instructions = (
+        "You are a meticulous editor reviewing a nonpartisan election forecast note for factual consistency with "
+        f"the underlying data for the {chamber_name}. You are given the authoritative forecast context and a drafted "
+        "analysis.\n\n"
+        "Check every claim in the draft against the context:\n"
+        "1. Seat totals, probabilities and percentages must match the context exactly. Never state a number the "
+        "context does not contain.\n"
+        "2. A party can only be described as defending or holding a seat it currently holds. The context gives the "
+        "current holder of every competitive race. A race the favored party does not hold is a pickup for them.\n"
+        "3. Do not conflate the projected seat split with the party most likely to control the chamber. Where they "
+        "differ, state both.\n"
+        "4. Named races must appear in the context, with the rating and direction the context gives them.\n"
+        "5. The prose must read as a sharp analyst note, free of AI boilerplate and filler.\n"
+    )
+    if goal:
+        instructions += (
+            "\nThe author also asks you to revise toward this goal. Apply it only where it does not conflict with "
+            f"the factual checks above, which always win:\n{goal}\n"
+        )
+    instructions += (
+        "\nReturn ONLY a JSON object with these keys:\n"
+        "- 'corrections': an array of short strings, one per problem you found and fixed, describing the error rather "
+        "than the edit. Empty if the draft was already sound.\n"
+        "- 'narrative', 'bottom_line', 'why_party_favored', 'opposing_party_path', 'key_uncertainty': the corrected "
+        "text, each returned unchanged if it needed no correction.\n\n"
+        "Output ONLY the JSON object, with no markdown code blocks, no backticks, and no extra text."
+    )
+    return instructions
+
+
 def get_chamber_forecast_system_prompt(chamber_name: str, cycle_year: str | int | None = None) -> str:
     # Never hardcode the cycle here: the model is told which election it is
     # analysing, so a stale literal would have it narrate the wrong one. Callers
@@ -719,5 +779,9 @@ def get_chamber_forecast_system_prompt(chamber_name: str, cycle_year: str | int 
         "copy projected and expected seat totals exactly, never invent or arithmetically alter them, and do not conflate the "
         "central projected seat split with the party that has the highest outright-control probability. If those point to "
         "different parties, explain that distinction plainly.\n\n"
+        "Every competitive race states who currently holds the seat. Use it: a race the favored party does not already "
+        "hold is a pickup opportunity for them and a seat the other party is defending. Never describe a party as "
+        "defending or holding a seat it does not currently hold, and never call a race a flip when the favored party is "
+        "the incumbent one.\n\n"
         "Output ONLY the JSON object, with no markdown code blocks, no backticks, and no extra text. Do not mention that you are an AI."
     )

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -1363,10 +1363,23 @@ async def generate_chamber_forecasts(
     # Must match DEFAULT_CHAMBER_FORECAST_MODEL in
     # services/races-api/routers/races_admin/forecasts.py.
     model: str = "google/gemini-3.6-flash",
+    review: bool = False,
+    goal: str | None = None,
 ) -> Dict[str, Any]:
-    """Automatically generate chamber-level forecast narratives using an LLM on the remote races-api backend."""
+    """Automatically generate chamber-level forecast narratives using an LLM on the remote races-api backend.
+
+    Set ``review=True`` to run a second pass that re-reads each drafted narrative against the same forecast data
+    and rewrites claims that contradict it — for instance describing a seat as defended by the party that does not
+    hold it. It costs one extra LLM call per chamber and reports what it changed under ``review_corrections``.
+
+    ``goal`` is an optional editorial steer for that pass, e.g. "lead with the tipping-point races". Factual
+    corrections always take precedence over it. It requires ``review=True``.
+    """
     client = _client()
-    res = await client.post("/api/races/chamber_forecasts/generate", json={"model": model})
+    payload: Dict[str, Any] = {"model": model, "review": review}
+    if goal:
+        payload["goal"] = goal
+    res = await client.post("/api/races/chamber_forecasts/generate", json=payload)
     return {"success": True, "api_response": res}
 
 

--- a/tests/test_forecast_summary.py
+++ b/tests/test_forecast_summary.py
@@ -505,3 +505,71 @@ def test_chamber_forecast_prompt_stays_cycle_neutral_without_a_year():
     prompt = get_chamber_forecast_system_prompt("US Senate")
     assert "in the current election cycle" in prompt
     assert not re.search(r"\b20\d{2}\b", prompt), "prompt must not name a hardcoded cycle"
+
+
+def test_context_states_who_currently_holds_each_competitive_seat():
+    """The narrative cannot tell a hold from a pickup without this.
+
+    The published Senate note listed Maine among the seats Democrats had to
+    "defend" at 64%, when the seat is Susan Collins's and a Democratic win there
+    would be a pickup. The context gave a rating and a probability and nothing
+    about the incumbent, so the model had no way to get it right.
+    """
+    from shared.forecast_summary import build_chamber_context
+
+    context = build_chamber_context(
+        [
+            {
+                "id": "me-senate-2026",
+                "title": "Maine U.S. Senate Election, 2026",
+                "office": "United States Senate",
+                "forecast": {"rating": "tilt_d", "predicted_winner_party": "Democratic", "win_probability": 0.64},
+                "candidates": [
+                    {"name": "Susan Collins", "party": "Republican", "incumbent": True},
+                    {"name": "Troy Jackson", "party": "Democratic"},
+                ],
+            },
+            {
+                "id": "oh-senate-2026-special",
+                "title": "Ohio Senate Special",
+                "office": "United States Senate",
+                "forecast": {"rating": "tossup", "predicted_winner_party": "Republican", "win_probability": 0.55},
+                "candidates": [{"name": "A", "party": "Republican"}, {"name": "B", "party": "Democratic"}],
+            },
+        ],
+        "US Senate",
+        {
+            "control_party": "Republican",
+            "control_probability": 0.533,
+            "outcome_probabilities": {"Democratic": 0.467, "Republican": 0.533, "tie_50_50": 0.199},
+            "projected_seats": {"Democratic": 50, "Republican": 50},
+            "expected_seats": {"Democratic": 50.0, "Republican": 49.7},
+        },
+    )
+
+    # A Democratic-favored race on a Republican-held seat is a pickup, not a defense.
+    assert "Maine U.S. Senate Election, 2026: Tilt DEMOCRATIC (Win Prob: 64.0%, currently Republican-held)" in context
+    # No incumbent running reads as an open seat rather than being left ambiguous.
+    assert "Ohio Senate Special: Toss-up (Win Prob: 55.0%, open seat, no incumbent running)" in context
+
+
+def test_forecast_prompt_forbids_defending_a_seat_the_party_does_not_hold():
+    from shared.forecast_summary import get_chamber_forecast_system_prompt
+
+    prompt = get_chamber_forecast_system_prompt("US Senate")
+
+    assert "pickup opportunity" in prompt
+    assert "does not currently hold" in prompt
+
+
+def test_narrative_review_prompt_carries_an_optional_goal():
+    from shared.forecast_summary import get_chamber_narrative_review_prompt
+
+    without = get_chamber_narrative_review_prompt("US Senate")
+    assert "corrections" in without
+    assert "currently holds" in without
+
+    with_goal = get_chamber_narrative_review_prompt("US Senate", "lead with the tipping-point races")
+    assert "lead with the tipping-point races" in with_goal
+    # An editorial steer must never be able to override a factual correction.
+    assert "which always win" in with_goal

--- a/tests/test_models_review.py
+++ b/tests/test_models_review.py
@@ -517,6 +517,52 @@ async def test_check_profile_links():
 
 
 @pytest.mark.asyncio
+async def test_link_severity_tracks_confidence_that_the_link_is_gone():
+    """A 404 is evidence a citation died. A 503 only says the host misbehaved.
+
+    Both used to be reported as warnings, which let one flaky fetch speak with
+    the authority of a confirmed dead link — and under the old scoring cap a
+    single warning was enough to block publication outright.
+    """
+    import httpx
+
+    from pipeline_client.agent.review import check_profile_links
+
+    statuses = {
+        "https://example.com/gone": 404,
+        "https://example.com/flaky": 503,
+        "https://example.com/botwalled": 403,
+    }
+
+    async def mock_head(url, *args, **kwargs):
+        return httpx.Response(statuses.get(url, 200), request=httpx.Request("HEAD", url))
+
+    race_data = {
+        "id": "mo-senate-2026",
+        "candidates": [
+            {
+                "name": "Candidate A",
+                "summary_sources": [
+                    {"url": url, "type": "website", "last_accessed": "2026-06-12T00:00:00Z"} for url in statuses
+                ],
+            }
+        ],
+    }
+
+    with patch("httpx.AsyncClient.head", side_effect=mock_head), patch("httpx.AsyncClient.get", side_effect=mock_head):
+        review = await check_profile_links(race_data)
+
+    by_url = {flag["url"]: flag for flag in review["flags"]}
+
+    assert by_url["https://example.com/gone"]["severity"] == "warning"
+    assert by_url["https://example.com/flaky"]["severity"] == "info"
+    # Bot-blocking establishes nothing either way, so it is not reported at all.
+    assert "https://example.com/botwalled" not in by_url
+    # Only a confirmed death flags the review.
+    assert review["verdict"] == "flagged"
+
+
+@pytest.mark.asyncio
 async def test_check_profile_links_skips_profiles_without_sources():
     from pipeline_client.agent.review import check_profile_links
 

--- a/tests/test_pipeline_quality_regressions.py
+++ b/tests/test_pipeline_quality_regressions.py
@@ -146,22 +146,56 @@ def test_polling_semantics_reject_placeholder_and_election_results():
     )
 
 
-def test_automated_warning_caps_validation_below_passing():
+def test_automated_warnings_deduct_rather_than_veto():
+    """Warnings scale with how many there are instead of pinning the score.
+
+    They used to cap the average at 79 against a pass mark of 80, so one
+    advisory flag was an unconditional veto — a race three models approved at 93
+    graded C and no further research could lift it, because every surviving
+    warning re-applied the same cap.
+    """
+
+    def grade_with(warning_count: int, score: int = 96):
+        return compute_validation_grade(
+            [
+                {"model": "reviewer", "score": score, "verdict": "approved", "flags": []},
+                {
+                    "model": "automated-profile-quality",
+                    "score": None,
+                    "verdict": "flagged",
+                    "flags": [{"severity": "warning", "field": f"candidate.field_{i}"} for i in range(warning_count)],
+                },
+            ]
+        )
+
+    # A strong review absorbs a couple of advisory flags.
+    one = grade_with(1)
+    assert one["score"] == 93
+    assert one["passed"] is True
+
+    # But they accumulate, and enough of them still block.
+    assert grade_with(6)["passed"] is False
+
+    # A weaker review has far less headroom than a strong one.
+    assert grade_with(2, score=83)["passed"] is False
+
+
+def test_error_flags_still_block_regardless_of_score():
+    """Errors are not advisory, so they stay an unconditional block."""
     grade = compute_validation_grade(
         [
-            {"model": "reviewer", "score": 96, "verdict": "approved", "flags": []},
+            {"model": "reviewer", "score": 99, "verdict": "approved", "flags": []},
             {
                 "model": "automated-profile-quality",
                 "score": None,
                 "verdict": "flagged",
-                "flags": [{"severity": "warning", "field": "candidate.summary_sources"}],
+                "flags": [{"severity": "error", "field": "candidates[0].name"}],
             },
         ]
     )
 
-    assert grade["score"] == 79
-    assert grade["grade"] == "C"
     assert grade["passed"] is False
+    assert grade["score"] < 80
 
 
 def test_quality_check_flags_implausible_house_term_count():


### PR DESCRIPTION
## The gate was a veto wearing a score's clothing

```python
if blocking_flags:
    avg = min(avg, 79)
...
passed = avg >= 80
```

The cap is 79. Passing needs 80. So a single warning-severity flag blocked
publication unconditionally — and it was reached by flags from the two
automated reviewers that the very same function deliberately excludes from the
score average.

`co-house-08-2026` was reviewed at **93** (88, 96, 95 — all three approving) and
graded **C**, blocked, over three unsourced stances and one dead link. Research
could not lift it: every surviving warning re-applied the same cap, so the grade
stayed pinned until the flag count hit exactly zero. 27 competitive races are
sitting in that state right now.

**Warnings now deduct 3 points each.** A race reviewed in the 90s absorbs two or
three; one scraping by in the low 80s does not. **Errors are unchanged** and
still pin the grade below the pass mark however well the race scored — an error
means something is demonstrably wrong, not merely unproven.

| review | flags | before | after |
|---|---|---|---|
| 96 | 1 warning | 79 · C · blocked | 93 · A · passes |
| 96 | 6 warnings | 79 · C · blocked | 78 · C · blocked |
| 83 | 2 warnings | 79 · C · blocked | 77 · C · blocked |
| 99 | 1 error | 79 · C · blocked | 79 · C · blocked |

## Link checks now report what they establish

Every failure was reported as a warning, so one flaky fetch spoke with the
authority of a confirmed dead link — and under the old cap that alone blocked a
race. A 404, a 410, an unresolvable host or a bad certificate stays a
`warning`; a timeout, a connection reset or a 5xx drops to `info`.

The permanent/transient split already existed and was computed on every check —
it simply never reached `severity`. `401/403/429` were already excluded
upstream, so bot-blocking never counted as evidence either way.

## The narrative could not tell a hold from a flip

The context handed the model a rating and a probability and nothing about who
holds the seat:

```
- Maine U.S. Senate Election, 2026: Tilt DEMOCRATIC (Win Prob: 64.0%)
```

So the published Senate note listed Maine among the seats Democrats had to
"defend". The seat is Susan Collins's; a Democratic win there is a pickup. Now:

```
- Maine U.S. Senate Election, 2026: Tilt DEMOCRATIC (Win Prob: 64.0%, currently Republican-held)
```

with the prompt explicit that a party cannot defend what it does not hold.

## Opt-in narrative review pass

`generate_chamber_forecasts(review=True, goal=...)` re-reads each drafted
narrative against the same authoritative context and rewrites claims that
contradict it — wrong seat totals, invented races, defending a seat the party
does not hold, conflating the projected split with the control call. It reports
what it corrected under `review_corrections`.

`goal` is an optional editorial steer ("lead with the tipping-point races"),
explicitly subordinate to the factual checks. Off by default — it costs one
extra LLM call per chamber. A review that fails returns the draft untouched
rather than losing a usable narrative.

## Gates

pipeline `1259 passed` · races-api `43 passed` · admin `93 passed` ·
black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
