### PR TITLE
Name the headshot check after the one host it actually matches

### DIFF
--- a/pipeline_client/agent/images.py
+++ b/pipeline_client/agent/images.py
@@ -131,8 +131,8 @@ def _looks_like_non_photo(url: str, alt: str = "") -> bool:
     return any(marker in haystack for marker in _GENERIC_CARD_MARKERS)
 
 
-def _looks_like_low_resolution_reference_photo(url: str) -> bool:
-    """Return True for usable-but-small reference headshots worth upgrading."""
+def _looks_like_govtrack_reference_headshot(url: str) -> bool:
+    """Return True for GovTrack's small legislator headshots worth upgrading."""
     try:
         parsed = urlparse(url)
     except Exception:
@@ -246,7 +246,7 @@ async def _lookup_known_page_image(candidate: Dict[str, Any]) -> Optional[str]:
                     accessible, final_url = await _check_url_accessible(image_url)
                     if accessible:
                         store_url = final_url if _is_valid_image_url(final_url) else image_url
-                        if _looks_like_low_resolution_reference_photo(store_url):
+                        if _looks_like_govtrack_reference_headshot(store_url):
                             continue
                         return store_url
     except Exception as exc:
@@ -553,7 +553,7 @@ async def _resolve_single_image(
     if not current_url:
         candidate["image_url"] = None
 
-    if current_url and _looks_like_low_resolution_reference_photo(current_url):
+    if current_url and _looks_like_govtrack_reference_headshot(current_url):
         low_resolution_fallback = current_url
         candidate["image_url"] = None
         current_url = None

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -3,6 +3,7 @@ import pytest
 from pipeline_client.agent.images import (
     _candidate_page_urls,
     _extract_page_image_urls,
+    _looks_like_govtrack_reference_headshot,
     _looks_like_non_photo,
     _lookup_wikipedia_image,
     _resolve_single_image,
@@ -156,7 +157,7 @@ async def test_resolve_single_image_replaces_existing_non_photo_url(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_resolve_single_image_replaces_low_resolution_govtrack_reference_photo(monkeypatch):
+async def test_resolve_single_image_replaces_govtrack_reference_headshot(monkeypatch):
     low_res = "https://www.govtrack.us/static/legislator-photos/412609-200px.jpeg"
     replacement = "https://upload.wikimedia.org/wikipedia/commons/0/0b/Hill_French_119th_Congress.jpg"
     candidate = {"name": "French Hill", "image_url": low_res}
@@ -182,6 +183,12 @@ async def test_resolve_single_image_replaces_low_resolution_govtrack_reference_p
     await _resolve_single_image(candidate, agent_loop_fn=fail_agent, model="test")
 
     assert candidate["image_url"] == replacement
+
+
+def test_looks_like_govtrack_reference_headshot_is_specific_to_govtrack_pattern():
+    assert _looks_like_govtrack_reference_headshot("https://www.govtrack.us/static/legislator-photos/412609-200px.jpeg")
+    assert not _looks_like_govtrack_reference_headshot("https://example.com/static/legislator-photos/412609-200px.jpeg")
+    assert not _looks_like_govtrack_reference_headshot("https://www.govtrack.us/congress/members/french_hill/412609")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`_looks_like_low_resolution_reference_photo` reads as a general low-resolution
test. The body only ever matched one thing:

```python
return netloc == "www.govtrack.us" and "/static/legislator-photos/" in path
```

Nothing about resolution is examined, and no other host can satisfy it. A name
that promises more than the code delivers invites the next caller to reach for
it on some other host's small photo and quietly get `False`.

Renamed to `_looks_like_govtrack_reference_headshot`.

Adds a test pinning the specificity, since the old name gave no hint that host
*and* path both have to match — the same path on another host is not a GovTrack
reference photo, and a GovTrack member page that is not a `legislator-photos`
asset is not one either.

Behaviour is unchanged.

`tests/test_images.py` 20 passed · black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
