### PR TITLE
Fix provisional roster audit validation

### DIFF
--- a/pipeline_client/agent/phases/discovery.py
+++ b/pipeline_client/agent/phases/discovery.py
@@ -7,6 +7,7 @@ authoritative source) without relying on the model to police itself.
 """
 
 import re
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from .. import roster
@@ -363,12 +364,16 @@ def _record_provisional_roster(race_json: Dict[str, Any], log: Any | None = None
     # ran sentences together ("...September 1, 2026 Expect this to firm up...").
     note = " ".join(part if part.rstrip().endswith((".", "!", "?")) else f"{part.rstrip()}." for part in note_parts)
 
-    roster_research = race_json.setdefault("pipeline_state", {}).setdefault("roster_research", {})
-    if isinstance(roster_research, dict):
-        roster_research["completeness_status"] = "unproven"
-        roster_research["completeness_note"] = note
-        roster_research["completeness_reference_urls"] = links
-        roster_research["active_candidate_count"] = len(names)
+    pipeline_state = race_json.setdefault("pipeline_state", {})
+    pipeline_state["roster_research"] = {
+        "finalized_at": datetime.now(timezone.utc).isoformat(),
+        "summary": note,
+        "active_candidate_count": len(names),
+        "completeness_sources": [],
+        "completeness_status": "unproven",
+        "completeness_note": note,
+        "completeness_reference_urls": links,
+    }
 
     record_step_failure(race_json, "discovery", RunFailureReason.ROSTER_COMPLETENESS_UNPROVEN, note)
     if log:

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -124,6 +124,7 @@ async def _run_update(
             race_json["pipeline_state"]["completed_units"] = sorted(completed_units)
 
         pre_sync_names = list(candidate_names)
+        roster_sync_succeeded: bool | None = None
         if "discovery.roster_sync" not in completed_units:
             log("info", "Update Phase 0: Verifying candidate roster...")
             roster_sync_succeeded = False
@@ -196,9 +197,8 @@ async def _run_update(
                 # a pending `review` but nothing else, so fl-house-10-2026 (a
                 # decided, uncontested race whose roster is correct) was blocked
                 # by bookkeeping rather than by any doubt about its data. The
-                # provisional status is already recorded on roster_research and as
-                # a step failure, and every refresh re-runs discovery anyway.
-                _record_provisional_roster(race_json, log)
+                # provisional status is recorded below on roster_research and as a
+                # step failure, and every refresh re-runs discovery anyway.
                 pipeline_state = race_json.setdefault("pipeline_state", {})
                 pipeline_state["complete"] = False
                 track(
@@ -265,6 +265,12 @@ async def _run_update(
             )
         else:
             log("info", "  Roster verify restored from checkpoint")
+
+        if roster_sync_succeeded is False:
+            # Roster verification can remove stale or ineligible candidates, so
+            # finalize the provisional audit only after that phase has settled
+            # the active roster and its count.
+            _record_provisional_roster(race_json, log)
 
         candidate_names = [_candidate_name(c) for c in race_json.get("candidates", []) if _candidate_name(c)]
         candidate_names = _select_target_candidates(candidate_names, target_candidate_names, log)

--- a/shared/models.py
+++ b/shared/models.py
@@ -460,6 +460,9 @@ class RosterResearchAudit(BaseModel):
     summary: str = ""
     active_candidate_count: int
     completeness_sources: List[CandidateRosterSource] = Field(default_factory=list)
+    completeness_status: Optional[Literal["unproven"]] = None
+    completeness_note: Optional[str] = None
+    completeness_reference_urls: List[str] = Field(default_factory=list)
 
 
 class MetadataResearchAudit(BaseModel):

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -21,6 +21,7 @@ from pipeline_client.agent.phases import (
 )
 from pipeline_client.agent.prompts import CANONICAL_ISSUES
 from pipeline_client.backend.handlers.agent import HandoffTriggered
+from shared.models import RaceJSON
 from shared.pipeline_config import PIPELINE_STEP_IDS
 
 
@@ -525,15 +526,25 @@ async def test_unproven_roster_completeness_keeps_going_and_says_so():
     existing = {
         "id": "al-house-02-2026",
         "election_date": "2026-11-03",
-        "candidates": [{"name": "Wrong Contest", "party": "Unknown", "roster_sources": []}],
+        "candidates": [
+            {"name": "Wrong Contest", "party": "Unknown", "roster_sources": []},
+            {"name": "Supported Candidate", "party": "Unknown", "roster_sources": []},
+        ],
         "updated_utc": "2026-01-01T00:00:00Z",
     }
+
+    async def fail_roster_finalization(*_args, **kwargs):
+        if kwargs.get("phase_name") == "roster-verify":
+            kwargs["extra_tool_handlers"]["remove_candidate"](
+                {"name": "Wrong Contest", "reason": "Officially withdrew from the race."}
+            )
+        return {"_tool_trace": {"required_final_tool_succeeded": False}}
 
     with (
         patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
         patch("pipeline_client.agent.phases._sync_ballotpedia_roster", new_callable=AsyncMock),
     ):
-        mock_loop.return_value = {"_tool_trace": {"required_final_tool_succeeded": False}}
+        mock_loop.side_effect = fail_roster_finalization
         result = await run_agent(
             "al-house-02-2026",
             cheap_mode=True,
@@ -552,8 +563,13 @@ async def test_unproven_roster_completeness_keeps_going_and_says_so():
     assert "discovery" not in (result["pipeline_state"].get("remaining_steps") or [])
     assert result["run_health"]["status"] == "degraded"
     roster_research = result["pipeline_state"]["roster_research"]
+    assert roster_research["finalized_at"]
+    assert roster_research["summary"] == roster_research["completeness_note"]
     assert roster_research["completeness_status"] == "unproven"
     assert "could not confirm the complete candidate field" in roster_research["completeness_note"].lower()
+    assert [candidate["name"] for candidate in result["candidates"]] == ["Supported Candidate"]
+    assert roster_research["active_candidate_count"] == len(result["candidates"])
+    RaceJSON.model_validate(result)
     reasons = result["run_health"]["reasons"]
     assert "roster_completeness_unproven" in reasons
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -257,6 +257,9 @@ export interface RosterResearchAudit {
   summary: string;
   active_candidate_count: number;
   completeness_sources: CandidateRosterSource[];
+  completeness_status?: "unproven";
+  completeness_note?: string;
+  completeness_reference_urls: string[];
 }
 
 export interface MetadataResearchAudit {


### PR DESCRIPTION
## What changed

- finalize provisional roster audits with the required timestamp and summary
- record the audit after roster verification so candidate counts reflect removals
- model provisional completeness metadata in Python and TypeScript
- add regression coverage proving the resulting RaceJSON validates

## Root cause

The unproven-completeness path wrote a partial RosterResearchAudit without the required finalized_at field. It also captured active_candidate_count before roster verification could remove stale candidates.

## Impact

Discovery can now safely preserve an evidence-backed but completeness-unproven roster without creating a schema-validation publication blocker.

## Validation

- 1,292 pipeline tests passed; 9 skipped
- 43 races API tests passed
- svelte-check: 0 errors and 0 warnings
- black and isort checks passed