### PR TITLE
Stop long race names blowing out the mobile layout

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -132,4 +132,24 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
+
+  .custom-scrollbar::-webkit-scrollbar {
+    height: 6px;
+    width: 6px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: rgba(156, 163, 175, 0.1);
+    border-radius: 3px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background: rgba(156, 163, 175, 0.35);
+    border-radius: 3px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: rgba(156, 163, 175, 0.6);
+  }
+  .custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(156, 163, 175, 0.35) transparent;
+  }
 }

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -161,7 +161,7 @@
     </div>
   {/if}
 
-  <div class="overflow-x-auto">
+  <div class="overflow-x-auto custom-scrollbar">
     <div style="min-width: {(compact ? 170 : 220) + candidates.length * 250}px">
       <div
         class:sticky={!compact}

--- a/web/src/lib/components/home/InteractiveRaceCompare.svelte
+++ b/web/src/lib/components/home/InteractiveRaceCompare.svelte
@@ -79,15 +79,15 @@
               type="button"
               on:click={() => (selectedId = race.id)}
               aria-pressed={selectedId === race.id}
-              class="min-h-11 whitespace-nowrap rounded-full border px-4 py-2 text-sm font-bold transition {selectedId ===
+              class="min-h-11 max-w-[220px] whitespace-nowrap rounded-full border px-4 py-2 text-sm font-bold transition sm:max-w-none {selectedId ===
               race.id
                 ? 'border-blue-600 bg-blue-600 text-white shadow-md shadow-blue-600/20'
                 : 'border-stroke bg-surface text-content-muted hover:border-blue-400 hover:text-blue-700'}"
             >
-              <span class="mr-1 opacity-70"
+              <span class="mr-1 shrink-0 opacity-70"
                 >{String(index + 1).padStart(2, "0")}</span
               >
-              {race.jurisdiction} · {race.office}
+              <span class="truncate">{race.jurisdiction} · {race.office}</span>
             </button>
           {/each}
         </div>

--- a/web/src/lib/components/support/TrustPage.svelte
+++ b/web/src/lib/components/support/TrustPage.svelte
@@ -17,7 +17,7 @@
   <meta name="twitter:card" content="summary_large_image" />
 </svelte:head>
 
-<div class="mx-auto max-w-4xl px-4 py-10 sm:py-16">
+<div class="mx-auto max-w-4xl px-4 py-10 sm:py-16 min-h-[calc(100vh-16rem)]">
   <header class="mb-10 max-w-3xl">
     <p
       class="mb-3 text-sm font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-500"


### PR DESCRIPTION
Three related overflow problems on narrow screens.

**Home comparison chips.** The race picker chips sized themselves to their
text, so a long jurisdiction and office ran the row past the viewport and
pushed a horizontal scrollbar onto the whole page. They now cap their width on
small screens and truncate the secondary line, staying unconstrained from `sm`
up where there is room. The leading marker is `shrink-0` so truncation takes
space from the label rather than collapsing the marker itself.

**Candidate comparison table.** It scrolls horizontally by design, but that
scrollbar was the browser default — a heavy bar sitting under the content. A
`custom-scrollbar` utility gives it a 6px thumb in both WebKit and Firefox,
keeping the affordance visible without dominating the table.

**Trust page.** Short enough that on tall viewports the footer rode up into the
middle of the screen. A minimum height on the content wrapper holds it down.

Layout only, no behaviour changes.

web unit `240 passed` · prettier/eslint clean · svelte-check `0 errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
