### PR TITLE
Refine site copy and methodology

### DIFF
--- a/web/e2e/frontend-smoke.e2e.ts
+++ b/web/e2e/frontend-smoke.e2e.ts
@@ -69,7 +69,6 @@ test("forecast and trust surfaces expose their primary content", async ({
   await expect(
     page.getByRole("heading", { name: "2026 Election Forecast" }),
   ).toBeVisible();
-  await expect(page.getByText("Model status: Live")).toBeVisible();
 
   await page.goto("/about/");
   await expect(
@@ -84,7 +83,7 @@ test("forecast and trust surfaces expose their primary content", async ({
     page.getByRole("heading", { name: "Support Smarter.Vote" }),
   ).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Contribution terms" }),
+    page.getByRole("heading", { name: "Support terms" }),
   ).toBeVisible();
 });
 
@@ -116,7 +115,7 @@ test("admin entry point is explicitly excluded from indexing", async ({
   page,
 }) => {
   await page.goto("/admin/");
-  await expect(page).toHaveTitle("Admin Sign In - SmarterVote");
+  await expect(page).toHaveTitle("Admin Sign In | Smarter.Vote");
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
     "content",
     "noindex,nofollow",

--- a/web/e2e/my-ballot.e2e.ts
+++ b/web/e2e/my-ballot.e2e.ts
@@ -67,7 +67,7 @@ test.describe("my-ballot address lookup", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "We identified your district, but no matching published national guide is available yet.",
+        "We identified your district, but no matching Smarter.Vote guide is available yet.",
       ),
     ).toBeVisible();
   });

--- a/web/e2e/race-detail.e2e.ts
+++ b/web/e2e/race-detail.e2e.ts
@@ -31,7 +31,7 @@ test.describe("race detail page", () => {
 
     // Validation grade badge
     await expect(
-      page.getByRole("button", { name: "Validation Grade: A" }),
+      page.getByRole("button", { name: "Automated Research Score: A" }),
     ).toBeVisible();
 
     // Forecast section (rating is "tossup" -> renders as "Toss-up" heading)
@@ -49,7 +49,7 @@ test.describe("race detail page", () => {
 
     // AI review panel starts collapsed; expand it and check both reviews
     const reviewToggle = page.getByRole("button", {
-      name: /AI Review Status/,
+      name: /Automated Review Details/,
     });
     await expect(reviewToggle).toContainText("2 reviews");
     await reviewToggle.click();
@@ -123,8 +123,8 @@ test.describe("race detail page", () => {
     await page.goto("/races/e2e-does-not-exist/");
 
     await expect(
-      page.getByRole("heading", { name: "Error Loading Race" }),
+      page.getByRole("heading", { name: "Error loading race" }),
     ).toBeVisible();
-    await expect(page.getByRole("button", { name: "Try Again" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
   });
 });

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -32,14 +32,14 @@
     </script>
 
     <!-- Global SEO defaults (page-specific tags are set in each page's svelte:head) -->
-    <meta name="author" content="Smarter.vote" />
+    <meta name="author" content="Smarter.Vote" />
 
     <!-- Structured Data -->
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "name": "Smarter.vote",
+        "name": "Smarter.Vote",
         "url": "https://smarter.vote",
         "description": "Candidate research tool for informed voting decisions, using publicly available sources",
         "potentialAction": {

--- a/web/src/lib/components/CandidateCard.svelte
+++ b/web/src/lib/components/CandidateCard.svelte
@@ -144,7 +144,7 @@
           rel="noopener noreferrer"
           class="website-link"
         >
-          Official Website
+          Campaign website
           <svg
             class="w-4 h-4"
             fill="none"
@@ -173,7 +173,7 @@
           : "Expand candidate details"}
       >
         <span class="expand-text">
-          {expanded ? "Show Less" : "Show More"}
+          {expanded ? "Show less" : "Show more"}
         </span>
         <svg
           class="expand-icon"

--- a/web/src/lib/components/CandidateCard.test.ts
+++ b/web/src/lib/components/CandidateCard.test.ts
@@ -70,7 +70,7 @@ describe("CandidateCard", () => {
     const { getByText } = render(CandidateCard, {
       candidate: candidateWithSources,
     });
-    await fireEvent.click(getByText("Show More"));
+    await fireEvent.click(getByText("Show more"));
     await fireEvent.click(getByText("Background"));
 
     expect(getByText("Career Source")).toBeTruthy();

--- a/web/src/lib/components/ConfidenceIndicator.svelte
+++ b/web/src/lib/components/ConfidenceIndicator.svelte
@@ -33,11 +33,21 @@
   };
 
   $: style = themes[confidence] ?? themes.unknown;
+  $: description =
+    (
+      {
+        high: "High evidence confidence: multiple corroborating sources or an official candidate position.",
+        medium: "Medium evidence confidence: at least one credible source.",
+        low: "Low evidence confidence: inferred, unverified, or unsupported by a source.",
+        unknown: "Evidence confidence has not been assessed.",
+      } satisfies Record<ConfidenceLevel, string>
+    )[confidence] ?? "Evidence confidence has not been assessed.";
 </script>
 
 <span
   class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-semibold select-none transition-all duration-300 {style.bg} {style.border} {style.text}"
-  title="Confidence: {confidence}"
+  title={description}
+  aria-label={description}
 >
   <span class="w-1.5 h-1.5 rounded-full {style.dot} transition-all duration-300"
   ></span>

--- a/web/src/lib/components/ElectionDirectory.svelte
+++ b/web/src/lib/components/ElectionDirectory.svelte
@@ -247,8 +247,8 @@
       />
     </svg>
     <span
-      ><strong>Alpha:</strong> AI-generated content can be wrong or outdated. Always
-      follow the source links and apply your own judgment.</span
+      ><strong>Early access:</strong> AI-generated research can be wrong or outdated.
+      Check the linked sources and use your own judgment.</span
     >
   </div>
 

--- a/web/src/lib/components/IssueTable.svelte
+++ b/web/src/lib/components/IssueTable.svelte
@@ -139,7 +139,9 @@
                   </button>
                 {/if}
               {:else}
-                <span class="text-content-faint text-sm">No sources</span>
+                <span class="text-content-faint text-sm"
+                  >No supporting sources</span
+                >
               {/if}
             </td>
           </tr>
@@ -224,7 +226,9 @@
             {/if}
           </div>
         {:else}
-          <p class="text-content-faint text-sm">No sources available</p>
+          <p class="text-content-faint text-sm">
+            No supporting sources available
+          </p>
         {/if}
       </div>
     {/each}

--- a/web/src/lib/components/ReviewPanel.svelte
+++ b/web/src/lib/components/ReviewPanel.svelte
@@ -55,7 +55,7 @@
         d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
       />
     </svg>
-    AI Review Status
+    Automated Review Details
     {#if displayReviews && displayReviews.length > 0}
       <span class="review-count"
         >{displayReviews.length} review{displayReviews.length !== 1
@@ -81,7 +81,9 @@
 
   {#if !collapsed}
     {#if !displayReviews || displayReviews.length === 0}
-      <p class="review-empty">No AI review has been run for this race yet.</p>
+      <p class="review-empty">
+        No automated review has been run for this race yet.
+      </p>
     {:else}
       <div class="review-cards">
         {#each displayReviews as review}
@@ -127,9 +129,7 @@
                 </ul>
               </details>
             {:else}
-              <p class="review-all-clear">
-                No issues found — profile looks good.
-              </p>
+              <p class="review-all-clear">No issues flagged in this review.</p>
             {/if}
             <span class="review-date">
               Reviewed: {(() => {

--- a/web/src/lib/components/ValidationGradeBadge.svelte
+++ b/web/src/lib/components/ValidationGradeBadge.svelte
@@ -34,7 +34,7 @@
     class="grade-badge {gradeColor(grade.grade)}"
     on:click={() => (showPopover = !showPopover)}
     on:keydown={(e) => e.key === "Escape" && (showPopover = false)}
-    aria-label="Validation Grade: {grade.grade}"
+    aria-label="Automated Research Score: {grade.grade}"
   >
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path
@@ -45,7 +45,7 @@
       />
     </svg>
     <span class="grade-letter">{grade.grade}</span>
-    <span class="grade-label">Validation</span>
+    <span class="grade-label">Research score</span>
   </button>
 
   {#if showPopover}
@@ -54,7 +54,7 @@
     <div class="popover-backdrop" on:click={() => (showPopover = false)}></div>
     <div class="popover" role="tooltip">
       <div class="popover-header">
-        <span class="popover-title">AI Validation Grade</span>
+        <span class="popover-title">Automated Research Score</span>
         <span class="popover-grade {gradeColor(grade.grade)}"
           >{grade.grade}</span
         >
@@ -62,12 +62,12 @@
       <p class="popover-score">Score: {grade.score}/100</p>
       <p class="popover-summary">{grade.summary}</p>
       <p class="popover-explain">
-        Multiple AI models independently review each race profile for factual
-        accuracy, source quality, completeness, and neutrality. The grade
-        reflects the average score across all reviewers.
+        Separate AI models review source quality, completeness, consistency, and
+        neutrality. The score summarizes those research checks; it is not a
+        guarantee that every claim is correct.
       </p>
       <button class="popover-link" on:click={scrollToReview}>
-        View Full Review
+        View review details
         <svg
           class="w-3.5 h-3.5"
           fill="none"

--- a/web/src/lib/components/compare/CandidateComparison.svelte
+++ b/web/src/lib/components/compare/CandidateComparison.svelte
@@ -153,7 +153,7 @@
       <div class="min-w-0 text-sm leading-6 text-content-muted">
         <span
           class="mr-1.5 text-[10px] font-bold uppercase tracking-wider text-content-subtle"
-          >Research review</span
+          >Automated Research Score</span
         >
         <strong class="text-content">{race.validation_grade.score}/100</strong
         ><ReviewScoreInfo panelId={`desktop-review-score-info-${race.id}`} />
@@ -177,7 +177,7 @@
           <div
             class="sticky left-0 z-40 flex self-stretch items-center border-r border-stroke bg-surface px-5 text-xs font-bold uppercase tracking-wider text-content-subtle"
           >
-            {compact ? "Compare" : "Compare Directory"}
+            {compact ? "Compare" : "Candidate comparison"}
           </div>
           {#each candidates as candidate}
             <div
@@ -246,7 +246,7 @@
                     target="_blank"
                     rel="noopener noreferrer"
                     class="text-xs font-semibold text-blue-600 hover:underline dark:text-blue-400"
-                    >Visit Campaign Website ↗</a
+                    >Visit campaign website ↗</a
                   >
                 </div>{/if}
             </div>

--- a/web/src/lib/components/compare/CandidateComparison.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.test.ts
@@ -112,12 +112,12 @@ describe("CandidateComparison", () => {
       "[data-desktop-candidate-comparison]",
     )!;
 
-    const label = within(desktop).getByText("Research review");
+    const label = within(desktop).getByText("Automated Research Score");
     expect(label.closest(".overflow-x-auto")).toBeNull();
     expect(within(desktop).getByText("95/100")).toBeTruthy();
   });
 
-  it("explains the limits of the AI review score", async () => {
+  it("explains the automated research score", async () => {
     const reviewedRace: Race = {
       ...race,
       validation_grade: {
@@ -138,13 +138,13 @@ describe("CandidateComparison", () => {
     );
 
     await fireEvent.click(
-      desktop.getByRole("button", { name: "About this AI review score" }),
+      desktop.getByRole("button", {
+        name: "About this automated research score",
+      }),
     );
 
     const note = desktop.getByRole("note").textContent?.replace(/\s+/g, " ");
-    expect(note).toContain("It is not independent fact-checking");
-    expect(note).toContain(
-      "does not validate that the underlying information is correct",
-    );
+    expect(note).toContain("Separate AI models review sourcing");
+    expect(note).toContain("not a guarantee that every claim is correct");
   });
 });

--- a/web/src/lib/components/compare/MobileCandidateComparison.svelte
+++ b/web/src/lib/components/compare/MobileCandidateComparison.svelte
@@ -69,7 +69,7 @@
         >{race.validation_grade.grade}</span
       >
       <div class="text-xs leading-5 text-content-muted">
-        <strong class="text-content">Research review:</strong>
+        <strong class="text-content">Automated Research Score:</strong>
         {race.validation_grade.score}/100<ReviewScoreInfo
           panelId={`mobile-review-score-info-${race.id}`}
         />

--- a/web/src/lib/components/compare/ReviewScoreInfo.svelte
+++ b/web/src/lib/components/compare/ReviewScoreInfo.svelte
@@ -8,10 +8,10 @@
   <button
     type="button"
     class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-amber-400 bg-amber-50 text-[11px] font-extrabold leading-none text-amber-800 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
-    aria-label="About this AI review score"
+    aria-label="About this automated research score"
     aria-expanded={open}
     aria-controls={panelId}
-    title="About this AI review score"
+    title="About this automated research score"
     on:click={() => (open = !open)}
     on:keydown={(event) => event.key === "Escape" && (open = false)}>i</button
   >
@@ -23,9 +23,8 @@
     role="note"
     class="mt-2 block rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs font-normal leading-5 text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
   >
-    <strong>AI-generated research:</strong> This score comes from other AI models
-    reviewing the generating model's methodology, sourcing, completeness, and signs
-    of bias. It is not independent fact-checking and does not validate that the underlying
-    information is correct.
+    <strong>Automated Research Score:</strong> Separate AI models review sourcing,
+    completeness, consistency, and neutrality. The score summarizes those research
+    checks; it is not a guarantee that every claim is correct.
   </span>
 {/if}

--- a/web/src/lib/components/forecast/ForecastKeyRaces.svelte
+++ b/web/src/lib/components/forecast/ForecastKeyRaces.svelte
@@ -24,7 +24,8 @@
         <span
           class="text-xs text-content-subtle font-semibold hidden sm:inline"
         >
-          Key battlegrounds driving chamber control
+          Competitive races with the greatest modeled implications for chamber
+          control
         </span>
         <button
           on:click={() => scrollKeyRaces(-1)}

--- a/web/src/lib/components/forecast/ForecastMissingRaces.svelte
+++ b/web/src/lib/components/forecast/ForecastMissingRaces.svelte
@@ -56,7 +56,7 @@
                 <span
                   class="inline-flex border border-slate-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 text-content-subtle rounded-full px-2 py-0.5 text-xs font-semibold leading-none"
                 >
-                  Pending Model Run
+                  Forecast not available yet
                 </span>
               </td>
               <td class="px-5 py-3">

--- a/web/src/lib/components/forecast/ForecastRaceCard.svelte
+++ b/web/src/lib/components/forecast/ForecastRaceCard.svelte
@@ -291,7 +291,7 @@
           <div class="pt-2 border-t border-stroke/20">
             <span
               class="font-bold text-content uppercase tracking-wider text-[9px] block mb-1"
-              >Source Documentation</span
+              >Forecast sources</span
             >
             <div class="flex flex-wrap gap-1.5">
               {#each race.forecast.source_urls as url}

--- a/web/src/lib/components/home/ElectionLookup.svelte
+++ b/web/src/lib/components/home/ElectionLookup.svelte
@@ -300,7 +300,7 @@
           type="submit"
           disabled={loading || !address.trim()}
           class="mt-4 inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-blue-700 px-6 font-bold text-white shadow-lg shadow-blue-900/10 transition hover:-translate-y-0.5 hover:bg-blue-800 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
-          >{loading ? "Finding your districts…" : "Show my elections"}</button
+          >{loading ? "Finding your district…" : "Show my elections"}</button
         >
       </form>
 
@@ -385,8 +385,8 @@
         <div
           class="mt-5 rounded-xl bg-surface-alt p-4 text-sm text-content-muted"
         >
-          We identified your district, but no matching published national guide
-          is available yet. This does not mean you have no elections.
+          We identified your district, but no matching Smarter.Vote guide is
+          available yet. This does not mean you have no elections.
         </div>
       {/if}
     </section>

--- a/web/src/lib/components/home/TrustPrinciples.svelte
+++ b/web/src/lib/components/home/TrustPrinciples.svelte
@@ -24,7 +24,7 @@
         >
       </div>
       <div class="divide-y divide-blue-800 border-y border-blue-800">
-        {#each [["01", "Every claim links to a source", "Follow the research back to candidate statements, public records, and reputable reporting."], ["02", "Uncertainty stays visible", "Sparse evidence, conflicting accounts, and confidence levels are part of the record—not hidden in fine print."], ["03", "No endorsements. Ever.", "We organize evidence consistently across parties. The judgment about what matters remains yours."]] as principle}
+        {#each [["01", "See the sources behind the research", "Follow the evidence back to candidate statements, public records, and reputable reporting."], ["02", "Uncertainty stays visible", "Sparse evidence, conflicting accounts, and confidence levels are part of the record—not hidden in fine print."], ["03", "No endorsements. Ever.", "We organize evidence consistently across parties. The judgment about what matters remains yours."]] as principle}
           <article
             class="grid grid-cols-[3rem_1fr] gap-4 py-7 sm:grid-cols-[4rem_1fr]"
           >

--- a/web/src/lib/components/support/SupportTiers.svelte
+++ b/web/src/lib/components/support/SupportTiers.svelte
@@ -168,12 +168,9 @@
       </svg>
       Redirecting…
     {:else if effectiveAmountCents !== null}
-      {mode === "subscription" ? "Support" : "Give"} ${(
-        effectiveAmountCents / 100
-      ).toFixed(effectiveAmountCents % 100 === 0 ? 0 : 2)}{mode ===
-      "subscription"
-        ? "/mo"
-        : ""} →
+      Support with ${(effectiveAmountCents / 100).toFixed(
+        effectiveAmountCents % 100 === 0 ? 0 : 2,
+      )}{mode === "subscription" ? " per month" : ""} →
     {:else}
       Enter an amount to continue
     {/if}

--- a/web/src/lib/components/support/SupportTiers.test.ts
+++ b/web/src/lib/components/support/SupportTiers.test.ts
@@ -31,7 +31,7 @@ describe("SupportTiers", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: "$25" }));
     expect(
-      screen.getByRole("button", { name: "Support $25/mo →" }),
+      screen.getByRole("button", { name: "Support with $25 per month →" }),
     ).toBeTruthy();
   });
 
@@ -41,13 +41,17 @@ describe("SupportTiers", () => {
     );
     render(SupportTiers);
 
-    await fireEvent.click(screen.getByRole("button", { name: "Give $10 →" }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Support with $10 →" }),
+    );
     await waitFor(() =>
       expect(screen.getByRole("alert").textContent).toContain(
         "Payments are not yet available",
       ),
     );
     expect(createSupportCheckout).toHaveBeenCalledWith(1000, "payment");
-    expect(screen.getByRole("button", { name: "Give $10 →" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Support with $10 →" }),
+    ).toBeTruthy();
   });
 });

--- a/web/src/lib/sampleData.ts
+++ b/web/src/lib/sampleData.ts
@@ -27,7 +27,7 @@ function createSource(sourceString: string): Source {
     website: {
       type: "website",
       baseUrl: "https://example.com/candidate",
-      title: "Official Website",
+      title: "Campaign website",
     },
     committee: {
       type: "government",

--- a/web/src/lib/utils/raceTitle.test.ts
+++ b/web/src/lib/utils/raceTitle.test.ts
@@ -96,7 +96,7 @@ describe("raceDisplayTitle", () => {
       state: "Georgia",
     };
     expect(racePageTitle(race)).toBe(
-      "2026 Georgia U.S. Senate Election | Smarter.vote",
+      "2026 Georgia U.S. Senate Election | Smarter.Vote",
     );
     expect(raceMetaDescription(race)).toContain(
       "Compare candidates in the 2026 Georgia U.S. Senate Election",

--- a/web/src/lib/utils/raceTitle.ts
+++ b/web/src/lib/utils/raceTitle.ts
@@ -136,8 +136,8 @@ export function raceDisplayTitle(race: TitleRace): string {
 }
 
 export function racePageTitle(race: TitleRace | null | undefined): string {
-  if (!race) return "Loading... | Smarter.vote";
-  return `${raceDisplayTitle(race)} | Smarter.vote`;
+  if (!race) return "Loading... | Smarter.Vote";
+  return `${raceDisplayTitle(race)} | Smarter.Vote`;
 }
 
 export function raceMetaDescription(

--- a/web/src/routes/+error.svelte
+++ b/web/src/routes/+error.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <svelte:head>
-  <title>{title} | Smarter.vote</title>
+  <title>{title} | Smarter.Vote</title>
   <meta name="description" content={message} />
 </svelte:head>
 
@@ -61,13 +61,13 @@
             d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
           />
         </svg>
-        Go Home
+        Go home
       </a>
       <a
         href="/elections/"
         class="inline-flex items-center gap-2 border border-stroke bg-surface-alt text-content px-5 py-2.5 rounded-xl font-semibold text-sm hover:bg-surface transition-colors"
       >
-        Browse Elections &rarr;
+        Browse elections &rarr;
       </a>
     </div>
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <svelte:head>
-  <title>Smarter.Vote | Understand Every Race on Your Ballot</title>
+  <title>Smarter.Vote | Know your candidates</title>
   <meta
     name="description"
     content="Explore sourced, nonpartisan research for national elections. Compare candidates, inspect original sources, and understand the federal races on your ballot."
@@ -16,7 +16,7 @@
   <link rel="canonical" href="https://smarter.vote/" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://smarter.vote/" />
-  <meta property="og:title" content="Smarter.Vote | Understand your ballot" />
+  <meta property="og:title" content="Smarter.Vote | Know your candidates" />
   <meta
     property="og:description"
     content="Sourced, nonpartisan candidate research with uncertainty and original evidence kept visible."

--- a/web/src/routes/about/+page.svelte
+++ b/web/src/routes/about/+page.svelte
@@ -48,9 +48,9 @@
   <PolicySection title="What is available today">
     <p>
       Smarter.Vote is an early-stage service operated by Smarter.Vote LLC.
-      Current research focuses on national and federal elections. It is not a
-      complete ballot guide and does not yet provide dependable state, local,
-      judicial, or ballot-measure coverage.
+      Current research focuses on national races. It is not a complete ballot
+      guide and does not yet provide dependable coverage of state legislatures,
+      local offices, judicial races, or ballot measures.
     </p>
     <p>
       Automated tools assist with research and review, but they can miss context
@@ -71,37 +71,93 @@
       </p>
     </div>
 
-    <PolicySection title="Research">
+    <PolicySection title="How the research is made">
       <p>
-        We gather public material such as candidate statements, campaign
-        websites, official records, and reputable reporting. Automated tools
-        help discover and organize evidence; they do not make endorsements.
+        Automated research agents search public sources—including candidate
+        statements, campaign websites, official records, voting databases, and
+        reputable reporting—and organize the evidence into candidate summaries,
+        issue positions, background, and race analysis. They are instructed to
+        describe what candidates say and do without endorsing them.
+      </p>
+      <p>
+        Source links remain attached to the research so readers can inspect the
+        evidence directly. A source is not treated as neutral merely because it
+        is linked: campaign material represents the candidate's own account,
+        while records and reporting provide additional context.
       </p>
     </PolicySection>
 
-    <PolicySection title="Review and publication">
+    <PolicySection title="Evidence and confidence">
       <p>
-        We compare claims with their sources, flag conflicts, run consistency
-        and quality checks, and publish citations and update dates. Confidence
-        labels describe the available evidence, not the value of a candidate or
-        policy.
+        Confidence labels describe the strength of the available evidence—not
+        the value of a candidate or policy. High confidence requires multiple
+        corroborating sources or an official candidate position. Medium
+        confidence requires at least one credible source. Low confidence marks
+        information that is inferred, unverified, or unsupported by a source.
+      </p>
+      <p>
+        “No public position found” means the research process looked for an
+        attributable position and did not find one. It does not mean the
+        candidate has no view, and it is different from an issue that has not
+        yet been researched.
       </p>
     </PolicySection>
 
-    <PolicySection title="Limits">
+    <PolicySection title="Automated review and publication">
+      <p>
+        Separate AI models review the full race side by side for the correct
+        candidate roster, internal consistency, source quality, completeness,
+        background accuracy, and neutral treatment across candidates. Automated
+        checks also look for broken sources, malformed polling, placeholders,
+        and missing required research.
+      </p>
+      <p>
+        The Automated Research Score combines the review models' scores and
+        accounts for unresolved warnings. A failing score or an unresolved error
+        blocks publication. This is automated editorial quality control, not a
+        promise that every statement has been independently fact-checked by a
+        human.
+      </p>
+    </PolicySection>
+
+    <div id="forecast-methodology" class="scroll-mt-24">
+      <PolicySection title="How forecasts work">
+        <p>
+          Race forecasts start with the published race record. They prefer
+          candidate-level polling when it is available and otherwise weigh
+          incumbency, party context, candidate strength, the documented race
+          environment, and other evidence already gathered for the contest.
+          Prediction-market signals may provide additional context, but they are
+          never treated as ground truth.
+        </p>
+        <p>
+          Each race forecast includes a rating, modeled win probability, key
+          drivers, uncertainty, and supporting sources where the analysis relies
+          on a specific external claim. Chamber forecasts combine those race
+          probabilities with known holdover seats to calculate projected seats,
+          seat-outcome distributions, and the chance of party control. For the
+          2026 Senate forecast, a 50–50 result is counted as Republican control
+          under the vice president tie-break assumption.
+        </p>
+      </PolicySection>
+    </div>
+
+    <PolicySection title="Limits and updates">
       <p>
         Sources can be incomplete, positions can change, and automated analysis
-        can misunderstand nuance. Current coverage focuses on national and
-        federal races and is not a complete ballot. Forecasts are estimates—not
-        election results, voting advice, or guarantees.
+        can misunderstand nuance. Polls capture a period in time, and forecasts
+        change as new evidence arrives. Forecasts are estimates—not election
+        results, voting advice, or guarantees.
       </p>
     </PolicySection>
 
-    <PolicySection title="Verify and correct">
+    <PolicySection title="Verification and corrections">
       <p>
-        Use the linked evidence and official election resources to verify
-        important information. Funding never determines findings,
-        classifications, forecasts, or publication decisions.
+        Use the linked evidence to check research claims, and rely on state and
+        local election officials for registration, deadlines, voting methods,
+        and official results. Report errors through our corrections process.
+        Funding never determines findings, classifications, forecasts, or
+        publication decisions.
       </p>
     </PolicySection>
   </div>

--- a/web/src/routes/admin/+page.svelte
+++ b/web/src/routes/admin/+page.svelte
@@ -62,7 +62,7 @@
 </script>
 
 <svelte:head>
-  <title>Admin Sign In - SmarterVote</title>
+  <title>Admin Sign In | Smarter.Vote</title>
   <meta name="robots" content="noindex,nofollow" />
 </svelte:head>
 

--- a/web/src/routes/admin/pipeline/+page.svelte
+++ b/web/src/routes/admin/pipeline/+page.svelte
@@ -219,7 +219,7 @@
 </script>
 
 <svelte:head>
-  <title>Admin Console - SmarterVote</title>
+  <title>Admin Console | Smarter.Vote</title>
   <meta name="robots" content="noindex,nofollow" />
 </svelte:head>
 

--- a/web/src/routes/corrections/+page.svelte
+++ b/web/src/routes/corrections/+page.svelte
@@ -31,8 +31,8 @@
     <p>
       Smarter.Vote LLC reviews the cited evidence and retains editorial control
       over the outcome. We may correct, clarify, add context, update sources, or
-      determine that no change is warranted. Material updates should be
-      reflected on the relevant page.
+      determine that no change is warranted. When we make a material correction,
+      we update the relevant page and its revision date.
     </p>
     <p>
       We are a small early-stage organization and do not yet promise a response

--- a/web/src/routes/forecast/+page.svelte
+++ b/web/src/routes/forecast/+page.svelte
@@ -159,29 +159,29 @@
 </script>
 
 <svelte:head>
-  <title>2026 Election Forecasts — Smarter.vote</title>
+  <title>2026 Election Forecasts — Smarter.Vote</title>
   <meta
     name="description"
-    content="AI-powered forecasts and interactive maps for 2026 House, Senate, and Governor races. See win probabilities, polling data, and prediction market signals."
+    content="Explore 2026 House, Senate, and governor forecasts with win probabilities, chamber-control projections, polling, and prediction-market signals."
   />
   <link rel="canonical" href="https://smarter.vote/forecast/" />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://smarter.vote/forecast/" />
-  <meta property="og:title" content="2026 Election Forecasts — Smarter.vote" />
+  <meta property="og:title" content="2026 Election Forecasts — Smarter.Vote" />
   <meta
     property="og:description"
-    content="AI-powered forecasts and interactive maps for 2026 House, Senate, and Governor races. See win probabilities, polling data, and prediction market signals."
+    content="Explore 2026 House, Senate, and governor forecasts with win probabilities, chamber-control projections, polling, and prediction-market signals."
   />
   <meta property="og:image" content="https://smarter.vote/og-image.png" />
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="https://smarter.vote/forecast/" />
   <meta
     property="twitter:title"
-    content="2026 Election Forecasts — Smarter.vote"
+    content="2026 Election Forecasts — Smarter.Vote"
   />
   <meta
     property="twitter:description"
-    content="AI-powered forecasts and interactive maps for 2026 House, Senate, and Governor races. See win probabilities, polling data, and prediction market signals."
+    content="Explore 2026 House, Senate, and governor forecasts with win probabilities, chamber-control projections, polling, and prediction-market signals."
   />
   <meta property="twitter:image" content="https://smarter.vote/og-image.png" />
 </svelte:head>
@@ -198,21 +198,36 @@
           2026 Election Forecast
         </h1>
         <p class="mt-2 text-base text-content-muted max-w-3xl">
-          Nonpartisan model projections, interactive maps, and structured
-          analysis for the 2026 House, Senate, and Governor races.
+          See who’s favored, what could decide control, and where the model sees
+          the most uncertainty across the 2026 House, Senate, and governor
+          races.
         </p>
-      </div>
-      <div
-        class="text-xs text-content-subtle border border-stroke/80 bg-surface-alt/40 backdrop-blur-md px-3 py-2 rounded-xl flex items-center gap-1.5 self-start md:self-auto"
-      >
-        <span class="relative flex h-2 w-2">
+        <div
+          class="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-semibold text-content-subtle"
+        >
           <span
-            class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"
-          ></span>
-          <span class="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"
-          ></span>
-        </span>
-        Model status: Live
+            >{aggregate.races.length}
+            {activeTab === "house"
+              ? "House"
+              : activeTab === "senate"
+                ? "Senate"
+                : "governor"} race{aggregate.races.length === 1 ? "" : "s"} modeled</span
+          >
+          {#if chamberForecasts?.updated_at}
+            <span aria-hidden="true">·</span>
+            <span
+              >Updated {new Date(
+                chamberForecasts.updated_at,
+              ).toLocaleDateString()}</span
+            >
+          {/if}
+          <span aria-hidden="true">·</span>
+          <a
+            href="/about/#forecast-methodology"
+            class="text-blue-600 hover:underline dark:text-blue-400"
+            >How the forecast works →</a
+          >
+        </div>
       </div>
     </div>
   </header>

--- a/web/src/routes/funding-and-editorial-independence/+page.svelte
+++ b/web/src/routes/funding-and-editorial-independence/+page.svelte
@@ -33,15 +33,15 @@
     <p>
       Funding may help prioritize a geography or coverage category only through
       published quality standards; it cannot change what the research says.
-      Individual recognition will be private by default and opt-in.
-      Institutional relationships should be disclosed at the program level with
-      the sponsor, purpose, and an amount band once those bands receive
+      Individual recognition will be private by default and opt-in. We disclose
+      institutional relationships at the program level, including the sponsor
+      and purpose. We will publish amount bands after those bands receive
       appropriate professional review.
     </p>
     <p>
-      Until disclosure bands and exceptions are approved, Smarter.Vote LLC
-      should use specific written agreements and avoid promising anonymity or
-      public recognition.
+      Until disclosure bands and exceptions are approved, Smarter.Vote LLC uses
+      specific written agreements and does not promise anonymity or public
+      recognition.
     </p>
   </PolicySection>
   <PolicySection title="Support is not a charitable donation">

--- a/web/src/routes/races/[slug]/+page.svelte
+++ b/web/src/routes/races/[slug]/+page.svelte
@@ -269,10 +269,10 @@
     </div>
   {:else if error}
     <div class="error-box">
-      <h2 class="error-title">Error Loading Race</h2>
+      <h2 class="error-title">Error loading race</h2>
       <p class="text-red-600">{error}</p>
       <button class="error-button" on:click={() => window.location.reload()}>
-        Try Again
+        Try again
       </button>
     </div>
   {:else if race}
@@ -839,7 +839,7 @@
         {/if}
 
         <div class="forecast-meta">
-          <span>Confidence: {forecast.confidence}</span>
+          <span>Forecast confidence: {forecast.confidence}</span>
           {#if forecast.model}
             <span>Model: {formatModelName(forecast.model)}</span>
           {/if}
@@ -942,9 +942,7 @@
     <!-- Data Note -->
     <div class="data-note">
       <p class="data-note-title">
-        {usingFallbackData
-          ? "Sample Data Information"
-          : "Data Analysis Information"}
+        {usingFallbackData ? "Sample Data Information" : "About this research"}
       </p>
       <p class="data-note-text">
         {#if usingFallbackData}
@@ -959,7 +957,7 @@
       </p>
     </div>
 
-    <!-- AI Review Status (bottom) -->
+    <!-- Automated review details (bottom) -->
     <ReviewPanel reviews={race.reviews ?? []} />
 
     <!-- Models used to generate this race -->
@@ -1004,7 +1002,7 @@
             d="M5 10l7-7m0 0l7 7m-7-7v18"
           />
         </svg>
-        Back to Top
+        Back to top
       </button>
     </div>
 

--- a/web/src/routes/races/[slug]/[candidate]/+page.svelte
+++ b/web/src/routes/races/[slug]/[candidate]/+page.svelte
@@ -108,7 +108,7 @@
   <title
     >{candidate?.name ?? "Candidate"} — {race
       ? raceDisplayTitle(race)
-      : "Loading..."} | Smarter.vote</title
+      : "Loading..."} | Smarter.Vote</title
   >
   <meta
     name="description"
@@ -129,7 +129,7 @@
     property="og:title"
     content="{candidate?.name ?? 'Candidate'} — {race
       ? raceDisplayTitle(race)
-      : 'Election'} | Smarter.vote"
+      : 'Election'} | Smarter.Vote"
   />
   <meta
     property="og:description"
@@ -150,7 +150,7 @@
     property="twitter:title"
     content="{candidate?.name ?? 'Candidate'} — {race
       ? raceDisplayTitle(race)
-      : 'Election'} | Smarter.vote"
+      : 'Election'} | Smarter.Vote"
   />
   <meta
     property="twitter:description"
@@ -505,7 +505,7 @@
                 d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9"
               />
             </svg>
-            Campaign Website
+            Campaign website
           </a>
         {/if}
         {#each socialLinks as [platform, url]}
@@ -667,7 +667,7 @@
 
     <!-- Data Note -->
     <div class="data-note">
-      <p class="data-note-title">Data Analysis Information</p>
+      <p class="data-note-title">About this research</p>
       <p class="data-note-text">
         Data compiled from public sources and analyzed using AI. Last updated
         {new Date(race.updated_utc).toLocaleDateString()}. Visit candidate

--- a/web/src/routes/races/[slug]/compare/+page.svelte
+++ b/web/src/routes/races/[slug]/compare/+page.svelte
@@ -94,7 +94,7 @@
   <title
     >Compare Candidates | {race
       ? raceDisplayTitle(race)
-      : "Smarter.vote"}</title
+      : "Smarter.Vote"}</title
   >
   <meta
     name="description"
@@ -112,7 +112,7 @@
     property="og:title"
     content="Compare Candidates | {race
       ? raceDisplayTitle(race)
-      : 'Smarter.vote'}"
+      : 'Smarter.Vote'}"
   />
   <meta
     property="og:description"
@@ -130,7 +130,7 @@
     property="twitter:title"
     content="Compare Candidates | {race
       ? raceDisplayTitle(race)
-      : 'Smarter.vote'}"
+      : 'Smarter.Vote'}"
   />
   <meta
     property="twitter:description"

--- a/web/src/routes/support/+page.svelte
+++ b/web/src/routes/support/+page.svelte
@@ -32,14 +32,14 @@
       imply complete state or local ballot coverage.
     </p>
   </PolicySection>
-  <PolicySection title="Contribution terms">
+  <PolicySection title="Support terms">
     <p>
       Support is accepted by Smarter.Vote LLC. It is not tax-deductible. Any
       geographic or program preference is a nonbinding request, not a legally
       restricted fund, unless a written agreement explicitly says otherwise.
     </p>
     <p>
-      No contribution buys favorable coverage, editorial review, access to
+      No support payment buys favorable coverage, editorial review, access to
       unpublished findings, or control of research.
     </p>
   </PolicySection>

--- a/web/src/routes/support/success/+page.svelte
+++ b/web/src/routes/support/success/+page.svelte
@@ -76,7 +76,7 @@
     {/if}
   </div>
   <p class="text-content-muted">
-    If you have any questions about your contribution, <a
+    If you have any questions about your support payment, <a
       href="/support/"
       class="text-primary-600 underline hover:text-primary-700 dark:text-primary-400"
       >contact us</a


### PR DESCRIPTION
## Summary
- standardize public-facing branding as `Smarter.Vote` and sharpen homepage trust copy
- rename and clearly explain the Automated Research Score across race and comparison views
- expand the existing About methodology with accurate research, review, publication, confidence, and forecast details
- improve forecast, ballot lookup, source, support, correction, and interface wording without weakening product language
- update unit and browser assertions for the revised copy

## Why
The site copy mixed brand forms, used unclear quality-score terminology, and did not fully explain how research and forecasts are produced. This pass makes the product more consistent and authoritative while preserving visible uncertainty and source transparency.

## Validation
- `npm run check`
- `npm run lint`
- `npm run test:unit -- --run` (250 passed)
- `npm run build`
- `npx playwright test e2e/frontend-smoke.e2e.ts e2e/race-detail.e2e.ts e2e/my-ballot.e2e.ts e2e/forecast.e2e.ts` (34 passed)