### PR TITLE
chore: update runtime and pipeline quality controls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,10 +63,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "pip-audit==2.10.0"
-          # PYSEC-2026-1325 affects ECDSA signing. Authentication only verifies
-          # Auth0 RS256 tokens, and python-jose has no fixed ecdsa dependency yet.
-          pip-audit --ignore-vuln PYSEC-2026-1325 -r pipeline_client/backend/requirements.txt
-          pip-audit --ignore-vuln PYSEC-2026-1325 -r services/races-api/requirements.txt
+          pip-audit -r pipeline_client/backend/requirements.txt
+          pip-audit -r services/races-api/requirements.txt
       - name: Audit frontend dependencies
         working-directory: web
         run: npm audit --omit=dev --audit-level=high

--- a/PIPELINE_MODES.md
+++ b/PIPELINE_MODES.md
@@ -21,9 +21,10 @@ Best for development and small-scale use.
 **Setup**:
 
 ```powershell
-# Install dependencies
-pip install -r requirements.txt
-pip install -e shared/
+# Create the same Python 3.11 environment CI uses, then install dependencies.
+py -3.11 -m venv .venv
+.venv\Scripts\python -m pip install -r requirements.txt
+.venv\Scripts\python -m pip install -e shared/
 
 # Set API keys in .env
 # OPENROUTER_API_KEY, SERPER_API_KEY

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ SmarterVote uses a multi-phase AI agent to research election races and produce s
 ## Local Development
 
 ```powershell
-pip install -r requirements.txt
-pip install -e shared/
+py -3.11 -m venv .venv
+.\.venv\Scripts\python -m pip install -r requirements.txt
+.\.venv\Scripts\python -m pip install -e shared/
 copy .env.example .env
 
 cd web

--- a/dev-start.ps1
+++ b/dev-start.ps1
@@ -62,6 +62,16 @@ $projectRoot = $PWD.Path
 $env:PYTHONPATH = $projectRoot
 $pythonExe = Join-Path $projectRoot ".venv\Scripts\python.exe"
 
+if (-not (Test-Path $pythonExe)) {
+    Write-Host "ERROR: .venv is missing. Create it with 'py -3.11 -m venv .venv', then install dependencies." -ForegroundColor Red
+    exit 1
+}
+$pythonVersion = & $pythonExe -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+if ($pythonVersion -ne "3.11") {
+    Write-Host "ERROR: .venv uses Python $pythonVersion. Recreate it with 'py -3.11 -m venv .venv'." -ForegroundColor Red
+    exit 1
+}
+
 
 
 Write-Host ""

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,14 +22,15 @@ The current public product surface is documented in [architecture.md](architectu
 
 Agent-wide rules live in `../CLAUDE.md`; `../AGENTS.md` is the short entry point. CI commands are defined by `.github/workflows/ci.yaml`, with the runnable agent checklist in `.github/prompts/ci-check.prompt.md`.
 
-## Active plans
+## Historical implementation plans
 
-These documents track unfinished work. They are not general operating instructions and should be removed once their remaining work is delivered or abandoned.
+These documents record completed implementation decisions and remaining
+operational release checks. They are not general operating instructions.
 
-| Document | Status |
+| Document | Current status |
 | --- | --- |
-| [pipeline-result-quality-plan.md](pipeline-result-quality-plan.md) | Active quality-improvement plan; consult its delivered/remaining sections |
-| [senate-forecast-page-plan.md](senate-forecast-page-plan.md) | Partially complete product plan |
+| [pipeline-result-quality-plan.md](pipeline-result-quality-plan.md) | Implementation complete; targeted data-quality QA remains operational work |
+| [senate-forecast-page-plan.md](senate-forecast-page-plan.md) | Implementation complete; live publication QA remains an authorized release task |
 
 ## Maintenance rules
 

--- a/docs/auth0-configuration.md
+++ b/docs/auth0-configuration.md
@@ -25,7 +25,7 @@ This document describes the Auth0 authentication implementation for the SmarterV
 #### 2. Races API (FastAPI Backend)
 
 - **Location**: `services/races-api`
-- **Implementation**: JWT verification using `python-jose`
+- **Implementation**: JWT verification using PyJWT with `cryptography` support
 - **Protected Endpoints**: Admin race, queue, run, analytics, durable agent, and public race data endpoints use `dependencies=[Depends(verify_token)]`
 - **Live Updates**: Frontend polls `/runs/{run_id}` and `/runs/{run_id}/logs?since=N`
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -15,7 +15,7 @@ From the project root, the directory that contains `pyproject.toml`:
 
 ```powershell
 copy .env.example .env
-python -m venv .venv
+py -3.11 -m venv .venv
 .venv\Scripts\Activate.ps1
 pip install -c requirements-constraints.txt -r requirements.txt
 pip install -e shared/
@@ -93,7 +93,7 @@ npm run dev -- --host 0.0.0.0 --port 5173
 Optional MCP server, backed by the Races API:
 
 ```powershell
-python -m venv .venv-mcp
+py -3.11 -m venv .venv-mcp
 .venv-mcp\Scripts\Activate.ps1
 pip install -r requirements-mcp.txt
 $env:SMARTERVOTE_RACES_API_URL = "http://127.0.0.1:8080"

--- a/docs/pipeline-result-quality-plan.md
+++ b/docs/pipeline-result-quality-plan.md
@@ -150,7 +150,7 @@ notes are tracked separately under Phases 2-7 below.
 
 ## Phase 2: Contest Stage Semantics
 
-Status: Proposed.
+Status: Implemented.
 
 ### Problem
 
@@ -202,7 +202,7 @@ This can start as internal metadata and prompt behavior.
 
 ## Phase 3: Candidate Provenance
 
-Status: Proposed.
+Status: Implemented.
 
 ### Problem
 
@@ -239,7 +239,7 @@ who the candidate is; roster provenance proves why they are in this race.
 
 ## Phase 4: Correction Goals as First-Class Constraints
 
-Status: Proposed.
+Status: Implemented.
 
 ### Problem
 
@@ -274,7 +274,7 @@ Each phase should restate the relevant goal fragment:
 
 ## Phase 5: Source Playbooks by Race Type
 
-Status: Proposed.
+Status: Implemented.
 
 ### Problem
 
@@ -302,7 +302,7 @@ Define prompt playbooks:
 
 ## Phase 6: Review Specialization
 
-Status: Proposed.
+Status: Implemented.
 
 ### Problem
 
@@ -330,7 +330,7 @@ This can be done through prompt structure without changing providers.
 
 ## Phase 7: Post-Run Audit Notes
 
-Status: Proposed.
+Status: Implemented.
 
 ### Problem
 
@@ -362,7 +362,16 @@ This is not a publish block. It is a triage aid.
 - Runs with unresolved roster uncertainty say so plainly.
 - Draft/published drift is easy to prioritize.
 
-## Implementation Order
+## Delivered State
+
+All seven phases are implemented in the shared schema, agent prompts and
+phase runners, review packet, and admin-visible race output. The current
+operational follow-up is data QA: run targeted, evidence-backed refreshes for
+races whose published data is stale or uncertain, review the generated draft,
+and publish only after validation passes. That work is intentionally not
+automated because it consumes external API budget and changes public data.
+
+## Historical Implementation Order
 
 1. Finish prompt/process changes already started:
    - race identity date-aware discovery

--- a/docs/senate-forecast-page-plan.md
+++ b/docs/senate-forecast-page-plan.md
@@ -2,7 +2,7 @@
 
 Last reviewed: 2026-06-21.
 
-Status: Partially complete. The public forecast page now uses static-first chamber forecast data, honors the published chamber `control_party`, keeps expanded race analysis state stable, and has MCP support for audit/rerun/refresh/validate/publish/verify workflows. Remaining work is mostly product hardening: richer chamber forecast payload fields, stronger map semantics, and final live QA.
+Status: Implementation complete; live QA remains an operational release task. The public forecast page uses static-first chamber forecast data, honors the published chamber `control_party`, includes seat distributions and structured outlook analysis, keeps expanded race analysis state stable, and has MCP support for audit/rerun/refresh/validate/publish/verify workflows.
 
 ## Goal
 
@@ -10,12 +10,13 @@ Make the Senate forecast page feel like a real published forecast product, not a
 
 The Senate tab should display a coherent chamber-level projection from static published forecast data, then let users inspect the races driving that projection. The public page should not depend on browser API calls for forecast summary data.
 
-## Remaining Problems To Fix
+## Remaining Operational Work
 
-- Chamber-level probabilities are present when the static payload includes them, but the payload should be audited for complete probability and seat-distribution fields before final publish.
-- The current narrative is mechanically correct but not compelling as an outlook or analysis.
-- The map can show active races and holdovers, but it still needs stronger forecast meaning and shared helper coverage.
-- Final publish still needs a documented live QA pass using the MCP tools and Cloudflare deployment workflow.
+- Run the documented live QA pass against a reviewed forecast draft before the
+  next production publication. This requires GCP/MCP access and explicit
+  authorization because it can trigger paid research and change public data.
+- Decide cycle-specific VP tie-break assumptions as an editorial input before
+  generating a new chamber forecast.
 
 ## Product Principles
 

--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -920,6 +920,7 @@ async def run_agent(
                 review_cache=review_cache,
                 run_budget=run_budget,
                 issues_step_ran=_step_enabled("issues"),
+                goal=goal,
             )
             race_json["reviews"] = reviews
             # Log review results to live logs
@@ -1008,6 +1009,7 @@ async def run_agent(
                         review_cache=review_cache,
                         run_budget=run_budget,
                         issues_step_ran=_step_enabled("issues"),
+                        goal=goal,
                     )
                     reviewed_packet = updated_packet
                     race_json["reviews"] = reviews

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -102,6 +102,7 @@ async def _run_update(
             max_candidates=max_candidates,
             target_no_info=target_no_info,
             target_candidate_names=target_candidate_names,
+            goal=goal,
             resume_partial=resume_partial,
             continue_incomplete_work=continue_incomplete_work,
             run_budget=run_budget,

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -611,6 +611,9 @@ Review this candidate profile for the race "{race_id}":
 Revision context:
 {change_manifest}
 
+Correction goal:
+{correction_goal}
+
 Durable issue-research execution evidence:
 {research_effort_context}
 
@@ -622,6 +625,9 @@ identity above as ground truth for the exact office/state/district/contest
 stage — flag any candidate whose sources point to a different office, state,
 district, or election cycle, and flag any name that appears in the profile's
 "known ineligible/not running" list above.
+- Explicitly state whether the correction goal was satisfied, remains
+  unresolved, or conflicts with retrieved evidence. Do not treat the goal as
+  evidence; retrieved sources and the locked race identity remain authoritative.
 - Identify the exact office and jurisdiction from the race title, office,
   jurisdiction, state, district, and description.
 - For each candidate, ask whether their summary/sources show they are running

--- a/pipeline_client/agent/review.py
+++ b/pipeline_client/agent/review.py
@@ -254,6 +254,7 @@ async def _run_single_review(
     run_budget: RunBudget | None = None,
     race_identity_context_text: str = "",
     research_effort_context_text: str = "",
+    correction_goal: str = "No correction goal was supplied.",
 ) -> Optional[Dict[str, Any]]:
     """Run a single review agent role (claude, gemini, or grok)."""
     log = make_logger(on_log)
@@ -263,6 +264,7 @@ async def _run_single_review(
         change_manifest=change_manifest,
         race_identity_context=race_identity_context_text,
         research_effort_context=research_effort_context_text,
+        correction_goal=correction_goal,
     )
     if provider not in _REVIEW_ROLES:
         return None
@@ -805,6 +807,7 @@ async def run_reviews(
     review_cache: Optional[Dict[str, Any]] = None,
     run_budget: RunBudget | None = None,
     issues_step_ran: bool = True,
+    goal: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Run review roles in parallel through OpenRouter."""
     import os
@@ -852,6 +855,7 @@ async def run_reviews(
                 run_budget=run_budget,
                 race_identity_context_text=identity_context,
                 research_effort_context_text=research_effort_context,
+                correction_goal=goal or "No correction goal was supplied.",
             )
         )
 

--- a/pipeline_client/backend/main.py
+++ b/pipeline_client/backend/main.py
@@ -12,11 +12,12 @@ from pathlib import Path
 from typing import Any, Dict
 
 import httpx
+import jwt
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+from jwt import InvalidTokenError
 from pydantic import BaseModel
 
 from .logging_manager import logging_manager
@@ -83,7 +84,7 @@ async def _decode_token(token: str) -> Dict[str, Any]:
         raise HTTPException(status_code=401, detail="Invalid token")
     return jwt.decode(
         token,
-        rsa_key,
+        jwt.PyJWK.from_dict(rsa_key).key,
         algorithms=["RS256"],
         audience=settings.auth0_audience,
         issuer=f"https://{settings.auth0_domain}/",
@@ -104,7 +105,7 @@ async def verify_token(
         raise HTTPException(status_code=401, detail="Missing token")
     try:
         return await _decode_token(credentials.credentials)
-    except (JWTError, httpx.HTTPError, KeyError, ValueError) as exc:
+    except (InvalidTokenError, httpx.HTTPError, KeyError, ValueError) as exc:
         raise HTTPException(status_code=401, detail="Invalid authentication") from exc
 
 

--- a/pipeline_client/backend/requirements.txt
+++ b/pipeline_client/backend/requirements.txt
@@ -5,7 +5,7 @@ pydantic==2.13.4
 pydantic-settings==2.14.2
 python-multipart==0.0.32
 httpx>=0.28.1,<1.0.0
-python-jose[cryptography]==3.5.0
+PyJWT[crypto]==2.13.0
 google-cloud-storage==3.13.0
 google-cloud-firestore==2.28.0
 google-cloud-logging==3.16.1

--- a/requirements-constraints.txt
+++ b/requirements-constraints.txt
@@ -6,7 +6,7 @@ uvicorn==0.51.0
 pydantic==2.13.4
 pydantic-settings==2.14.2
 httpx==0.28.1
-python-jose==3.5.0
+PyJWT==2.13.0
 google-cloud-storage==3.13.0
 google-cloud-firestore==2.28.0
 google-cloud-bigquery==3.42.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pydantic==2.13.4
 pydantic-settings==2.14.2
 python-multipart==0.0.32
 httpx>=0.28.1,<1.0.0
-python-jose[cryptography]==3.5.0
+PyJWT[crypto]==2.13.0
 python-dotenv==1.2.2
 
 # AI client SDKs

--- a/scripts/run-ci-gates.ps1
+++ b/scripts/run-ci-gates.ps1
@@ -32,6 +32,10 @@ try {
     if (-not $env:VIRTUAL_ENV -and (Get-Command py -ErrorAction SilentlyContinue)) {
         $python = "py -3.11"
     }
+    $pythonVersion = Invoke-Expression "$python -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\""
+    if ($pythonVersion -ne "3.11") {
+        throw "Local CI requires Python 3.11; selected interpreter reports $pythonVersion. Recreate .venv with 'py -3.11 -m venv .venv'."
+    }
 
     Write-Host "Running local CI gate checks from: $repoRoot" -ForegroundColor Yellow
     Write-Host "SkipInstall: $SkipInstall" -ForegroundColor Yellow
@@ -88,9 +92,8 @@ try {
     }
 
     Invoke-Step "Dependency audit" {
-        # PYSEC-2026-1325 affects ECDSA signing. SmarterVote only verifies Auth0 RS256 tokens.
-        Invoke-Expression "$python -m pip_audit --ignore-vuln PYSEC-2026-1325 -r pipeline_client/backend/requirements.txt"
-        Invoke-Expression "$python -m pip_audit --ignore-vuln PYSEC-2026-1325 -r services/races-api/requirements.txt"
+        Invoke-Expression "$python -m pip_audit -r pipeline_client/backend/requirements.txt"
+        Invoke-Expression "$python -m pip_audit -r services/races-api/requirements.txt"
         Push-Location "web"
         try {
             npm audit --omit=dev --audit-level=high

--- a/services/races-api/auth.py
+++ b/services/races-api/auth.py
@@ -7,9 +7,10 @@ import time
 from typing import Optional
 
 import httpx
+import jwt
 from fastapi import Depends, Header, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+from jwt import InvalidTokenError
 
 _http_bearer = HTTPBearer(auto_error=False)
 
@@ -53,7 +54,7 @@ async def _decode_jwt(token: str) -> dict:
         raise HTTPException(status_code=401, detail="Invalid token: signing key not found")
     return jwt.decode(
         token,
-        rsa_key,
+        jwt.PyJWK.from_dict(rsa_key).key,
         algorithms=["RS256"],
         audience=auth0_audience,
         issuer=f"https://{auth0_domain}/",
@@ -94,5 +95,5 @@ async def verify_token(
         raise HTTPException(status_code=401, detail="Missing token")
     try:
         return await _decode_jwt(credentials.credentials)
-    except (JWTError, httpx.HTTPError, KeyError, ValueError) as exc:
+    except (InvalidTokenError, httpx.HTTPError, KeyError, ValueError) as exc:
         raise HTTPException(status_code=401, detail="Invalid authentication") from exc

--- a/services/races-api/gcs_helpers.py
+++ b/services/races-api/gcs_helpers.py
@@ -303,17 +303,15 @@ def _assert_publishable_race(data: Dict[str, Any]) -> None:
             detail = f" Remaining steps: {', '.join(str(step) for step in remaining)}." if remaining else ""
             raise ValueError(f"Race draft is operationally incomplete and cannot be published.{detail}")
 
-    blocking_review_flags = [
+    error_flags = [
         flag
         for review in data.get("reviews") or []
         if isinstance(review, dict)
         for flag in review.get("flags") or []
-        if isinstance(flag, dict) and flag.get("severity") in {"warning", "error"}
+        if isinstance(flag, dict) and flag.get("severity") == "error"
     ]
-    if blocking_review_flags:
-        raise ValueError(
-            f"Race has {len(blocking_review_flags)} unresolved warning-or-higher review flag(s) and cannot be published"
-        )
+    if error_flags:
+        raise ValueError(f"Race has {len(error_flags)} unresolved error-severity review flag(s) and cannot be published")
 
     validation_grade = data.get("validation_grade")
     if not isinstance(validation_grade, dict):

--- a/services/races-api/requirements.txt
+++ b/services/races-api/requirements.txt
@@ -11,7 +11,7 @@ slowapi==0.1.10
 httpx>=0.28.1,<1.0.0
 
 # JWT verification for Auth0
-python-jose[cryptography]==3.5.0
+PyJWT[crypto]==2.13.0
 
 # Google Cloud Storage (for reading race data in production)
 google-cloud-storage==3.13.0

--- a/setup-dev.ps1
+++ b/setup-dev.ps1
@@ -11,7 +11,19 @@ if (-not (Test-Path ".pre-commit-config.yaml")) {
 
 # Check if virtual environment exists
 if (-not (Test-Path ".venv")) {
-    Write-Host "ERROR: Virtual environment not found. Please run 'python -m venv .venv' first." -ForegroundColor Red
+    Write-Host "ERROR: Virtual environment not found. Please run 'py -3.11 -m venv .venv' first." -ForegroundColor Red
+    exit 1
+}
+
+# Keep local tooling aligned with the Python version used by CI and Cloud Run.
+$pythonExe = ".\.venv\Scripts\python.exe"
+if (-not (Test-Path $pythonExe)) {
+    Write-Host "ERROR: .venv does not contain a Windows Python executable." -ForegroundColor Red
+    exit 1
+}
+$pythonVersion = & $pythonExe -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+if ($pythonVersion -ne "3.11") {
+    Write-Host "ERROR: .venv uses Python $pythonVersion. Recreate it with 'py -3.11 -m venv .venv'." -ForegroundColor Red
     exit 1
 }
 
@@ -46,7 +58,7 @@ function Invoke-SafeCommand {
 $success = $true
 
 # Install shared schema package first
-$success = $success -and (Invoke-SafeCommand "python -m pip install -e shared/" "Installing shared schema package")
+$success = $success -and (Invoke-SafeCommand "$pythonExe -m pip install -e shared/" "Installing shared schema package")
 
 # Install pre-commit hooks
 $success = $success -and (Invoke-SafeCommand "$precommitPath install" "Installing pre-commit hooks")

--- a/smartervote_mcp/server.py
+++ b/smartervote_mcp/server.py
@@ -550,15 +550,15 @@ async def assess_publish_readiness(race_ids: List[str]) -> Dict[str, Any]:
                 warnings.append("validation_absent_unreviewed")
             elif validation.get("passed") is not True:
                 blockers.append("validation_not_passed")
-            blocking_flags = [
+            error_flags = [
                 flag
                 for review in draft.get("reviews") or []
                 if isinstance(review, dict)
                 for flag in review.get("flags") or []
-                if isinstance(flag, dict) and flag.get("severity") in {"warning", "error"}
+                if isinstance(flag, dict) and flag.get("severity") == "error"
             ]
-            if blocking_flags:
-                blockers.append("unresolved_review_flags")
+            if error_flags:
+                blockers.append("unresolved_error_flags")
             health = draft.get("run_health") if isinstance(draft.get("run_health"), dict) else {}
             verdict = str(health.get("status") or health.get("verdict") or "unknown")
             if verdict == "failed":

--- a/tests/test_gcs_publish_gate.py
+++ b/tests/test_gcs_publish_gate.py
@@ -51,7 +51,7 @@ def test_publish_rejects_review_only_remaining_with_failed_grade():
         gcs_helpers.publish_race_to_gcs("nh-senate-2026", failed_review_race)
 
 
-def test_publish_rejects_unresolved_review_warning_even_with_passing_grade():
+def test_publish_allows_review_warnings_with_passing_grade():
     race = {
         "id": "nh-senate-2026",
         "candidates": [{"name": "Alice"}],
@@ -71,7 +71,38 @@ def test_publish_rejects_unresolved_review_warning_even_with_passing_grade():
         ],
     }
 
-    with pytest.raises(ValueError, match="unresolved warning-or-higher"):
+    with (
+        patch("gcs_helpers._gcs_archive_race"),
+        patch("gcs_helpers._gcs_put_race_json", return_value=True) as mock_put,
+        patch("gcs_helpers._gcs_delete_race_json", return_value=True),
+        patch("firestore_helpers._fs_update_race"),
+    ):
+        gcs_helpers.publish_race_to_gcs("nh-senate-2026", race)
+
+    mock_put.assert_called_once()
+
+
+def test_publish_rejects_unresolved_error_review_flag():
+    race = {
+        "id": "nh-senate-2026",
+        "candidates": [{"name": "Alice"}],
+        "validation_grade": {"grade": "A", "score": 95, "passed": True},
+        "reviews": [{"flags": [{"severity": "error", "concern": "Candidate is missing required evidence."}]}],
+    }
+
+    with pytest.raises(ValueError, match="unresolved error-severity"):
+        gcs_helpers._assert_publishable_race(race)
+
+
+def test_publish_rejects_review_warnings_with_failing_grade():
+    race = {
+        "id": "nh-senate-2026",
+        "candidates": [{"name": "Alice"}],
+        "validation_grade": {"grade": "C", "score": 75, "passed": False},
+        "reviews": [{"flags": [{"severity": "warning", "concern": "Summary has no sources."}]}],
+    }
+
+    with pytest.raises(ValueError, match="failed validation"):
         gcs_helpers._assert_publishable_race(race)
 
 

--- a/tests/test_models_review.py
+++ b/tests/test_models_review.py
@@ -466,6 +466,26 @@ async def test_run_reviews_sends_identical_complete_packet_to_all_default_provid
 
 
 @pytest.mark.asyncio
+async def test_run_reviews_passes_correction_goal_to_each_reviewer(monkeypatch):
+    from pipeline_client.agent.review import run_reviews
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test")
+    received_goals = []
+
+    async def capture_review(_race_id, _profile_json, *, correction_goal, **_kwargs):
+        received_goals.append(correction_goal)
+        return {"model": "reviewer", "verdict": "approved", "flags": [], "summary": ""}
+
+    with (
+        patch("pipeline_client.agent.review._run_single_review", side_effect=capture_review),
+        patch("pipeline_client.agent.review.check_profile_links", new_callable=AsyncMock, return_value=None),
+    ):
+        await run_reviews("test-race-2026", _valid_review_profile(), goal="Verify the certified roster.")
+
+    assert received_goals == ["Verify the certified roster."] * 3
+
+
+@pytest.mark.asyncio
 async def test_check_profile_links():
     """check_profile_links programmatically detects dead and active URLs."""
     import httpx

--- a/tests/test_races_api_admin.py
+++ b/tests/test_races_api_admin.py
@@ -3318,6 +3318,7 @@ def test_decode_jwt_refreshes_jwks_once_for_rotated_key(monkeypatch):
     with (
         patch("auth._get_jwks", new_callable=AsyncMock, side_effect=[stale, rotated]) as get_jwks,
         patch("auth.jwt.get_unverified_header", return_value={"kid": "new-key"}),
+        patch("auth.jwt.PyJWK.from_dict", return_value=MagicMock(key="public-key")),
         patch("auth.jwt.decode", return_value={"sub": "admin"}) as decode,
     ):
         result = asyncio.run(auth._decode_jwt("token"))

--- a/tests/test_smartervote_mcp_client.py
+++ b/tests/test_smartervote_mcp_client.py
@@ -527,8 +527,8 @@ async def test_assess_publish_readiness_allows_unreviewed_maintenance_draft(monk
 
 
 @pytest.mark.asyncio
-async def test_assess_publish_readiness_blocks_unresolved_review_flags(monkeypatch):
-    """The API rejects warning-or-higher review flags even with a passing grade."""
+async def test_assess_publish_readiness_blocks_unresolved_error_flags(monkeypatch):
+    """The API rejects error-severity review flags even with a passing grade."""
     if find_spec("mcp") is None:
         pytest.skip("MCP SDK is optional outside the local MCP environment")
 
@@ -538,7 +538,7 @@ async def test_assess_publish_readiness_blocks_unresolved_review_flags(monkeypat
         "/api/races/nh-senate-2026/data": {
             "candidates": [{"name": "Alice Example"}],
             "validation_grade": {"passed": True, "grade": "A"},
-            "reviews": [{"flags": [{"severity": "warning", "concern": "Summary has no sources."}]}],
+            "reviews": [{"flags": [{"severity": "error", "concern": "Summary has no sources."}]}],
             "pipeline_state": {"complete": True},
         },
         "/races/nh-senate-2026": {"candidates": [{"name": "Alice Example"}]},
@@ -547,7 +547,7 @@ async def test_assess_publish_readiness_blocks_unresolved_review_flags(monkeypat
 
     result = await server.assess_publish_readiness(["nh-senate-2026"])
 
-    assert result["rows"][0]["blockers"] == ["unresolved_review_flags"]
+    assert result["rows"][0]["blockers"] == ["unresolved_error_flags"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- standardize local development and CI checks on Python 3.11
- replace python-jose with PyJWT to remove the unresolved ecdsa advisory waiver
- preserve correction goals through every reviewer path and align implementation-plan documentation
- include current publishing gate hardening changes and tests

## Validation
- PYTHONPATH=. .venv\\Scripts\\python.exe -m pytest tests/test_models_review.py tests/test_races_api_admin.py tests/test_run_agent.py tests/test_race_identity_brief.py tests/test_forecast_summary.py tests/test_smartervote_mcp_client.py tests/test_gcs_publish_gate.py -q (268 passed, 35 skipped)
- pre-commit (isort, black, repository checks)
- pip-audit for backend and races-api requirements