### PR TITLE
Make roster recovery, artifacts, and test coverage durable

### DIFF
--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -26,6 +26,10 @@ services:
       - .env
     environment:
       PIPELINE_MODE: gcp
+      # Agent drafts already use GCS directly. The generic run-artifact backend
+      # must also be explicit or Settings defaults it to ephemeral container
+      # storage even though this worker has a cloud bucket configured.
+      STORAGE_MODE: gcp
       GOOGLE_APPLICATION_CREDENTIALS: /gcloud-config/application_default_credentials.json
       # Four concurrent races uses the workstation's available CPU while the
       # 16 GB Docker allocation remains the practical memory ceiling.

--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -229,8 +229,13 @@ atomically applies the submitted complete roster (preserving matching candidate
 profiles), so a final synthesis turn can add or remove the whole field without
 one tool turn per name. It persists the audit under
 `pipeline_state.roster_research`. If the gate does not
-pass, the run stops before images, polling, and forecast work and keeps `discovery`
-visibly incomplete for a retry.
+pass, update mode persists `roster_finalization_pending` across any continuation.
+The roster verifier may first remove candidates with qualifying exit evidence
+and then gets one recovery attempt through the same strict `finalize_roster`
+contract. A successful recovery clears the pending marker. If recovery still
+cannot prove the whole field, the run records an explicit provisional-roster
+health reason and continues any requested downstream maintenance; it never
+turns candidate-by-candidate evidence into completeness by weakening the gate.
 
 Update discovery applies race metadata with the same end-of-phase discipline.
 Its last turn is reserved for a stronger synthesis model and forced to call
@@ -379,6 +384,14 @@ Example fresh cloud run:
 Use `debug_mode` for a small diagnostic run when investigating cost, retries,
 handoffs, or context behavior. Debug mode increases observability, not quality,
 and does not reduce cost.
+
+When `save_artifact` is enabled, both direct and queued worker runs persist a
+sanitized run artifact and attach its ID to the terminal run and queue records.
+The artifact omits the duplicated in-memory agent log list; use the bounded
+diagnostics export for the chronological log timeline. The supported local
+worker compose file sets `STORAGE_MODE=gcp`, so these artifacts survive a
+container rebuild in the configured GCS bucket rather than its ephemeral
+filesystem.
 
 ## Monitoring
 

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -24,6 +24,7 @@ from ..tools import (
     CANDIDATE_TOOLS,
     DESCRIPTION_TOOLS,
     FINALIZE_METADATA_TOOL,
+    FINALIZE_ROSTER_TOOL,
     READ_PROFILE_TOOL,
     RECORD_TOOLS,
     REMOVE_CANDIDATE_TOOL,
@@ -42,6 +43,25 @@ from .context import PhaseContext
 from .discovery import _backfill_source_timestamps, _record_provisional_roster, _sanitize_roster
 from .fresh_run import _run_fresh
 from .shared_runner import _run_shared_phases
+
+
+def _clear_recovered_roster_verification_failure(race_json: Dict[str, Any]) -> None:
+    """Remove an initial roster-sync error after strict recovery succeeds."""
+    pipeline_state = race_json.get("pipeline_state")
+    if not isinstance(pipeline_state, dict):
+        return
+    failures = pipeline_state.get("step_failures")
+    if not isinstance(failures, list):
+        return
+    pipeline_state["step_failures"] = [
+        failure
+        for failure in failures
+        if not (
+            isinstance(failure, dict)
+            and failure.get("step") == "discovery"
+            and failure.get("reason") == RunFailureReason.ROSTER_VERIFICATION_FAILED.value
+        )
+    ]
 
 
 async def _run_update(
@@ -84,7 +104,8 @@ async def _run_update(
     _sanitize_roster(race_json, log)
 
     existing_candidates = race_json.get("candidates", [])
-    candidate_names = [_candidate_name(c) for c in existing_candidates if _candidate_name(c)]
+    all_candidate_names = [_candidate_name(c) for c in existing_candidates if _candidate_name(c)]
+    candidate_names = list(all_candidate_names)
     candidate_names = _select_target_candidates(candidate_names, target_candidate_names, log)
     selected_name_set = set(candidate_names)
     n = len(candidate_names)
@@ -122,9 +143,24 @@ async def _run_update(
         if not resume_partial:
             completed_units.difference_update({"discovery.roster_sync", "discovery.roster_verify", "discovery.metadata"})
             race_json["pipeline_state"]["completed_units"] = sorted(completed_units)
+            race_json["pipeline_state"].pop("roster_finalization_pending", None)
+            race_json["pipeline_state"].pop("roster_sync_original_names", None)
 
-        pre_sync_names = list(candidate_names)
-        roster_sync_succeeded: bool | None = None
+        stored_original_names = race_json["pipeline_state"].get("roster_sync_original_names")
+        pre_sync_names = (
+            [str(name) for name in stored_original_names if str(name).strip()]
+            if isinstance(stored_original_names, list)
+            else list(all_candidate_names)
+        )
+        if "discovery.roster_verify" not in completed_units:
+            race_json["pipeline_state"]["roster_sync_original_names"] = list(pre_sync_names)
+        else:
+            race_json["pipeline_state"].pop("roster_sync_original_names", None)
+        # This survives a continuation between roster-sync and roster-verify.
+        # The recovery decision is pipeline state, never wording in a queue goal.
+        roster_sync_succeeded: bool | None = (
+            False if race_json["pipeline_state"].get("roster_finalization_pending") is True else None
+        )
         if "discovery.roster_sync" not in completed_units:
             log("info", "Update Phase 0: Verifying candidate roster...")
             roster_sync_succeeded = False
@@ -175,6 +211,10 @@ async def _run_update(
                 _record_step_failure(race_json, "discovery", RunFailureReason.ROSTER_VERIFICATION_FAILED, str(exc))
 
             _sanitize_roster(race_json, log)
+            if roster_sync_succeeded:
+                race_json["pipeline_state"].pop("roster_finalization_pending", None)
+            else:
+                race_json["pipeline_state"]["roster_finalization_pending"] = True
             await _await_with_run_budget(
                 _sync_ballotpedia_roster(race_json, race_id, log),
                 run_budget=run_budget,
@@ -199,8 +239,6 @@ async def _run_update(
                 # by bookkeeping rather than by any doubt about its data. The
                 # provisional status is recorded below on roster_research and as a
                 # step failure, and every refresh re-runs discovery anyway.
-                pipeline_state = race_json.setdefault("pipeline_state", {})
-                pipeline_state["complete"] = False
                 track(
                     "progress",
                     "discovery",
@@ -226,7 +264,19 @@ async def _run_update(
         if "discovery.roster_verify" not in completed_units:
             log("info", f"  Roster verify: checking {len(post_sync_names)} candidate(s)")
             try:
-                await _agent_loop(
+                recover_completeness = roster_sync_succeeded is False
+                pre_sync_keys = {name.casefold() for name in pre_sync_names}
+                added_names = [name for name in post_sync_names if name.casefold() not in pre_sync_keys]
+                finalization_instruction = (
+                    "The earlier roster-sync phase did not prove completeness. After removing any verified "
+                    "inactive candidates, fetch an authoritative exact-contest source or the exact Ballotpedia "
+                    "race page that names the entire current field. Then you MUST call finalize_roster with the "
+                    "remaining complete candidates array, matching source_candidate_names, and the retrieved "
+                    "completeness source. Do not finalize from search snippets or candidate-by-candidate sources."
+                    if recover_completeness
+                    else "Roster completeness was already finalized. Do not call finalize_roster again."
+                )
+                verify_result = await _agent_loop(
                     ROSTER_VERIFY_SYSTEM.format(**cycle_kwargs(race_id)),
                     ROSTER_VERIFY_USER.format(
                         **cycle_kwargs(race_id),
@@ -234,20 +284,30 @@ async def _run_update(
                         current_date=as_of_date,
                         candidate_names=", ".join(post_sync_names),
                         original_names=", ".join(pre_sync_names),
-                        added_names=", ".join(post_sync_names),
+                        added_names=", ".join(added_names) or "(none)",
+                        finalization_instruction=finalization_instruction,
                     ),
                     model=roster_model or model,
                     on_log=on_log,
                     race_id=race_id,
                     contest_label=format_contest_label(race_json, race_id),
-                    max_iterations=8,
+                    max_iterations=(min(max_iterations, max(10, 6 + len(post_sync_names))) if recover_completeness else 8),
                     phase_name="roster-verify",
                     max_tokens=4096,
-                    extra_tools=[REMOVE_CANDIDATE_TOOL, READ_PROFILE_TOOL],
+                    extra_tools=[REMOVE_CANDIDATE_TOOL, READ_PROFILE_TOOL]
+                    + ([FINALIZE_ROSTER_TOOL] if recover_completeness else []),
                     extra_tool_handlers=handlers,
                     tools_mode=True,
                     run_budget=run_budget,
+                    required_final_tool_name="finalize_roster" if recover_completeness else None,
+                    required_final_instruction=finalization_instruction if recover_completeness else None,
+                    return_tool_trace=recover_completeness,
                 )
+                if recover_completeness:
+                    roster_sync_succeeded = bool((verify_result.get("_tool_trace") or {}).get("required_final_tool_succeeded"))
+                    if roster_sync_succeeded:
+                        race_json["pipeline_state"].pop("roster_finalization_pending", None)
+                        _clear_recovered_roster_verification_failure(race_json)
                 _sanitize_roster(race_json, log)
             except RunBudgetExceeded:
                 raise
@@ -256,6 +316,7 @@ async def _run_update(
                 _record_step_failure(race_json, "discovery", RunFailureReason.ROSTER_VERIFICATION_FAILED, str(exc))
             _mark_pipeline_unit_complete(race_json, "discovery.roster_verify")
             completed_units.add("discovery.roster_verify")
+            race_json["pipeline_state"].pop("roster_sync_original_names", None)
             track(
                 "progress",
                 "discovery",
@@ -270,6 +331,8 @@ async def _run_update(
             # Roster verification can remove stale or ineligible candidates, so
             # finalize the provisional audit only after that phase has settled
             # the active roster and its count.
+            race_json.setdefault("pipeline_state", {})["complete"] = False
+            race_json["pipeline_state"].pop("roster_finalization_pending", None)
             _record_provisional_roster(race_json, log)
 
         candidate_names = [_candidate_name(c) for c in race_json.get("candidates", []) if _candidate_name(c)]

--- a/pipeline_client/agent/prompts.py
+++ b/pipeline_client/agent/prompts.py
@@ -1246,8 +1246,10 @@ You are a nonpartisan political fact-checker. Your ONLY task is to audit the
 candidate roster produced by a prior research step and remove any entries that
 are clearly fabricated, nonsensical, or not real candidates in this race.
 
-You may ONLY call remove_candidate (to veto a bad entry) or read_profile (to
-inspect the current roster). Do NOT call add_candidate or any other tool.
+You may ONLY call remove_candidate (to veto a bad entry), read_profile (to
+inspect the current roster), or finalize_roster when the run instructions
+explicitly require a completeness recovery. Do NOT call add_candidate or any
+other tool.
 
 A candidate should be removed ONLY if:
 - The name is obviously fake, a test value, or a placeholder (e.g. "dummy",
@@ -1312,6 +1314,8 @@ evidence is verified:
 7. Never infer the result of an election scheduled after {current_date}.
 8. Do NOT remove a PRE-EXISTING candidate because Ballotpedia has no candidates
    listed, a generated Ballotpedia URL fails, or a single source is missing them.
+
+{finalization_instruction}
 
 When done, stop — do not produce any text reply."""
 

--- a/pipeline_client/backend/queue_processor.py
+++ b/pipeline_client/backend/queue_processor.py
@@ -115,6 +115,52 @@ def _draft_catalog_update(race_id: str, draft_data: Dict[str, Any]) -> Dict[str,
     return fields
 
 
+def _save_completed_artifact(
+    *,
+    run_id: str,
+    race_id: str,
+    options: Dict[str, Any],
+    output: Optional[Dict[str, Any]],
+    duration_ms: int,
+    run_started_utc: str,
+    save_requested: bool,
+) -> Optional[str]:
+    """Persist the same audit artifact for queued runs as the direct runner.
+
+    Queue workers invoke ``AgentHandler`` directly, so they otherwise bypass
+    ``pipeline_runner``'s ``save_artifact`` handling even when callers request
+    it. Keep artifact failure non-fatal: the canonical draft has already been
+    saved by the handler and remains the source of truth.
+    """
+    if not save_requested:
+        return None
+    try:
+        from pipeline_client.backend.storage import new_artifact_id, save_artifact
+
+        artifact_id = new_artifact_id("agent")
+        artifact_output = json.loads(json.dumps(output, default=str))
+        if isinstance(artifact_output, dict) and isinstance(artifact_output.get("agent_logs"), list):
+            artifact_output["agent_log_count"] = len(artifact_output["agent_logs"])
+            artifact_output.pop("agent_logs", None)
+        save_artifact(
+            artifact_id,
+            {
+                "step": "agent",
+                "input": {"race_id": race_id},
+                "options": {key: value for key, value in options.items() if key != "deadline_at"},
+                "output": artifact_output,
+                "run_started_utc": run_started_utc,
+                "duration_ms": duration_ms,
+                "run_id": run_id,
+            },
+        )
+        logger.info("Saved queue-run artifact %s for run %s", artifact_id, run_id)
+        return artifact_id
+    except Exception:
+        logger.warning("Queue-run artifact save failed; run will still complete", exc_info=True)
+        return None
+
+
 def claim_item(db: Any, item_ref: Any, lease_owner: str, expected_runner: str) -> Optional[Dict[str, Any]]:
     """Atomically claim an item for the expected runner (pending → running).
 
@@ -286,6 +332,8 @@ async def process_claimed_item(
     options["queue_item_id"] = item_id
     import time as _time
 
+    save_artifact_requested = bool(options.get("save_artifact", True))
+    run_started_utc = _now().isoformat()
     started_at = _time.perf_counter()
     lease_stop, lease_thread = _start_lease_heartbeat(db, item_ref, lease_owner)
     success = False
@@ -466,9 +514,21 @@ async def process_claimed_item(
         # run_health.status is "failed"/"degraded" (e.g. review didn't pass,
         # or a step like finance silently produced no data for anyone).
         run_health = last_result.get("run_health") if isinstance(last_result, dict) else None
+        duration_ms = int((_time.perf_counter() - started_at) * 1000)
+        artifact_id = _save_completed_artifact(
+            run_id=run_id,
+            race_id=race_id,
+            options=options,
+            output=last_result,
+            duration_ms=duration_ms,
+            run_started_utc=run_started_utc,
+            save_requested=save_artifact_requested,
+        )
         item_ref.update(
             {
                 "status": "completed",
+                "artifact_id": artifact_id,
+                "duration_ms": duration_ms,
                 "completed_at": _now().isoformat(),
                 "lease_owner": None,
                 "lease_expires_at": None,
@@ -478,6 +538,8 @@ async def process_claimed_item(
         run_update: Dict[str, Any] = {
             "status": "completed",
             "progress": 100,
+            "artifact_id": artifact_id,
+            "duration_ms": duration_ms,
             "completed_at": SERVER_TIMESTAMP,
             "activity_at": SERVER_TIMESTAMP,
         }

--- a/tests/test_queue_worker.py
+++ b/tests/test_queue_worker.py
@@ -83,7 +83,11 @@ async def test_process_follows_handoff_in_process_instead_of_failing():
     from pipeline_client.backend import queue_processor as qp
     from pipeline_client.backend.handlers.agent import HandoffTriggered
 
-    item = {"race_id": "ca-house-01-2026", "run_id": "run-3", "options": {"cheap_mode": True}}
+    item = {
+        "race_id": "ca-house-01-2026",
+        "run_id": "run-3",
+        "options": {"cheap_mode": True, "save_artifact": False},
+    }
     db, item_ref, run_ref, race_ref = _fs_mock(item)
 
     cont_doc = MagicMock()
@@ -118,12 +122,16 @@ async def test_process_follows_handoff_in_process_instead_of_failing():
         if len(calls) == 1:
             raise HandoffTriggered("cont-1", ["issues"], run_id)
 
-    with patch.object(qp, "_run_agent", side_effect=fake_run):
+    with (
+        patch.object(qp, "_run_agent", side_effect=fake_run),
+        patch("pipeline_client.backend.storage.save_artifact") as save_artifact,
+    ):
         await qp.process_claimed_item(db, MagicMock(), "bucket", "item-1", item, "owner-1")
 
     assert len(calls) == 2, "must retry in-process after the handoff instead of giving up"
     assert calls[1]["enabled_steps"] == ["issues"], "must resume with the continuation's own options"
     cont_ref.delete.assert_called_once()
+    save_artifact.assert_not_called(), "a continuation must not override the caller's artifact preference"
 
     item_updates = [c.args[0] for c in item_ref.update.call_args_list]
     assert any(u.get("status") == "completed" for u in item_updates)
@@ -187,6 +195,82 @@ async def test_process_persists_run_health_from_successful_agent_result():
     completed_run_updates = [u for u in run_updates if u.get("status") == "completed"]
     assert completed_run_updates
     assert completed_run_updates[-1]["run_health"] == run_health_payload
+
+
+@pytest.mark.asyncio
+async def test_process_saves_requested_artifact_and_persists_id():
+    from pipeline_client.backend import queue_processor as qp
+
+    item = {
+        "race_id": "ca-house-01-2026",
+        "run_id": "run-artifact",
+        "options": {"cheap_mode": True, "save_artifact": True},
+    }
+    db, item_ref, run_ref, _race_ref = _fs_mock(item)
+    result = {"race_id": item["race_id"], "status": "draft", "agent_logs": [{"message": "large"}]}
+
+    with (
+        patch.object(qp, "_run_agent", AsyncMock(return_value=result)),
+        patch("pipeline_client.backend.storage.new_artifact_id", return_value="artifact-queue"),
+        patch("pipeline_client.backend.storage.save_artifact") as save_artifact,
+    ):
+        await qp.process_claimed_item(db, MagicMock(), "bucket", "item-artifact", item, "owner-artifact")
+
+    artifact_payload = save_artifact.call_args.args[1]
+    assert artifact_payload["run_id"] == "run-artifact"
+    assert artifact_payload["run_started_utc"]
+    assert artifact_payload["output"]["agent_log_count"] == 1
+    assert "agent_logs" not in artifact_payload["output"]
+    assert "deadline_at" not in artifact_payload["options"]
+    assert any(update.get("artifact_id") == "artifact-queue" for update in (c.args[0] for c in item_ref.update.call_args_list))
+    assert any(update.get("artifact_id") == "artifact-queue" for update in (c.args[0] for c in run_ref.update.call_args_list))
+
+
+@pytest.mark.asyncio
+async def test_process_can_disable_artifact_save():
+    from pipeline_client.backend import queue_processor as qp
+
+    item = {
+        "race_id": "ca-house-01-2026",
+        "run_id": "run-no-artifact",
+        "options": {"cheap_mode": True, "save_artifact": False},
+    }
+    db, _item_ref, run_ref, _race_ref = _fs_mock(item)
+
+    with (
+        patch.object(qp, "_run_agent", AsyncMock(return_value={"status": "draft"})),
+        patch("pipeline_client.backend.storage.save_artifact") as save_artifact,
+    ):
+        await qp.process_claimed_item(db, MagicMock(), "bucket", "item-no-artifact", item, "owner-no-artifact")
+
+    save_artifact.assert_not_called()
+    completed = [c.args[0] for c in run_ref.update.call_args_list if c.args[0].get("status") == "completed"]
+    assert completed[-1]["artifact_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_process_artifact_save_failure_is_non_fatal():
+    from pipeline_client.backend import queue_processor as qp
+
+    item = {
+        "race_id": "ca-house-01-2026",
+        "run_id": "run-artifact-failure",
+        "options": {"cheap_mode": True, "save_artifact": True},
+    }
+    db, item_ref, run_ref, _race_ref = _fs_mock(item)
+
+    with (
+        patch.object(qp, "_run_agent", AsyncMock(return_value={"status": "draft"})),
+        patch("pipeline_client.backend.storage.save_artifact", side_effect=RuntimeError("gcs unavailable")),
+    ):
+        await qp.process_claimed_item(db, MagicMock(), "bucket", "item-artifact-failure", item, "owner-artifact-failure")
+
+    run_updates = [call.args[0] for call in run_ref.update.call_args_list]
+    completed = [update for update in run_updates if update.get("status") == "completed"]
+    assert completed[-1]["artifact_id"] is None
+    assert not any(update.get("status") == "failed" for update in run_updates)
+    item_updates = [call.args[0] for call in item_ref.update.call_args_list]
+    assert any(update.get("status") == "completed" for update in item_updates)
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -575,6 +575,171 @@ async def test_unproven_roster_completeness_keeps_going_and_says_so():
 
 
 @pytest.mark.asyncio
+async def test_roster_verify_can_recover_completeness_after_removing_primary_losers():
+    existing = {
+        "id": "al-house-02-2026",
+        "election_date": "2026-11-03",
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic", "roster_sources": []},
+            {"name": "Rhett Marques", "party": "Republican", "roster_sources": []},
+            {"name": "Primary Loser", "party": "Republican", "roster_sources": []},
+        ],
+        "updated_utc": "2026-08-01T00:00:00Z",
+    }
+
+    async def recover_in_verify(*args, **kwargs):
+        if kwargs.get("phase_name") == "roster-sync":
+            return {"_tool_trace": {"required_final_tool_succeeded": False}}
+        if kwargs.get("phase_name") == "roster-verify":
+            assert kwargs["required_final_tool_name"] == "finalize_roster"
+            assert any(tool["function"]["name"] == "finalize_roster" for tool in kwargs["extra_tools"])
+            assert "Any candidates added during the sync that were NOT in the original list:\n(none)" in args[1]
+            kwargs["extra_tool_handlers"]["remove_candidate"](
+                {"name": "Primary Loser", "reason": "Lost the completed special primary."}
+            )
+            return {"_tool_trace": {"required_final_tool_succeeded": True}}
+        return {}
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
+        patch("pipeline_client.agent.phases._sync_ballotpedia_roster", new_callable=AsyncMock),
+    ):
+        mock_loop.side_effect = recover_in_verify
+        result = await run_agent(
+            "al-house-02-2026",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["discovery"],
+            candidate_names=["Shomari Figures"],
+        )
+
+    assert [candidate["name"] for candidate in result["candidates"]] == ["Shomari Figures", "Rhett Marques"]
+    assert "roster_completeness_unproven" not in result["run_health"]["reasons"]
+    assert (result["pipeline_state"].get("roster_research") or {}).get("completeness_status") != "unproven"
+    assert result["pipeline_state"]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_roster_completeness_recovery_survives_continuation_checkpoint():
+    existing = {
+        "id": "al-house-02-2026",
+        "election_date": "2026-11-03",
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic", "roster_sources": []},
+            {"name": "Rhett Marques", "party": "Republican", "roster_sources": []},
+        ],
+        "pipeline_state": {
+            "complete": True,
+            "remaining_candidates": [],
+            "remaining_steps": [],
+            "completed_units": ["discovery.roster_sync"],
+            "roster_finalization_pending": True,
+            "roster_sync_original_names": ["Shomari Figures"],
+        },
+        "updated_utc": "2026-08-12T00:00:00Z",
+    }
+
+    async def finish_recovery(*_args, **kwargs):
+        if kwargs.get("phase_name") == "roster-verify":
+            assert kwargs["required_final_tool_name"] == "finalize_roster"
+            assert "Any candidates added during the sync that were NOT in the original list:\nRhett Marques" in _args[1]
+            return {"_tool_trace": {"required_final_tool_succeeded": True}}
+        return {}
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
+        patch("pipeline_client.agent.phases._sync_ballotpedia_roster", new_callable=AsyncMock),
+    ):
+        mock_loop.side_effect = finish_recovery
+        result = await run_agent(
+            "al-house-02-2026",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["discovery"],
+            resume_partial=True,
+        )
+
+    assert [call.kwargs["phase_name"] for call in mock_loop.call_args_list] == ["roster-verify", "update-meta"]
+    assert "roster_finalization_pending" not in result["pipeline_state"]
+    assert "roster_sync_original_names" not in result["pipeline_state"]
+    assert "roster_completeness_unproven" not in result["run_health"]["reasons"]
+    assert result["pipeline_state"]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_failed_roster_sync_writes_recovery_state_before_checkpoint():
+    existing = {
+        "id": "al-house-02-2026",
+        "election_date": "2026-11-03",
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic", "roster_sources": []},
+            {"name": "Rhett Marques", "party": "Republican", "roster_sources": []},
+        ],
+        "updated_utc": "2026-08-12T00:00:00Z",
+    }
+    checkpoint = {}
+
+    def capture_checkpoint(step, **kwargs):
+        race_json = kwargs.get("race_json") or {}
+        state = race_json.get("pipeline_state") or {}
+        if step == "discovery" and state.get("roster_finalization_pending") is True:
+            checkpoint.update(copy.deepcopy(state))
+            raise HandoffTriggered("continuation-item", ["discovery"], "continuation-run")
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
+        patch("pipeline_client.agent.phases._sync_ballotpedia_roster", new_callable=AsyncMock),
+    ):
+        mock_loop.return_value = {"_tool_trace": {"required_final_tool_succeeded": False}}
+        with pytest.raises(HandoffTriggered):
+            await run_agent(
+                "al-house-02-2026",
+                cheap_mode=True,
+                existing_data=existing,
+                enabled_steps=["discovery"],
+                step_tracker={"progress": capture_checkpoint},
+            )
+
+    assert checkpoint["roster_finalization_pending"] is True
+    assert checkpoint["roster_sync_original_names"] == ["Shomari Figures", "Rhett Marques"]
+
+
+@pytest.mark.asyncio
+async def test_successful_roster_recovery_clears_initial_sync_error():
+    existing = {
+        "id": "ar-supreme-court-2026",
+        "election_date": "2026-03-03",
+        "candidates": [
+            {"name": "Nicholas Bronni", "party": "Nonpartisan", "roster_sources": []},
+            {"name": "John Adams", "party": "Nonpartisan", "roster_sources": []},
+        ],
+        "updated_utc": "2026-01-01T00:00:00Z",
+    }
+
+    async def recover_after_error(*_args, **kwargs):
+        if kwargs.get("phase_name") == "roster-sync":
+            raise RuntimeError("temporary provider error")
+        if kwargs.get("phase_name") == "roster-verify":
+            return {"_tool_trace": {"required_final_tool_succeeded": True}}
+        return {}
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
+        patch("pipeline_client.agent.phases._sync_ballotpedia_roster", new_callable=AsyncMock),
+    ):
+        mock_loop.side_effect = recover_after_error
+        result = await run_agent(
+            "ar-supreme-court-2026",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["discovery"],
+        )
+
+    assert result["run_health"]["status"] == "healthy"
+    assert result["pipeline_state"]["step_failures"] == []
+
+
+@pytest.mark.asyncio
 async def test_run_agent_defaults_existing_profile_to_low_cost_update_steps():
     existing = {
         "id": "maintenance-2026",

--- a/web/src/lib/components/ElectionDirectory.test.ts
+++ b/web/src/lib/components/ElectionDirectory.test.ts
@@ -1,0 +1,411 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RaceSummary } from "$lib/types";
+import ElectionDirectory from "./ElectionDirectory.svelte";
+
+const { goto, pageControl } = vi.hoisted(() => ({
+  goto: vi.fn(),
+  pageControl: { setUrl: (_: string) => {} },
+}));
+
+vi.mock("$app/environment", () => ({ browser: true }));
+vi.mock("$app/navigation", () => ({ goto }));
+vi.mock("$app/stores", async () => {
+  const { writable } = await import("svelte/store");
+  const store = writable({ url: new URL("https://smarter.vote/elections/") });
+  pageControl.setUrl = (href: string) => store.set({ url: new URL(href) });
+  return { page: store };
+});
+
+const ROUTE = "https://smarter.vote/elections/";
+
+/**
+ * The embedded USMap fetches /states-10m.json in onMount with no try/catch, so
+ * an unstubbed fetch produces an unhandled rejection that has nothing to do
+ * with the directory. An empty-but-valid topology lets the map mount and settle
+ * without drawing anything.
+ */
+const EMPTY_TOPOLOGY = {
+  type: "Topology",
+  objects: { states: { type: "GeometryCollection", geometries: [] } },
+  arcs: [],
+};
+
+function race(overrides: Partial<RaceSummary> = {}): RaceSummary {
+  return {
+    id: "mo-senate-2024",
+    title: "2024 Missouri U.S. Senate Election",
+    office: "U.S. Senate",
+    state: "Missouri",
+    jurisdiction: "Missouri",
+    election_date: "2024-11-05",
+    updated_utc: "2024-06-01T12:00:00Z",
+    candidates: [{ name: "Jane Doe", party: "Democratic", incumbent: false }],
+    ...overrides,
+  } as RaceSummary;
+}
+
+function renderDirectory(races: RaceSummary[] = [race()]) {
+  return render(ElectionDirectory, { races });
+}
+
+function searchBox(container: HTMLElement): HTMLInputElement {
+  return container.querySelector(
+    'input[placeholder^="Search by candidate name"]',
+  ) as HTMLInputElement;
+}
+
+function cards(container: HTMLElement): NodeListOf<Element> {
+  return container.querySelectorAll(
+    '#election-results-grid a[href^="/races/"]',
+  );
+}
+
+function officeChip(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+}
+
+beforeEach(() => {
+  pageControl.setUrl(ROUTE);
+  goto.mockReset();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(EMPTY_TOPOLOGY),
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("ElectionDirectory rendering", () => {
+  it("renders a card per race", async () => {
+    const { container } = renderDirectory([
+      race({ id: "a", title: "Race A" }),
+      race({ id: "b", title: "Race B" }),
+    ]);
+
+    await waitFor(() => expect(cards(container)).toHaveLength(2));
+  });
+
+  it("renders nothing in the grid when there are no races", async () => {
+    const { container } = renderDirectory([]);
+
+    await waitFor(() => expect(cards(container)).toHaveLength(0));
+  });
+
+  // PAGE_SIZE is 24; anything beyond that waits for the load-more control.
+  it("shows at most one page of races initially", async () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      race({ id: `race-${i}`, title: `Race ${i}` }),
+    );
+    const { container } = renderDirectory(many);
+
+    await waitFor(() => expect(cards(container)).toHaveLength(24));
+  });
+});
+
+describe("ElectionDirectory office filtering", () => {
+  const mixed = [
+    race({ id: "s", title: "Senate Race", office: "U.S. Senate" }),
+    race({
+      id: "h",
+      title: "House Race",
+      office: "U.S. House of Representatives",
+    }),
+    race({ id: "g", title: "Governor Race", office: "Governor of Missouri" }),
+    race({ id: "o", title: "Coroner Race", office: "County Coroner" }),
+  ];
+
+  it("offers a chip per distinct office type", async () => {
+    const { container } = renderDirectory(mixed);
+
+    await waitFor(() => {
+      expect(officeChip(container, "Senate")).toBeTruthy();
+      expect(officeChip(container, "House")).toBeTruthy();
+      expect(officeChip(container, "Governor")).toBeTruthy();
+      expect(officeChip(container, "Other")).toBeTruthy();
+    });
+  });
+
+  it("narrows the grid to the chosen office", async () => {
+    const { container } = renderDirectory(mixed);
+
+    await waitFor(() => expect(officeChip(container, "Senate")).toBeTruthy());
+    await fireEvent.click(officeChip(container, "Senate")!);
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1));
+    // RaceCard renders a derived title, not race.title, so assert on the id.
+    expect(cards(container)[0].getAttribute("href")).toBe("/races/s");
+  });
+
+  it("buckets an unrecognised office under Other", async () => {
+    const { container } = renderDirectory(mixed);
+
+    await waitFor(() => expect(officeChip(container, "Other")).toBeTruthy());
+    await fireEvent.click(officeChip(container, "Other")!);
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1));
+    expect(cards(container)[0].getAttribute("href")).toBe("/races/o");
+  });
+});
+
+describe("ElectionDirectory search", () => {
+  const searchable = [
+    race({
+      id: "mo",
+      title: "Missouri Senate",
+      jurisdiction: "Missouri",
+      candidates: [{ name: "Jane Doe", party: "Democratic", incumbent: false }],
+    }),
+    race({
+      id: "ks",
+      title: "Kansas House",
+      office: "U.S. House",
+      state: "Kansas",
+      jurisdiction: "Kansas",
+      candidates: [{ name: "Bob Roe", party: "Republican", incumbent: true }],
+    }),
+  ];
+
+  /** Search is debounced through goto → $page.url, so drive that loop. */
+  function wireNavigation() {
+    goto.mockImplementation((href: string) => {
+      pageControl.setUrl(new URL(href, ROUTE).href);
+    });
+  }
+
+  it("filters by candidate name", async () => {
+    wireNavigation();
+    const { container } = renderDirectory(searchable);
+
+    await fireEvent.input(searchBox(container), { target: { value: "Jane" } });
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1), {
+      timeout: 2000,
+    });
+    expect(cards(container)[0].getAttribute("href")).toBe("/races/mo");
+  });
+
+  it("filters by party", async () => {
+    wireNavigation();
+    const { container } = renderDirectory(searchable);
+
+    await fireEvent.input(searchBox(container), {
+      target: { value: "Republican" },
+    });
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1), {
+      timeout: 2000,
+    });
+    expect(cards(container)[0].getAttribute("href")).toBe("/races/ks");
+  });
+
+  it("filters by title", async () => {
+    wireNavigation();
+    const { container } = renderDirectory(searchable);
+
+    await fireEvent.input(searchBox(container), {
+      target: { value: "Kansas" },
+    });
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1), {
+      timeout: 2000,
+    });
+  });
+
+  it("seeds the box from ?q= in the url", async () => {
+    pageControl.setUrl(`${ROUTE}?q=Kansas`);
+    const { container } = renderDirectory(searchable);
+
+    await waitFor(() => expect(searchBox(container).value).toBe("Kansas"));
+    await waitFor(() => expect(cards(container)).toHaveLength(1));
+  });
+
+  it("writes the query into the url without stacking history entries", async () => {
+    const { container } = renderDirectory(searchable);
+
+    await fireEvent.input(searchBox(container), { target: { value: "Jane" } });
+
+    await waitFor(
+      () =>
+        expect(goto).toHaveBeenCalledWith(
+          "/elections/?q=Jane",
+          expect.objectContaining({
+            replaceState: true,
+            keepFocus: true,
+            noScroll: true,
+          }),
+        ),
+      { timeout: 2000 },
+    );
+  });
+
+  it("clears the query and drops it from the url", async () => {
+    wireNavigation();
+    pageControl.setUrl(`${ROUTE}?q=Kansas`);
+    const { container } = renderDirectory(searchable);
+
+    const clear = await waitFor(() => {
+      const el = container.querySelector('[aria-label="Clear search query"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    await fireEvent.click(clear);
+
+    await waitFor(() => expect(searchBox(container).value).toBe(""));
+    await waitFor(() => expect(cards(container)).toHaveLength(2));
+  });
+
+  it("matches case-insensitively", async () => {
+    wireNavigation();
+    const { container } = renderDirectory(searchable);
+
+    await fireEvent.input(searchBox(container), { target: { value: "jane" } });
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1), {
+      timeout: 2000,
+    });
+  });
+});
+
+/**
+ * USMap raises `stateClick` through createEventDispatcher, which Svelte 5 makes
+ * unobservable from a direct render (component.$on is gone). These tests cover
+ * the dispatch end-to-end instead: a real topology so the map draws clickable
+ * paths, then a click, then the resulting filter change in the grid.
+ *
+ * ids are FIPS codes — 29 = Missouri, 20 = Kansas.
+ */
+const REAL_TOPOLOGY = {
+  type: "Topology",
+  arcs: [
+    [
+      [-95, 36],
+      [-89, 36],
+      [-89, 40],
+      [-95, 40],
+      [-95, 36],
+    ],
+    [
+      [-102, 37],
+      [-95, 37],
+      [-95, 40],
+      [-102, 40],
+      [-102, 37],
+    ],
+  ],
+  objects: {
+    states: {
+      type: "GeometryCollection",
+      geometries: [
+        { type: "Polygon", id: 29, arcs: [[0]] },
+        { type: "Polygon", id: 20, arcs: [[1]] },
+      ],
+    },
+  },
+};
+
+describe("ElectionDirectory map selection", () => {
+  const twoStates = [
+    race({ id: "mo", title: "Missouri Senate", state: "Missouri" }),
+    race({ id: "ks", title: "Kansas Senate", state: "Kansas" }),
+  ];
+
+  function statePath(container: HTMLElement, name: string) {
+    return Array.from(container.querySelectorAll("path")).find((p) =>
+      p.getAttribute("aria-label")?.startsWith(name),
+    ) as SVGPathElement | undefined;
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(REAL_TOPOLOGY),
+      }),
+    );
+  });
+
+  it("filters the grid when a state is clicked on the map", async () => {
+    const { container } = renderDirectory(twoStates);
+
+    const kansas = await waitFor(() => {
+      const el = statePath(container, "Kansas");
+      expect(el).toBeTruthy();
+      return el!;
+    });
+
+    await fireEvent.click(kansas);
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1));
+    expect(cards(container)[0].getAttribute("href")).toBe("/races/ks");
+  });
+
+  it("clears the state filter when the same state is clicked again", async () => {
+    const { container } = renderDirectory(twoStates);
+
+    const kansas = await waitFor(() => {
+      const el = statePath(container, "Kansas");
+      expect(el).toBeTruthy();
+      return el!;
+    });
+
+    await fireEvent.click(kansas);
+    await waitFor(() => expect(cards(container)).toHaveLength(1));
+
+    await fireEvent.click(statePath(container, "Kansas")!);
+    await waitFor(() => expect(cards(container)).toHaveLength(2));
+  });
+});
+
+describe("ElectionDirectory state filtering", () => {
+  const twoStates = [
+    race({ id: "mo", title: "Missouri Senate", state: "Missouri" }),
+    race({ id: "ks", title: "Kansas Senate", state: "Kansas" }),
+  ];
+
+  it("narrows to a state chosen from the mobile picker", async () => {
+    const { container } = renderDirectory(twoStates);
+    const select = (await waitFor(() => {
+      const el = container.querySelector("#mobile-state-select");
+      expect(el).not.toBeNull();
+      return el as HTMLSelectElement;
+    })) as HTMLSelectElement;
+
+    await fireEvent.change(select, { target: { value: "Kansas" } });
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1));
+    expect(cards(container)[0].getAttribute("href")).toBe("/races/ks");
+  });
+
+  it("falls back to jurisdiction when a race has no explicit state", async () => {
+    const { container } = renderDirectory([
+      race({
+        id: "legacy",
+        title: "Legacy Race",
+        state: undefined,
+        jurisdiction: "Kansas",
+      }),
+    ]);
+
+    const select = (await waitFor(() => {
+      const el = container.querySelector("#mobile-state-select");
+      expect(el).not.toBeNull();
+      return el as HTMLSelectElement;
+    })) as HTMLSelectElement;
+
+    await fireEvent.change(select, { target: { value: "Kansas" } });
+
+    await waitFor(() => expect(cards(container)).toHaveLength(1));
+  });
+});

--- a/web/src/lib/components/IssueTable.test.ts
+++ b/web/src/lib/components/IssueTable.test.ts
@@ -1,0 +1,237 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import IssueTable from "./IssueTable.svelte";
+import type { IssueKey, IssueStance, Source } from "$lib/types";
+
+/**
+ * IssueTable renders a desktop <table> and a parallel mobile card list. jsdom
+ * applies no CSS, so *both* are in the DOM at once and a bare querySelector
+ * would match whichever comes first. Every assertion below scopes to one view,
+ * and the two are exercised separately because they key their expand/tooltip
+ * state differently (`issue` vs `issue + "-mobile"`).
+ */
+function desktop(container: HTMLElement): HTMLElement {
+  return container.querySelector("table") as HTMLElement;
+}
+
+function mobile(container: HTMLElement): HTMLElement {
+  return container.querySelector('[class~="lg:hidden"]') as HTMLElement;
+}
+
+function source(n: number): Source {
+  return {
+    url: `https://example.test/source-${n}`,
+    type: "website",
+    title: `Source ${n}`,
+    last_accessed: "2026-01-01T00:00:00Z",
+  } as Source;
+}
+
+function stance(overrides: Partial<IssueStance> = {}): IssueStance {
+  return {
+    stance: "Supports expanding coverage.",
+    confidence: "high",
+    sources: [],
+    ...overrides,
+  } as IssueStance;
+}
+
+function renderTable(
+  issues: Partial<Record<IssueKey, IssueStance>>,
+  props: Record<string, unknown> = {},
+) {
+  return render(IssueTable, {
+    issues,
+    raceId: "mo-senate-2024",
+    candidateName: "Jane Doe",
+    ...props,
+  });
+}
+
+afterEach(cleanup);
+
+describe("IssueTable empty state", () => {
+  it("falls back when there are no issues", () => {
+    const { container } = renderTable({});
+
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  it("renders the table once at least one issue exists", () => {
+    const { container } = renderTable({
+      Healthcare: stance(),
+    } as Partial<Record<IssueKey, IssueStance>>);
+
+    expect(container.querySelector("table")).not.toBeNull();
+  });
+});
+
+describe("IssueTable content", () => {
+  it("renders the issue name and stance in both views", () => {
+    const { container } = renderTable({
+      Healthcare: stance({ stance: "Supports a public option." }),
+    } as Partial<Record<IssueKey, IssueStance>>);
+
+    expect(desktop(container).textContent).toContain("Healthcare");
+    expect(desktop(container).textContent).toContain(
+      "Supports a public option.",
+    );
+    expect(mobile(container).textContent).toContain(
+      "Supports a public option.",
+    );
+  });
+
+  it("renders every supplied issue", () => {
+    const { container } = renderTable({
+      Healthcare: stance(),
+      Economy: stance({ stance: "Favours targeted tax relief." }),
+    } as Partial<Record<IssueKey, IssueStance>>);
+
+    expect(desktop(container).querySelectorAll("tbody tr")).toHaveLength(2);
+  });
+
+  it("says so when an issue has no supporting sources", () => {
+    const { container } = renderTable({
+      Healthcare: stance({ sources: [] }),
+    } as Partial<Record<IssueKey, IssueStance>>);
+
+    expect(desktop(container).textContent).toContain("No supporting sources");
+  });
+});
+
+describe("IssueTable source expansion", () => {
+  const fiveSources = {
+    Healthcare: stance({ sources: [1, 2, 3, 4, 5].map(source) }),
+  } as Partial<Record<IssueKey, IssueStance>>;
+
+  it("shows only the first three sources initially", () => {
+    const { container } = renderTable(fiveSources);
+
+    expect(desktop(container).querySelectorAll("a")).toHaveLength(3);
+  });
+
+  it("offers to reveal exactly the remaining sources", () => {
+    const { container } = renderTable(fiveSources);
+    const toggle = desktop(container).querySelector("button")!;
+
+    expect(toggle.textContent?.trim()).toBe("Show 2 more");
+    expect(toggle.getAttribute("aria-label")).toContain(
+      "Show 2 more sources for Healthcare",
+    );
+  });
+
+  it("expands to every source and offers to collapse again", async () => {
+    const { container } = renderTable(fiveSources);
+    const toggle = desktop(container).querySelector("button")!;
+
+    await fireEvent.click(toggle);
+
+    expect(desktop(container).querySelectorAll("a")).toHaveLength(5);
+    const collapse = desktop(container).querySelector("button")!;
+    expect(collapse.textContent?.trim()).toBe("Show fewer");
+    expect(collapse.getAttribute("aria-label")).toContain(
+      "Show fewer sources for Healthcare",
+    );
+
+    await fireEvent.click(collapse);
+    expect(desktop(container).querySelectorAll("a")).toHaveLength(3);
+  });
+
+  it("omits the toggle when there are three or fewer sources", () => {
+    const { container } = renderTable({
+      Healthcare: stance({ sources: [1, 2, 3].map(source) }),
+    } as Partial<Record<IssueKey, IssueStance>>);
+
+    expect(desktop(container).querySelector("button")).toBeNull();
+    expect(desktop(container).querySelectorAll("a")).toHaveLength(3);
+  });
+
+  // Desktop and mobile track expansion under different keys, so expanding one
+  // must not expand the other — that would be a state-collision bug.
+  it("keeps desktop and mobile expansion independent", async () => {
+    const { container } = renderTable(fiveSources);
+
+    await fireEvent.click(desktop(container).querySelector("button")!);
+
+    expect(desktop(container).querySelectorAll("a")).toHaveLength(5);
+    expect(mobile(container).querySelectorAll("a")).toHaveLength(3);
+  });
+
+  it("expands the mobile view on its own", async () => {
+    const { container } = renderTable(fiveSources);
+    const mobileToggle = Array.from(
+      mobile(container).querySelectorAll("button"),
+    ).find((b) => b.textContent?.includes("Show 2 more"))!;
+
+    await fireEvent.click(mobileToggle);
+
+    expect(mobile(container).querySelectorAll("a")).toHaveLength(5);
+  });
+});
+
+describe("IssueTable renamed-issue tooltip", () => {
+  const renamed = {
+    "Reproductive Rights": stance(),
+  } as unknown as Partial<Record<IssueKey, IssueStance>>;
+
+  it("offers an explanation only for issues that were renamed", () => {
+    const { container } = renderTable(renamed);
+
+    expect(
+      desktop(container).querySelector('[aria-label="About this issue name"]'),
+    ).not.toBeNull();
+  });
+
+  it("shows no explanation button for a current issue name", () => {
+    const { container } = renderTable({
+      Healthcare: stance(),
+    } as Partial<Record<IssueKey, IssueStance>>);
+
+    expect(
+      desktop(container).querySelector('[aria-label="About this issue name"]'),
+    ).toBeNull();
+  });
+
+  it("reveals the rename note on click and dismisses it again", async () => {
+    const { container } = renderTable(renamed);
+    const info = desktop(container).querySelector(
+      '[aria-label="About this issue name"]',
+    )!;
+
+    expect(desktop(container).querySelector('[role="tooltip"]')).toBeNull();
+
+    await fireEvent.click(info);
+    const tooltip = desktop(container).querySelector('[role="tooltip"]');
+    expect(tooltip?.textContent).toContain("has been renamed");
+
+    const dismiss = Array.from(
+      desktop(container).querySelectorAll("button"),
+    ).find((b) => b.textContent?.trim() === "Dismiss")!;
+    await fireEvent.click(dismiss);
+    expect(desktop(container).querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it("toggles the note closed when the info button is clicked twice", async () => {
+    const { container } = renderTable(renamed);
+    const info = desktop(container).querySelector(
+      '[aria-label="About this issue name"]',
+    )!;
+
+    await fireEvent.click(info);
+    expect(desktop(container).querySelector('[role="tooltip"]')).not.toBeNull();
+
+    await fireEvent.click(info);
+    expect(desktop(container).querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it("keeps the desktop and mobile tooltips independent", async () => {
+    const { container } = renderTable(renamed);
+
+    await fireEvent.click(
+      desktop(container).querySelector('[aria-label="About this issue name"]')!,
+    );
+
+    expect(desktop(container).querySelector('[role="tooltip"]')).not.toBeNull();
+    expect(mobile(container).querySelector('[role="tooltip"]')).toBeNull();
+  });
+});

--- a/web/src/lib/components/RaceCard.test.ts
+++ b/web/src/lib/components/RaceCard.test.ts
@@ -1,0 +1,230 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import RaceCard from "./RaceCard.svelte";
+import type { RaceSummary } from "$lib/types";
+
+function makeRace(overrides: Partial<RaceSummary> = {}): RaceSummary {
+  return {
+    id: "mo-senate-2024",
+    title: "2024 Missouri U.S. Senate Election",
+    office: "U.S. Senator",
+    jurisdiction: "Missouri",
+    election_date: "2024-11-05",
+    updated_utc: "2024-06-01T12:00:00Z",
+    candidates: [
+      { name: "Jane Doe", party: "Democratic", incumbent: false },
+      { name: "John Roe", party: "Republican", incumbent: true },
+    ],
+    ...overrides,
+  } as RaceSummary;
+}
+
+afterEach(cleanup);
+
+/**
+ * Read the office badge specifically rather than the card's whole textContent.
+ * The card also renders the race *title*, which contains words like "Senate" —
+ * asserting on textContent passes even when the badge is broken.
+ */
+function badgeText(container: HTMLElement): string {
+  return container.querySelector(".font-semibold")?.textContent?.trim() ?? "";
+}
+
+describe("RaceCard office badge", () => {
+  // Office strings as they actually appear in published race data.
+  it.each([
+    ["U.S. Senate", "Senate"],
+    ["United States Senate", "Senate"],
+    ["Governor of Hawaii", "Governor"],
+    ["Gubernatorial", "Governor"],
+    ["U.S. House of Representatives", "House"],
+    ["United States House of Representatives", "House"],
+    ["Secretary of State", "Sec. of State"],
+    ["Attorney General", "Atty. General"],
+  ])("labels office %j as %j", (office, expected) => {
+    const { container } = render(RaceCard, { race: makeRace({ office }) });
+
+    expect(badgeText(container)).toBe(expected);
+  });
+
+  it("falls back to a generic label when office is absent", () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({ office: undefined }),
+    });
+
+    expect(badgeText(container)).toBe("Race");
+  });
+
+  it("passes a short unrecognised office through verbatim", () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({ office: "County Coroner" }),
+    });
+
+    expect(badgeText(container)).toBe("County Coroner");
+  });
+
+  it("truncates an unrecognised office longer than 22 characters", () => {
+    const long = "Commissioner of Public Lands and Waterways";
+    const { container } = render(RaceCard, {
+      race: makeRace({ office: long }),
+    });
+
+    expect(badgeText(container)).toBe(`${long.slice(0, 22)}…`);
+  });
+
+  it("matches office case-insensitively", () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({ office: "UNITED STATES SENATE" }),
+    });
+
+    expect(badgeText(container)).toBe("Senate");
+  });
+
+  // "U.S. Senator" (singular) does not contain the substring "senate", so it
+  // gets the neutral badge. Real published data uses "U.S. Senate" / "United
+  // States Senate", so this is a quirk rather than a live defect — pinned so
+  // that stays true if the pipeline's office vocabulary ever shifts.
+  it("does not recognise the singular 'U.S. Senator' form", () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({ office: "U.S. Senator" }),
+    });
+
+    expect(badgeText(container)).toBe("U.S. Senator");
+  });
+});
+
+describe("RaceCard content", () => {
+  it("links to the race detail page", () => {
+    const { container } = render(RaceCard, { race: makeRace() });
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "/races/mo-senate-2024",
+    );
+  });
+
+  it("shows the jurisdiction when present", () => {
+    const { container } = render(RaceCard, { race: makeRace() });
+
+    expect(container.textContent).toContain("Missouri");
+  });
+
+  it("omits the jurisdiction chip when absent", () => {
+    const withChip = render(RaceCard, { race: makeRace() });
+    const chip = withChip.container.querySelector(".bg-green-100");
+    expect(chip?.textContent?.trim()).toBe("Missouri");
+    cleanup();
+
+    const { container } = render(RaceCard, {
+      race: makeRace({ jurisdiction: undefined }),
+    });
+
+    expect(container.querySelector(".bg-green-100")).toBeNull();
+  });
+
+  it("renders every candidate name", () => {
+    const { container } = render(RaceCard, { race: makeRace() });
+
+    expect(container.textContent).toContain("Jane Doe");
+    expect(container.textContent).toContain("John Roe");
+  });
+
+  it("renders an empty candidate list without error", () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({ candidates: [] }),
+    });
+
+    expect(container.querySelector("a")).not.toBeNull();
+  });
+
+  it("formats the election date", () => {
+    const { container } = render(RaceCard, { race: makeRace() });
+
+    expect(container.textContent).toMatch(/Nov/);
+    expect(container.textContent).toContain("2024");
+  });
+});
+
+describe("RaceCard candidate avatars", () => {
+  it("uses the headshot when one is available", () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({
+        candidates: [
+          {
+            name: "Jane Doe",
+            party: "Democratic",
+            incumbent: false,
+            image_url: "https://example.test/jane.jpg",
+          },
+        ],
+      } as Partial<RaceSummary>),
+    });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.test/jane.jpg",
+    );
+  });
+
+  it("shows an initial placeholder when there is no headshot", () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({
+        candidates: [
+          { name: "Jane Doe", party: "Democratic", incumbent: false },
+        ],
+      } as Partial<RaceSummary>),
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  // A dead headshot URL is common — the card must degrade to initials rather
+  // than render a broken-image icon.
+  it("falls back to initials when the headshot fails to load", async () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({
+        candidates: [
+          {
+            name: "Jane Doe",
+            party: "Democratic",
+            incumbent: false,
+            image_url: "https://example.test/broken.jpg",
+          },
+        ],
+      } as Partial<RaceSummary>),
+    });
+
+    const img = container.querySelector("img")!;
+    await fireEvent.error(img);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toContain("Jane Doe");
+  });
+
+  it("only replaces the candidate whose image failed", async () => {
+    const { container } = render(RaceCard, {
+      race: makeRace({
+        candidates: [
+          {
+            name: "Jane Doe",
+            party: "Democratic",
+            incumbent: false,
+            image_url: "https://example.test/broken.jpg",
+          },
+          {
+            name: "John Roe",
+            party: "Republican",
+            incumbent: true,
+            image_url: "https://example.test/ok.jpg",
+          },
+        ],
+      } as Partial<RaceSummary>),
+    });
+
+    await fireEvent.error(container.querySelectorAll("img")[0]);
+
+    const remaining = container.querySelectorAll("img");
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].getAttribute("src")).toBe(
+      "https://example.test/ok.jpg",
+    );
+  });
+});

--- a/web/src/lib/components/ReviewPanel.test.ts
+++ b/web/src/lib/components/ReviewPanel.test.ts
@@ -1,0 +1,297 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import ReviewPanel from "./ReviewPanel.svelte";
+import type { AgentReview, ReviewFlag } from "$lib/types";
+
+function makeReview(overrides: Partial<AgentReview> = {}): AgentReview {
+  return {
+    model: "anthropic/claude-haiku-4.5",
+    reviewed_at: "2026-01-15T00:00:00Z",
+    verdict: "approved",
+    score: 88,
+    flags: [],
+    summary: "Sources check out.",
+    ...overrides,
+  } as AgentReview;
+}
+
+function makeFlag(overrides: Partial<ReviewFlag> = {}): ReviewFlag {
+  return {
+    field: "candidates[0].summary",
+    concern: "Summary lacks a citation.",
+    severity: "warning",
+    ...overrides,
+  } as ReviewFlag;
+}
+
+/** The panel starts collapsed; most assertions need it open first. */
+async function renderExpanded(reviews: AgentReview[]) {
+  const result = render(ReviewPanel, { reviews });
+  await fireEvent.click(result.container.querySelector(".review-title")!);
+  return result;
+}
+
+afterEach(cleanup);
+
+describe("ReviewPanel collapsing", () => {
+  it("starts collapsed with nothing but the header", () => {
+    const { container } = render(ReviewPanel, { reviews: [makeReview()] });
+
+    expect(container.querySelector(".review-cards")).toBeNull();
+    expect(
+      container.querySelector(".review-title")?.getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
+  it("expands and collapses on click", async () => {
+    const { container } = render(ReviewPanel, { reviews: [makeReview()] });
+    const toggle = container.querySelector(".review-title")!;
+
+    await fireEvent.click(toggle);
+    expect(container.querySelector(".review-cards")).not.toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    await fireEvent.click(toggle);
+    expect(container.querySelector(".review-cards")).toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("exposes an #ai-review anchor for the grade badge to scroll to", () => {
+    const { container } = render(ReviewPanel, { reviews: [] });
+
+    expect(container.querySelector("#ai-review")).not.toBeNull();
+  });
+});
+
+describe("ReviewPanel review filtering", () => {
+  // These two are internal automated checks, not model reviews — surfacing
+  // them would misrepresent how many independent models looked at the race.
+  it.each(["automated-link-validator", "automated-profile-quality"])(
+    "hides the internal %s entry",
+    async (model) => {
+      const { container } = await renderExpanded([
+        makeReview({ model }),
+        makeReview({ model: "x-ai/grok-4.3" }),
+      ]);
+
+      expect(container.textContent).not.toContain(model);
+      expect(container.textContent).toContain("x-ai/grok-4.3");
+    },
+  );
+
+  it("counts only the visible reviews", () => {
+    const { container } = render(ReviewPanel, {
+      reviews: [
+        makeReview({ model: "automated-link-validator" }),
+        makeReview({ model: "x-ai/grok-4.3" }),
+      ],
+    });
+
+    expect(container.querySelector(".review-count")?.textContent).toContain(
+      "1 review",
+    );
+  });
+
+  it.each([
+    [1, "1 review"],
+    [2, "2 reviews"],
+  ])("pluralises a count of %i as %j", (count, expected) => {
+    const { container } = render(ReviewPanel, {
+      reviews: Array.from({ length: count }, (_, i) =>
+        makeReview({ model: `model-${i}` }),
+      ),
+    });
+
+    expect(container.querySelector(".review-count")?.textContent?.trim()).toBe(
+      expected,
+    );
+  });
+
+  it("omits the count entirely when nothing is visible", () => {
+    const { container } = render(ReviewPanel, {
+      reviews: [makeReview({ model: "automated-link-validator" })],
+    });
+
+    expect(container.querySelector(".review-count")).toBeNull();
+  });
+
+  it.each([
+    ["an empty array", []],
+    ["a null prop", null],
+  ])("shows the empty state for %s", async (_label, reviews) => {
+    const { container } = await renderExpanded(reviews as AgentReview[]);
+
+    expect(container.querySelector(".review-empty")?.textContent).toContain(
+      "No automated review has been run",
+    );
+  });
+});
+
+describe("ReviewPanel verdicts and scores", () => {
+  it.each([
+    ["approved", "green"],
+    ["needs_revision", "yellow"],
+    ["flagged", "red"],
+  ])("colours the %s verdict with the %s ramp", async (verdict, hue) => {
+    const { container } = await renderExpanded([
+      makeReview({ verdict: verdict as AgentReview["verdict"] }),
+    ]);
+
+    expect(container.querySelector(".review-verdict")?.className).toContain(
+      hue,
+    );
+  });
+
+  it("falls back to a neutral verdict style", async () => {
+    const { container } = await renderExpanded([
+      makeReview({ verdict: "unheard_of" as AgentReview["verdict"] }),
+    ]);
+
+    expect(container.querySelector(".review-verdict")?.className).toContain(
+      "bg-surface-alt",
+    );
+  });
+
+  it("renders the verdict as words rather than a snake_case token", async () => {
+    const { container } = await renderExpanded([
+      makeReview({ verdict: "needs_revision" }),
+    ]);
+
+    expect(
+      container.querySelector(".review-verdict")?.textContent?.trim(),
+    ).toBe("needs revision");
+  });
+
+  it("shows a score when present", async () => {
+    const { container } = await renderExpanded([makeReview({ score: 73 })]);
+
+    expect(container.querySelector(".review-score")?.textContent).toContain(
+      "73/100",
+    );
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+  ])("hides the score when it is %s", async (_label, score) => {
+    const { container } = await renderExpanded([
+      makeReview({ score: score as number | undefined }),
+    ]);
+
+    expect(container.querySelector(".review-score")).toBeNull();
+  });
+
+  // 0 is a real score, not a missing one — the guard is `!= null`, so it must
+  // survive. A truthiness check here would silently hide the worst reviews.
+  it("shows a zero score rather than treating it as missing", async () => {
+    const { container } = await renderExpanded([makeReview({ score: 0 })]);
+
+    expect(container.querySelector(".review-score")?.textContent).toContain(
+      "0/100",
+    );
+  });
+
+  it("omits the summary paragraph when there is no summary", async () => {
+    const { container } = await renderExpanded([makeReview({ summary: "" })]);
+
+    expect(container.querySelector(".review-summary")).toBeNull();
+  });
+});
+
+describe("ReviewPanel flags", () => {
+  it("says so explicitly when a review raised nothing", async () => {
+    const { container } = await renderExpanded([makeReview({ flags: [] })]);
+
+    expect(container.querySelector(".review-all-clear")?.textContent).toContain(
+      "No issues flagged",
+    );
+  });
+
+  it.each([
+    [1, "1 flag"],
+    [3, "3 flags"],
+  ])("pluralises %i flags as %j", async (count, expected) => {
+    const { container } = await renderExpanded([
+      makeReview({
+        flags: Array.from({ length: count }, () => makeFlag()),
+      }),
+    ]);
+
+    expect(container.querySelector(".flags-toggle")?.textContent?.trim()).toBe(
+      expected,
+    );
+  });
+
+  it.each([
+    ["error", "🔴"],
+    ["warning", "🟡"],
+    ["info", "🔵"],
+    ["anything-else", "🔵"],
+  ])("marks %s severity with %s", async (severity, icon) => {
+    const { container } = await renderExpanded([
+      makeReview({
+        flags: [makeFlag({ severity: severity as ReviewFlag["severity"] })],
+      }),
+    ]);
+
+    expect(container.querySelector(".flag-severity")?.textContent).toContain(
+      icon,
+    );
+  });
+
+  it("renders the flagged field and concern", async () => {
+    const { container } = await renderExpanded([
+      makeReview({
+        flags: [
+          makeFlag({ field: "polling[0]", concern: "Pollster missing." }),
+        ],
+      }),
+    ]);
+
+    expect(container.textContent).toContain("polling[0]");
+    expect(container.textContent).toContain("Pollster missing.");
+  });
+
+  it("shows a suggestion when one is offered", async () => {
+    const { container } = await renderExpanded([
+      makeReview({ flags: [makeFlag({ suggestion: "Cite the pollster." })] }),
+    ]);
+
+    expect(container.querySelector(".flag-suggestion")?.textContent).toContain(
+      "Cite the pollster.",
+    );
+  });
+
+  it("omits the suggestion line when none is offered", async () => {
+    const { container } = await renderExpanded([
+      makeReview({ flags: [makeFlag({ suggestion: undefined })] }),
+    ]);
+
+    expect(container.querySelector(".flag-suggestion")).toBeNull();
+  });
+});
+
+describe("ReviewPanel review date", () => {
+  it("formats a valid timestamp as a local date", async () => {
+    const { container } = await renderExpanded([
+      makeReview({ reviewed_at: "2026-01-15T00:00:00Z" }),
+    ]);
+
+    const text = container.querySelector(".review-date")?.textContent ?? "";
+    expect(text).toContain("Reviewed:");
+    expect(text).toContain(
+      new Date("2026-01-15T00:00:00Z").toLocaleDateString(),
+    );
+  });
+
+  // An unparseable timestamp must render verbatim rather than "Invalid Date".
+  it("falls back to the raw value for an unparseable timestamp", async () => {
+    const { container } = await renderExpanded([
+      makeReview({ reviewed_at: "not-a-date" }),
+    ]);
+
+    const text = container.querySelector(".review-date")?.textContent ?? "";
+    expect(text).toContain("not-a-date");
+    expect(text).not.toContain("Invalid Date");
+  });
+});

--- a/web/src/lib/components/SiteHeader.test.ts
+++ b/web/src/lib/components/SiteHeader.test.ts
@@ -1,0 +1,457 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RaceSummary } from "$lib/types";
+import SiteHeader from "./SiteHeader.svelte";
+
+const { goto, getRaceSummaries, pageControl } = vi.hoisted(() => ({
+  goto: vi.fn(),
+  getRaceSummaries: vi.fn(),
+  // Filled in by the $app/stores factory below so tests can drive the route.
+  pageControl: { setUrl: (_: string) => {} },
+}));
+
+vi.mock("$app/environment", () => ({ browser: true }));
+vi.mock("$app/navigation", () => ({ goto }));
+vi.mock("$app/stores", async () => {
+  const { writable } = await import("svelte/store");
+  const store = writable({ url: new URL("https://smarter.vote/elections/") });
+  pageControl.setUrl = (href: string) => store.set({ url: new URL(href) });
+  return { page: store };
+});
+vi.mock("$lib/api", () => ({ getRaceSummaries }));
+
+/**
+ * On "/" the header treats the URL's `?q=` as the source of truth for the
+ * search box: a reactive block copies it into `query` whenever it differs from
+ * the last value the header itself wrote. In the real app `goto` updates
+ * `$page.url`, closing that loop. Under test `goto` is a spy, so the URL never
+ * changes and typing on "/" is immediately reset to "".
+ *
+ * Search behaviour is therefore exercised from a non-home route, and the
+ * homepage URL-sync path gets its own describe block that drives the store by
+ * hand. Getting this wrong makes every search assertion fail for a reason that
+ * has nothing to do with search.
+ */
+const NON_HOME_ROUTE = "https://smarter.vote/elections/";
+
+// jsdom has no ResizeObserver, and onMount observes the header for height.
+class FakeResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function race(overrides: Partial<RaceSummary> = {}): RaceSummary {
+  return {
+    id: "mo-senate-2024",
+    title: "2024 Missouri U.S. Senate Election",
+    office: "U.S. Senate",
+    state: "Missouri",
+    jurisdiction: "Missouri",
+    election_date: "2024-11-05",
+    updated_utc: "2024-06-01T12:00:00Z",
+    candidates: [{ name: "Jane Doe", party: "Democratic", incumbent: false }],
+    ...overrides,
+  } as RaceSummary;
+}
+
+function renderHeader(props: Record<string, unknown> = {}) {
+  return render(SiteHeader, {
+    races: [race()],
+    isAuthenticated: false,
+    darkMode: false,
+    onToggleDark: vi.fn(),
+    ...props,
+  });
+}
+
+function searchBox(container: HTMLElement): HTMLInputElement {
+  return container.querySelector("#site-search") as HTMLInputElement;
+}
+
+async function type(input: HTMLInputElement, value: string) {
+  await fireEvent.input(input, { target: { value } });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  pageControl.setUrl(NON_HOME_ROUTE);
+  goto.mockReset();
+  getRaceSummaries.mockReset();
+  getRaceSummaries.mockResolvedValue([race()]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("SiteHeader search matching", () => {
+  it("shows no results panel until something is typed", () => {
+    const { container } = renderHeader();
+
+    expect(container.querySelector("#site-search-results")).toBeNull();
+  });
+
+  it("matches a race by title", async () => {
+    const { container } = renderHeader();
+
+    await type(searchBox(container), "Missouri");
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("Missouri U.S. Senate"),
+    );
+  });
+
+  it("matches a candidate by name", async () => {
+    const { container } = renderHeader();
+
+    await type(searchBox(container), "Jane");
+
+    await waitFor(() => expect(container.textContent).toContain("Jane Doe"));
+  });
+
+  it("caps race results at five", async () => {
+    const races = Array.from({ length: 9 }, (_, i) =>
+      race({
+        id: `race-${i}`,
+        title: `Senate Race ${i}`,
+        candidates: [],
+      }),
+    );
+    const { container } = renderHeader({ races });
+
+    await type(searchBox(container), "Senate");
+
+    await waitFor(() => {
+      const links = Array.from(container.querySelectorAll("li, button")).filter(
+        (el) => el.textContent?.includes("Senate Race"),
+      );
+      expect(links.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  it("finds nothing for a query that matches no race or candidate", async () => {
+    const { container } = renderHeader();
+
+    await type(searchBox(container), "zzzzz-no-match");
+
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("Jane Doe");
+    });
+  });
+});
+
+describe("SiteHeader navigation", () => {
+  it("navigates to a race when its result is chosen", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+
+    await type(input, "Missouri");
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(goto).toHaveBeenCalledWith("/races/mo-senate-2024");
+  });
+
+  it("slugifies a candidate name into the profile url", async () => {
+    const { container } = renderHeader({
+      races: [
+        race({
+          title: "No Match Here",
+          office: "",
+          state: "",
+          jurisdiction: "",
+          candidates: [
+            { name: "Jane Q. Doe", party: "Democratic", incumbent: false },
+          ],
+        }),
+      ],
+    });
+    const input = searchBox(container);
+
+    await type(input, "Jane");
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(goto).toHaveBeenCalledWith("/races/mo-senate-2024/jane-q-doe");
+  });
+
+  it("falls back to the elections page when nothing is highlighted", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+
+    await type(input, "Missouri");
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(goto).toHaveBeenCalledWith("/elections/?q=Missouri");
+  });
+
+  it("url-encodes the fallback query", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+
+    await type(input, "a & b");
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(goto).toHaveBeenCalledWith("/elections/?q=a%20%26%20b");
+  });
+
+  it("does not navigate on Enter with an empty query", async () => {
+    const { container } = renderHeader();
+
+    await fireEvent.keyDown(searchBox(container), { key: "Enter" });
+
+    expect(goto).not.toHaveBeenCalled();
+  });
+});
+
+describe("SiteHeader keyboard navigation", () => {
+  it("wraps around the end of the result list", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+    await type(input, "Missouri");
+
+    // One race + one candidate = two results; three downs wraps to the first.
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(goto).toHaveBeenCalledWith("/races/mo-senate-2024");
+  });
+
+  // NOTE: with nothing highlighted (activeIndex === -1), ArrowUp computes
+  // (-1 - 1 + total) % total, which lands on the FIRST result, not the last.
+  // Conventional combobox behaviour would wrap to the last item. Pinned as-is
+  // rather than "fixed" here — it is a deliberate-looking formula and changing
+  // it is a UX decision, not a test concern.
+  it("selects the first result when ArrowUp is pressed with nothing highlighted", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+    await type(input, "Missouri");
+
+    await fireEvent.keyDown(input, { key: "ArrowUp" });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(goto).toHaveBeenCalledWith("/races/mo-senate-2024");
+  });
+
+  it("steps backwards through results once one is highlighted", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+    await type(input, "Missouri");
+
+    // Down to the race (0), down to the candidate (1), up back to the race (0).
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "ArrowUp" });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(goto).toHaveBeenCalledWith("/races/mo-senate-2024");
+  });
+
+  it("closes the panel on Escape", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+
+    await type(input, "Missouri");
+    await waitFor(() =>
+      expect(container.querySelector("#site-search-results")).not.toBeNull(),
+    );
+
+    await fireEvent.keyDown(input, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(container.querySelector("#site-search-results")).toBeNull(),
+    );
+  });
+
+  it("ignores arrow keys when there are no matches", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+
+    await type(input, "zzzzz-no-match");
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    // Falls through to the elections fallback rather than selecting nothing.
+    expect(goto).toHaveBeenCalledWith("/elections/?q=zzzzz-no-match");
+  });
+});
+
+describe("SiteHeader lazy race loading", () => {
+  it("does not fetch summaries when races were supplied", async () => {
+    const { container } = renderHeader({ races: [race()] });
+
+    await type(searchBox(container), "Missouri");
+
+    expect(getRaceSummaries).not.toHaveBeenCalled();
+  });
+
+  it("fetches summaries on first search when none were supplied", async () => {
+    const { container } = renderHeader({ races: [] });
+
+    await type(searchBox(container), "Missouri");
+
+    await waitFor(() => expect(getRaceSummaries).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(container.textContent).toContain("Missouri U.S. Senate"),
+    );
+  });
+
+  it("fetches only once across repeated searches", async () => {
+    const { container } = renderHeader({ races: [] });
+    const input = searchBox(container);
+
+    await type(input, "Mis");
+    await waitFor(() => expect(getRaceSummaries).toHaveBeenCalledTimes(1));
+    await type(input, "Missouri");
+    await type(input, "Missouri S");
+
+    expect(getRaceSummaries).toHaveBeenCalledTimes(1);
+  });
+
+  // A failed summaries fetch must leave the header usable rather than throwing.
+  it("survives a failed summaries fetch", async () => {
+    getRaceSummaries.mockRejectedValue(new Error("offline"));
+    const { container } = renderHeader({ races: [] });
+
+    await type(searchBox(container), "Missouri");
+
+    await waitFor(() => expect(getRaceSummaries).toHaveBeenCalled());
+    expect(searchBox(container)).not.toBeNull();
+  });
+});
+
+describe("SiteHeader homepage query sync", () => {
+  const HOME = "https://smarter.vote/";
+
+  it("seeds the search box from ?q= on the homepage", async () => {
+    pageControl.setUrl(`${HOME}?q=Missouri`);
+    const { container } = renderHeader();
+
+    await waitFor(() => expect(searchBox(container).value).toBe("Missouri"));
+  });
+
+  it("loads summaries when arriving with a query already in the url", async () => {
+    pageControl.setUrl(`${HOME}?q=Missouri`);
+    renderHeader({ races: [] });
+
+    await waitFor(() => expect(getRaceSummaries).toHaveBeenCalled());
+  });
+
+  it("does not seed the box from ?q= away from the homepage", async () => {
+    pageControl.setUrl("https://smarter.vote/elections/?q=Missouri");
+    const { container } = renderHeader();
+
+    expect(searchBox(container).value).toBe("");
+  });
+
+  it("pushes the typed query into the homepage url without adding history", async () => {
+    vi.useFakeTimers();
+    pageControl.setUrl(HOME);
+    const { container } = renderHeader();
+
+    await fireEvent.input(searchBox(container), {
+      target: { value: "Missouri" },
+    });
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(goto).toHaveBeenCalledWith(
+      "/?q=Missouri",
+      expect.objectContaining({
+        replaceState: true,
+        keepFocus: true,
+        noScroll: true,
+      }),
+    );
+  });
+
+  it("offers a clear button only while there is a query", async () => {
+    pageControl.setUrl(HOME);
+    const { container } = renderHeader();
+    expect(container.querySelector('[aria-label="Clear search"]')).toBeNull();
+    cleanup();
+
+    pageControl.setUrl(`${HOME}?q=Missouri`);
+    const seeded = renderHeader();
+
+    await waitFor(() =>
+      expect(
+        seeded.container.querySelector('[aria-label="Clear search"]'),
+      ).not.toBeNull(),
+    );
+  });
+
+  it("drops the q parameter when the search is cleared", async () => {
+    // Close the navigation feedback loop: the header only stays cleared once
+    // $page.url loses its `q`, which real SvelteKit navigation does for it.
+    goto.mockImplementation((href: string) => {
+      pageControl.setUrl(new URL(href, HOME).href);
+    });
+    pageControl.setUrl(`${HOME}?q=Missouri`);
+    const { container } = renderHeader();
+
+    const clear = await waitFor(() => {
+      const el = container.querySelector('[aria-label="Clear search"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    await fireEvent.click(clear);
+
+    await waitFor(() =>
+      expect(goto).toHaveBeenCalledWith("/?", expect.anything()),
+    );
+    await waitFor(() => expect(searchBox(container).value).toBe(""));
+  });
+});
+
+describe("SiteHeader global shortcuts", () => {
+  it("opens search when '/' is pressed outside a text field", async () => {
+    const { container } = renderHeader();
+
+    await fireEvent.keyDown(window, { key: "/" });
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(searchBox(container)),
+    );
+  });
+
+  it("ignores '/' while typing in the search box", async () => {
+    const { container } = renderHeader();
+    const input = searchBox(container);
+    input.focus();
+
+    await fireEvent.keyDown(window, { key: "/" });
+
+    // Still focused, but the shortcut must not have hijacked the keystroke.
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("closes overlays on Escape", async () => {
+    const { container } = renderHeader();
+
+    await fireEvent.keyDown(window, { key: "/" });
+    await fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(container.querySelector("#site-search-results")).toBeNull();
+  });
+
+  it("closes the results panel on an outside click", async () => {
+    const { container } = renderHeader();
+
+    await type(searchBox(container), "Missouri");
+    await waitFor(() =>
+      expect(container.querySelector("#site-search-results")).not.toBeNull(),
+    );
+
+    await fireEvent.click(document.body);
+
+    await waitFor(() =>
+      expect(container.querySelector("#site-search-results")).toBeNull(),
+    );
+  });
+});

--- a/web/src/lib/components/USMap.test.ts
+++ b/web/src/lib/components/USMap.test.ts
@@ -1,0 +1,344 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import USMap from "./USMap.svelte";
+
+/**
+ * A real (tiny) TopoJSON payload rather than an empty one: the component turns
+ * geometries into SVG path data via geoAlbersUsa, and a feature whose projected
+ * path is empty is deliberately filtered out. Testing the fill/interaction
+ * logic therefore needs geometry that actually projects, which means polygons
+ * with plausible US coordinates.
+ *
+ * No `transform` key, so arc coordinates are absolute rather than delta-encoded.
+ * ids are FIPS codes: 29 = Missouri, 20 = Kansas, 06 = California.
+ */
+const TOPOLOGY = {
+  type: "Topology",
+  arcs: [
+    [
+      [-95, 36],
+      [-89, 36],
+      [-89, 40],
+      [-95, 40],
+      [-95, 36],
+    ],
+    [
+      [-102, 37],
+      [-95, 37],
+      [-95, 40],
+      [-102, 40],
+      [-102, 37],
+    ],
+    [
+      [-124, 33],
+      [-115, 33],
+      [-115, 42],
+      [-124, 42],
+      [-124, 33],
+    ],
+  ],
+  objects: {
+    states: {
+      type: "GeometryCollection",
+      geometries: [
+        { type: "Polygon", id: 29, arcs: [[0]] },
+        { type: "Polygon", id: 20, arcs: [[1]] },
+        { type: "Polygon", id: 6, arcs: [[2]] },
+      ],
+    },
+  },
+};
+
+function stubFetch(payload: unknown = TOPOLOGY) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    }),
+  );
+}
+
+async function renderMap(props: Record<string, unknown> = {}) {
+  const result = render(USMap, {
+    activeStates: new Set<string>(),
+    selectedState: null,
+    raceCounts: {},
+    matchingCandidatesByState: {},
+    stateColors: {},
+    stateTooltips: {},
+    ...props,
+  });
+  await waitFor(() =>
+    expect(result.container.querySelector("svg")).not.toBeNull(),
+  );
+  return result;
+}
+
+function pathFor(container: HTMLElement, label: string): SVGPathElement | null {
+  const match = Array.from(container.querySelectorAll("path")).find((p) =>
+    p.getAttribute("aria-label")?.startsWith(label),
+  );
+  // Normalise Array.find's `undefined` to `null` so absence assertions read
+  // consistently against the querySelector-based lookups elsewhere.
+  return (match as SVGPathElement) ?? null;
+}
+
+beforeEach(() => stubFetch());
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("USMap loading", () => {
+  it("shows a skeleton until the topology arrives", () => {
+    const { container } = render(USMap, { activeStates: new Set<string>() });
+
+    expect(container.querySelector(".skeleton")).not.toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders one path per projected state once loaded", async () => {
+    const { container } = await renderMap();
+
+    expect(container.querySelectorAll("path")).toHaveLength(3);
+    expect(fetch).toHaveBeenCalledWith("/states-10m.json");
+  });
+
+  it("maps FIPS ids to state names", async () => {
+    const { container } = await renderMap();
+
+    expect(pathFor(container, "Missouri")).not.toBeNull();
+    expect(pathFor(container, "Kansas")).not.toBeNull();
+    expect(pathFor(container, "California")).not.toBeNull();
+  });
+
+  it("falls back to the padded FIPS code for an unknown id", async () => {
+    stubFetch({
+      ...TOPOLOGY,
+      objects: {
+        states: {
+          type: "GeometryCollection",
+          geometries: [{ type: "Polygon", id: 99, arcs: [[0]] }],
+        },
+      },
+    });
+    const { container } = await renderMap();
+
+    expect(pathFor(container, "99")).not.toBeNull();
+  });
+
+  // TopoJSON represents "no geometry" as a null-typed member; geoPath returns
+  // null for it and the feature is filtered out rather than rendering an empty
+  // <path>. Note this is the *only* way to get empty path data here — a polygon
+  // with non-US coordinates does not vanish, because geoAlbersUsa's clipping
+  // turns it into an inverted fill covering the viewport.
+  it("drops members that carry no geometry", async () => {
+    stubFetch({
+      ...TOPOLOGY,
+      objects: {
+        states: {
+          type: "GeometryCollection",
+          geometries: [
+            { type: null, id: 29 },
+            { type: "Polygon", id: 20, arcs: [[1]] },
+          ],
+        },
+      },
+    });
+    const { container } = await renderMap();
+
+    expect(container.querySelectorAll("path")).toHaveLength(1);
+    expect(pathFor(container, "Kansas")).not.toBeNull();
+    expect(pathFor(container, "Missouri")).toBeNull();
+  });
+});
+
+describe("USMap fill precedence", () => {
+  it("paints inactive states with the inactive token", async () => {
+    const { container } = await renderMap();
+
+    expect(pathFor(container, "Missouri")?.getAttribute("fill")).toBe(
+      "var(--map-inactive)",
+    );
+  });
+
+  it("paints states that have races as active", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+    });
+
+    expect(pathFor(container, "Missouri")?.getAttribute("fill")).toBe(
+      "var(--map-active)",
+    );
+  });
+
+  it("paints the selected state with the selected token", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+      selectedState: "Missouri",
+    });
+
+    expect(pathFor(container, "Missouri")?.getAttribute("fill")).toBe(
+      "var(--map-selected)",
+    );
+  });
+
+  // An explicit per-state colour outranks everything, including selection —
+  // that is what lets a forecast tab paint the map by party.
+  it("lets an explicit state colour win over selection", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+      selectedState: "Missouri",
+      stateColors: { Missouri: "#ff0000" },
+    });
+
+    expect(pathFor(container, "Missouri")?.getAttribute("fill")).toBe(
+      "#ff0000",
+    );
+  });
+});
+
+describe("USMap selection rendering", () => {
+  it("draws the selected state last so its stroke is not clipped", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri", "Kansas"]),
+      selectedState: "Missouri",
+    });
+
+    const paths = Array.from(container.querySelectorAll("path"));
+    expect(paths.at(-1)?.getAttribute("aria-label")).toContain("Missouri");
+    expect(paths.at(-1)?.getAttribute("stroke")).toBe(
+      "var(--map-selected-stroke)",
+    );
+  });
+
+  it("labels the selected state as selected", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+      selectedState: "Missouri",
+      raceCounts: { Missouri: 3 },
+    });
+
+    expect(pathFor(container, "Missouri")?.getAttribute("aria-label")).toBe(
+      "Missouri, 3 races, selected",
+    );
+  });
+});
+
+describe("USMap accessibility labelling", () => {
+  it.each([
+    [1, "Missouri, 1 race"],
+    [2, "Missouri, 2 races"],
+    [0, "Missouri, 0 races"],
+  ])("pluralises a count of %i correctly", async (count, expected) => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+      raceCounts: { Missouri: count },
+    });
+
+    expect(pathFor(container, "Missouri")?.getAttribute("aria-label")).toBe(
+      expected,
+    );
+  });
+
+  it("marks an active state as a button and makes it focusable", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+    });
+
+    const path = pathFor(container, "Missouri")!;
+    expect(path.getAttribute("role")).toBe("button");
+    expect(path.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("keeps an inactive state out of the tab order", async () => {
+    const { container } = await renderMap();
+
+    const path = pathFor(container, "Missouri")!;
+    expect(path.getAttribute("role")).toBe("presentation");
+    expect(path.getAttribute("tabindex")).toBe("-1");
+  });
+
+  // A state with a tooltip but no races is readable but not clickable.
+  it("marks a tooltip-only state as an image rather than a button", async () => {
+    const { container } = await renderMap({
+      stateTooltips: { Missouri: { title: "No races yet" } },
+    });
+
+    const path = pathFor(container, "Missouri")!;
+    expect(path.getAttribute("role")).toBe("img");
+    expect(path.getAttribute("tabindex")).toBe("-1");
+  });
+});
+
+/**
+ * `stateClick` is raised through `createEventDispatcher`, and Svelte 5 removed
+ * `component.$on(...)`, so the emission cannot be observed from here. The
+ * dispatch is covered end-to-end in ElectionDirectory.test.ts, which renders
+ * this map for real and asserts the resulting filter change. What is asserted
+ * below is everything that *gates* the dispatch — handlers attached, and
+ * interaction refused for states that should not be clickable.
+ */
+describe("USMap interaction", () => {
+  it("handles a click on an active state without error", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+    });
+
+    await expect(
+      fireEvent.click(pathFor(container, "Missouri")!),
+    ).resolves.not.toThrow();
+  });
+
+  it.each(["Enter", " ", "a"])(
+    "handles the %s key without error",
+    async (key) => {
+      const { container } = await renderMap({
+        activeStates: new Set(["Missouri"]),
+      });
+
+      await expect(
+        fireEvent.keyDown(pathFor(container, "Missouri")!, { key }),
+      ).resolves.not.toThrow();
+    },
+  );
+
+  it("shows a hover tooltip for an active state", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+      raceCounts: { Missouri: 2 },
+    });
+
+    await fireEvent.mouseEnter(pathFor(container, "Missouri")!);
+
+    await waitFor(() => expect(container.textContent).toContain("Missouri"));
+  });
+
+  it("clears the tooltip on mouse leave", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+      raceCounts: { Missouri: 2 },
+    });
+    const path = pathFor(container, "Missouri")!;
+
+    await fireEvent.mouseEnter(path);
+    await fireEvent.mouseLeave(path);
+
+    await waitFor(() => expect(container.querySelector(".tooltip")).toBeNull());
+  });
+
+  it("shows a tooltip on keyboard focus and clears it on blur", async () => {
+    const { container } = await renderMap({
+      activeStates: new Set(["Missouri"]),
+      raceCounts: { Missouri: 1 },
+    });
+    const path = pathFor(container, "Missouri")!;
+
+    await fireEvent.focus(path);
+    await fireEvent.blur(path);
+
+    await waitFor(() => expect(container.querySelector(".tooltip")).toBeNull());
+  });
+});

--- a/web/src/lib/components/ValidationGradeBadge.test.ts
+++ b/web/src/lib/components/ValidationGradeBadge.test.ts
@@ -1,0 +1,179 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ValidationGradeBadge from "./ValidationGradeBadge.svelte";
+import type { ValidationGrade } from "$lib/types";
+
+function makeGrade(overrides: Partial<ValidationGrade> = {}): ValidationGrade {
+  return {
+    grade: "A",
+    score: 92,
+    passed: true,
+    summary: "Sources are complete and consistent.",
+    ...overrides,
+  } as ValidationGrade;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("ValidationGradeBadge rendering", () => {
+  it("shows the grade letter and an accessible label", () => {
+    const { getByLabelText, container } = render(ValidationGradeBadge, {
+      grade: makeGrade({ grade: "B" }),
+    });
+
+    expect(getByLabelText("Automated Research Score: B")).toBeTruthy();
+    expect(container.textContent).toContain("B");
+    expect(container.textContent).toContain("Research score");
+  });
+
+  it.each([
+    ["A", "green"],
+    ["B", "blue"],
+    ["C", "yellow"],
+    ["D", "orange"],
+    ["F", "red"],
+  ])("colours grade %s with the %s ramp", (grade, hue) => {
+    const { container } = render(ValidationGradeBadge, {
+      grade: makeGrade({ grade: grade as ValidationGrade["grade"] }),
+    });
+
+    expect(container.querySelector(".grade-badge")?.className).toContain(hue);
+  });
+
+  it("falls back to a neutral style for an unrecognised grade", () => {
+    const { container } = render(ValidationGradeBadge, {
+      grade: makeGrade({ grade: "Z" as ValidationGrade["grade"] }),
+    });
+
+    const className = container.querySelector(".grade-badge")?.className ?? "";
+    expect(className).toContain("bg-surface-alt");
+  });
+
+  it("keeps the popover closed until asked", () => {
+    const { container } = render(ValidationGradeBadge, { grade: makeGrade() });
+
+    expect(container.querySelector(".popover")).toBeNull();
+  });
+});
+
+describe("ValidationGradeBadge popover", () => {
+  it("opens on click and shows the score, summary, and caveat", async () => {
+    const { container, getByLabelText } = render(ValidationGradeBadge, {
+      grade: makeGrade({ score: 74, summary: "Two issues lack sources." }),
+    });
+
+    await fireEvent.click(getByLabelText(/Automated Research Score/));
+
+    const popover = container.querySelector(".popover");
+    expect(popover).not.toBeNull();
+    expect(popover?.textContent).toContain("Score: 74/100");
+    expect(popover?.textContent).toContain("Two issues lack sources.");
+    // The caveat is the product's honesty disclaimer — it must not be quietly
+    // dropped. Collapse whitespace first: the source wraps mid-sentence, so
+    // textContent carries the newline and indentation.
+    const caveat = (popover?.textContent ?? "").replace(/\s+/g, " ");
+    expect(caveat).toContain("not a guarantee that every claim is correct");
+  });
+
+  it("toggles closed on a second click", async () => {
+    const { container, getByLabelText } = render(ValidationGradeBadge, {
+      grade: makeGrade(),
+    });
+    const badge = getByLabelText(/Automated Research Score/);
+
+    await fireEvent.click(badge);
+    expect(container.querySelector(".popover")).not.toBeNull();
+
+    await fireEvent.click(badge);
+    expect(container.querySelector(".popover")).toBeNull();
+  });
+
+  it("closes on Escape", async () => {
+    const { container, getByLabelText } = render(ValidationGradeBadge, {
+      grade: makeGrade(),
+    });
+    const badge = getByLabelText(/Automated Research Score/);
+
+    await fireEvent.click(badge);
+    expect(container.querySelector(".popover")).not.toBeNull();
+
+    await fireEvent.keyDown(badge, { key: "Escape" });
+    expect(container.querySelector(".popover")).toBeNull();
+  });
+
+  it("ignores other keys", async () => {
+    const { container, getByLabelText } = render(ValidationGradeBadge, {
+      grade: makeGrade(),
+    });
+    const badge = getByLabelText(/Automated Research Score/);
+
+    await fireEvent.click(badge);
+    await fireEvent.keyDown(badge, { key: "a" });
+
+    expect(container.querySelector(".popover")).not.toBeNull();
+  });
+
+  it("closes when the backdrop is clicked", async () => {
+    const { container, getByLabelText } = render(ValidationGradeBadge, {
+      grade: makeGrade(),
+    });
+
+    await fireEvent.click(getByLabelText(/Automated Research Score/));
+    const backdrop = container.querySelector(".popover-backdrop");
+    expect(backdrop).not.toBeNull();
+
+    await fireEvent.click(backdrop!);
+    expect(container.querySelector(".popover")).toBeNull();
+  });
+
+  it("repeats the grade inside the popover header", async () => {
+    const { container, getByLabelText } = render(ValidationGradeBadge, {
+      grade: makeGrade({ grade: "C" }),
+    });
+
+    await fireEvent.click(getByLabelText(/Automated Research Score/));
+
+    expect(container.querySelector(".popover-grade")?.textContent).toContain(
+      "C",
+    );
+  });
+});
+
+describe("ValidationGradeBadge review link", () => {
+  it("scrolls to the review section and closes the popover", async () => {
+    const target = document.createElement("div");
+    target.id = "ai-review";
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+    document.body.appendChild(target);
+
+    const { container, getByLabelText, getByText } = render(
+      ValidationGradeBadge,
+      { grade: makeGrade() },
+    );
+
+    await fireEvent.click(getByLabelText(/Automated Research Score/));
+    await fireEvent.click(getByText("View review details"));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+    expect(container.querySelector(".popover")).toBeNull();
+  });
+
+  // The badge renders on pages that have no review section; a missing anchor
+  // must close the popover rather than throw.
+  it("still closes cleanly when there is no review section on the page", async () => {
+    const { container, getByLabelText, getByText } = render(
+      ValidationGradeBadge,
+      { grade: makeGrade() },
+    );
+
+    await fireEvent.click(getByLabelText(/Automated Research Score/));
+    await fireEvent.click(getByText("View review details"));
+
+    expect(container.querySelector(".popover")).toBeNull();
+  });
+});

--- a/web/src/lib/components/VotingRecordTable.test.ts
+++ b/web/src/lib/components/VotingRecordTable.test.ts
@@ -1,0 +1,165 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import VotingRecordTable from "./VotingRecordTable.svelte";
+import type { Source } from "$lib/types";
+
+function source(url: string, title?: string): Source {
+  return {
+    url,
+    type: "website",
+    title,
+    last_accessed: "2026-01-01T00:00:00Z",
+  } as Source;
+}
+
+function renderTable(props: Record<string, unknown> = {}) {
+  return render(VotingRecordTable, {
+    votingSummary: "",
+    votingSourceUrl: "",
+    votingSources: [],
+    raceId: "mo-senate-2024",
+    candidateName: "Jane Doe",
+    ...props,
+  });
+}
+
+afterEach(cleanup);
+
+describe("VotingRecordTable empty state", () => {
+  it("falls back when there is neither a summary nor a source", () => {
+    const { container } = renderTable();
+
+    expect(container.querySelector(".voting-summary")).toBeNull();
+    expect(container.querySelector(".source-list")).toBeNull();
+  });
+
+  it("renders the summary alone when no sources exist", () => {
+    const { container } = renderTable({ votingSummary: "Voted for the bill." });
+
+    expect(container.textContent).toContain("Voted for the bill.");
+    expect(container.querySelector(".source-list")).toBeNull();
+  });
+
+  it("renders sources alone when there is no summary", () => {
+    const { container } = renderTable({
+      votingSourceUrl: "https://govtrack.us/x",
+    });
+
+    expect(container.querySelector(".source-list")).not.toBeNull();
+    expect(container.querySelector(".voting-summary")).toBeNull();
+  });
+});
+
+describe("VotingRecordTable inline-source handling", () => {
+  // Some records arrive with citations glued onto the end of the prose. The
+  // summary must render clean while those URLs still surface as real links.
+  it("strips a trailing 'Sources: <url>' block from the prose", () => {
+    const { container } = renderTable({
+      votingSummary:
+        "Consistently voted for expansion. Sources: https://govtrack.us/a https://congress.gov/b",
+    });
+
+    const summary = container.querySelector(".summary-text")?.textContent ?? "";
+    expect(summary).toBe("Consistently voted for expansion.");
+    expect(summary).not.toContain("http");
+  });
+
+  it("promotes inline URLs to source links", () => {
+    const { container } = renderTable({
+      votingSummary: "Voted yes. Sources: https://govtrack.us/a",
+    });
+
+    const links = Array.from(container.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(links).toContain("https://govtrack.us/a");
+  });
+
+  it("trims trailing punctuation off an extracted URL", () => {
+    const { container } = renderTable({
+      votingSummary: "See Sources: https://govtrack.us/a).",
+    });
+
+    const links = Array.from(container.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(links).toContain("https://govtrack.us/a");
+  });
+
+  it("leaves prose untouched when there is no source marker", () => {
+    const { container } = renderTable({
+      votingSummary: "No citations here at all.",
+    });
+
+    expect(container.querySelector(".summary-text")?.textContent).toBe(
+      "No citations here at all.",
+    );
+  });
+});
+
+describe("VotingRecordTable source links", () => {
+  it("labels the primary source url explicitly and lists it first", () => {
+    const { container } = renderTable({
+      votingSourceUrl: "https://govtrack.us/primary",
+      votingSources: [source("https://congress.gov/other", "Congress")],
+    });
+
+    const anchors = Array.from(container.querySelectorAll("a"));
+    expect(anchors[0].getAttribute("href")).toBe("https://govtrack.us/primary");
+    expect(anchors[0].textContent).toContain("View full voting record");
+  });
+
+  it("uses a source's own title when present", () => {
+    const { container } = renderTable({
+      votingSources: [source("https://congress.gov/x", "Congress.gov record")],
+    });
+
+    expect(container.textContent).toContain("Congress.gov record");
+  });
+
+  it("falls back to a bare hostname when a source has no title", () => {
+    const { container } = renderTable({
+      votingSources: [source("https://www.congress.gov/x")],
+    });
+
+    // www. is stripped so the label reads as a publisher, not a URL.
+    expect(container.textContent).toContain("congress.gov");
+    expect(container.textContent).not.toContain("www.congress.gov");
+  });
+
+  it("deduplicates a url that appears as both primary and listed source", () => {
+    const { container } = renderTable({
+      votingSourceUrl: "https://govtrack.us/same",
+      votingSources: [source("https://govtrack.us/same", "Duplicate")],
+    });
+
+    const hrefs = Array.from(container.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs.filter((h) => h === "https://govtrack.us/same")).toHaveLength(
+      1,
+    );
+    // The first-wins title is the explicit one.
+    expect(container.textContent).toContain("View full voting record");
+  });
+
+  it.each([
+    ["a relative path", "/internal/path"],
+    ["a javascript url", "javascript:alert(1)"],
+    ["an empty string", ""],
+  ])("rejects %s as a source", (_label, url) => {
+    const { container } = renderTable({ votingSourceUrl: url });
+
+    expect(container.querySelector(".source-list")).toBeNull();
+  });
+
+  it("opens external links safely in a new tab", () => {
+    const { container } = renderTable({
+      votingSourceUrl: "https://govtrack.us/x",
+    });
+
+    const anchor = container.querySelector("a")!;
+    expect(anchor.getAttribute("target")).toBe("_blank");
+    expect(anchor.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+});

--- a/web/src/lib/components/admin/CostsTab.test.ts
+++ b/web/src/lib/components/admin/CostsTab.test.ts
@@ -1,0 +1,286 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CostsTab from "./CostsTab.svelte";
+
+const { getPipelineMetricsSummary, getPipelineMetrics, getGcpCosts } =
+  vi.hoisted(() => ({
+    getPipelineMetricsSummary: vi.fn(),
+    getPipelineMetrics: vi.fn(),
+    getGcpCosts: vi.fn(),
+  }));
+
+vi.mock("$lib/services/analyticsService", () => ({
+  analyticsService: {
+    getPipelineMetricsSummary,
+    getPipelineMetrics,
+    getGcpCosts,
+  },
+}));
+
+const DAY_MS = 86_400_000;
+
+function record(overrides: Record<string, unknown> = {}) {
+  return {
+    race_id: "mo-senate-2024",
+    cost_usd: 1,
+    serper_calls: 0,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function setup({
+  summary = { total_usd: 100 },
+  windowSummary = { total_usd: 10 },
+  records = [] as ReturnType<typeof record>[],
+  gcp = { configured: true, total_net_usd: 5, by_service: [] } as {
+    configured: boolean;
+    total_net_usd?: number;
+    by_service?: unknown[];
+    reason?: string;
+  },
+} = {}) {
+  // First call is the all-time summary (no args), second is the window.
+  getPipelineMetricsSummary
+    .mockResolvedValueOnce(summary)
+    .mockResolvedValueOnce(windowSummary)
+    .mockResolvedValue(windowSummary);
+  getPipelineMetrics.mockResolvedValue({ records, count: records.length });
+  getGcpCosts.mockResolvedValue(gcp);
+}
+
+/** Wait for the initial onMount load to settle. */
+async function renderLoaded() {
+  const result = render(CostsTab);
+  await waitFor(() => expect(getGcpCosts).toHaveBeenCalled());
+  await waitFor(() =>
+    expect(result.container.textContent).not.toContain("Loading"),
+  );
+  return result;
+}
+
+function rangeButton(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+}
+
+beforeEach(() => {
+  getPipelineMetricsSummary.mockReset();
+  getPipelineMetrics.mockReset();
+  getGcpCosts.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("CostsTab loading", () => {
+  it("requests all four cost sources on mount", async () => {
+    setup();
+    await renderLoaded();
+
+    expect(getPipelineMetricsSummary).toHaveBeenCalledTimes(2);
+    // All-time summary takes no window; the second call scopes to 30 days.
+    expect(getPipelineMetricsSummary).toHaveBeenNthCalledWith(1);
+    expect(getPipelineMetricsSummary).toHaveBeenNthCalledWith(2, 30 * 24);
+    expect(getPipelineMetrics).toHaveBeenCalledWith(500);
+    expect(getGcpCosts).toHaveBeenCalledWith(30);
+  });
+
+  it("defaults to the 30 day window", async () => {
+    setup();
+    const { container } = await renderLoaded();
+
+    expect(rangeButton(container, "30d")?.className).toContain("bg-surface");
+  });
+
+  it.each([
+    ["7d", 7],
+    ["90d", 90],
+  ])("reloads scoped to %s when that range is chosen", async (label, days) => {
+    setup();
+    const { container } = await renderLoaded();
+    getGcpCosts.mockClear();
+    getPipelineMetrics.mockClear();
+
+    await fireEvent.click(rangeButton(container, label)!);
+
+    await waitFor(() => expect(getGcpCosts).toHaveBeenCalledWith(days));
+    expect(getPipelineMetrics).toHaveBeenCalledWith(500);
+  });
+
+  it("refetches on demand", async () => {
+    setup();
+    const { container } = await renderLoaded();
+    getGcpCosts.mockClear();
+
+    await fireEvent.click(rangeButton(container, "Refresh")!);
+
+    await waitFor(() => expect(getGcpCosts).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("CostsTab partial failure handling", () => {
+  // Promise.allSettled means one dead endpoint must not blank the whole tab.
+  it("reports how many cost requests failed", async () => {
+    getPipelineMetricsSummary.mockRejectedValue(new Error("down"));
+    getPipelineMetrics.mockResolvedValue({ records: [], count: 0 });
+    getGcpCosts.mockResolvedValue({ configured: true, total_net_usd: 0 });
+
+    const { container } = await renderLoaded();
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("2 cost requests failed"),
+    );
+  });
+
+  it("uses the singular form for a lone failure", async () => {
+    setup();
+    getPipelineMetrics.mockReset();
+    getPipelineMetrics.mockRejectedValue(new Error("down"));
+
+    const { container } = await renderLoaded();
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("1 cost request failed"),
+    );
+  });
+
+  it("treats a failed GCP call as 'not configured' rather than an error", async () => {
+    setup();
+    getGcpCosts.mockReset();
+    getGcpCosts.mockRejectedValue(new Error("no billing export"));
+
+    const { container } = await renderLoaded();
+
+    // A rejected GCP call must not count toward the failure banner.
+    expect(container.textContent).not.toContain("cost request");
+    expect(container.textContent).toContain("no billing export");
+  });
+
+  it("renders without error when everything resolves", async () => {
+    setup();
+    const { container } = await renderLoaded();
+
+    expect(container.textContent).not.toContain("cost requests failed");
+  });
+});
+
+describe("CostsTab cost arithmetic", () => {
+  it("estimates search spend from serper call volume", async () => {
+    setup({
+      records: [record({ serper_calls: 1500 }), record({ serper_calls: 500 })],
+    });
+    const { container } = await renderLoaded();
+
+    // 2,000 calls at $1 per 1,000 = $2.00
+    await waitFor(() => expect(container.textContent).toContain("$2.00"));
+  });
+
+  it("excludes records older than the selected window from the estimate", async () => {
+    setup({
+      records: [
+        record({ serper_calls: 1000 }),
+        record({
+          serper_calls: 5000,
+          timestamp: new Date(Date.now() - 60 * DAY_MS).toISOString(),
+        }),
+      ],
+    });
+    const { container } = await renderLoaded();
+
+    // Only the in-window 1,000 calls count: $1.00, not $6.00.
+    await waitFor(() => expect(container.textContent).toContain("$1.00"));
+    expect(container.textContent).not.toContain("$6.00");
+  });
+
+  // A record with no parseable timestamp is kept rather than silently dropped —
+  // losing spend from the total would understate the bill.
+  it("keeps records whose timestamp cannot be parsed", async () => {
+    setup({
+      records: [record({ serper_calls: 3000, timestamp: "not-a-date" })],
+    });
+    const { container } = await renderLoaded();
+
+    await waitFor(() => expect(container.textContent).toContain("$3.00"));
+  });
+
+  it("ranks the costliest races", async () => {
+    setup({
+      records: [
+        record({ race_id: "cheap", cost_usd: 1 }),
+        record({ race_id: "pricey", cost_usd: 7 }),
+        record({ race_id: "pricey", cost_usd: 3 }),
+      ],
+    });
+    const { container } = await renderLoaded();
+
+    await waitFor(() => expect(container.textContent).toContain("pricey"));
+    const text = container.textContent ?? "";
+    expect(text.indexOf("pricey")).toBeLessThan(text.indexOf("cheap"));
+    // 7 + 3 summed into one row.
+    expect(text).toContain("$10.00");
+  });
+
+  it("falls back to the estimate when a run has no billed cost", async () => {
+    setup({
+      records: [
+        record({ race_id: "est", cost_usd: undefined, estimated_usd: 4 }),
+      ],
+    });
+    const { container } = await renderLoaded();
+
+    await waitFor(() => expect(container.textContent).toContain("$4.00"));
+  });
+
+  it("treats a run with neither cost as zero", async () => {
+    setup({
+      records: [
+        record({
+          race_id: "free",
+          cost_usd: undefined,
+          estimated_usd: undefined,
+        }),
+      ],
+    });
+    const { container } = await renderLoaded();
+
+    await waitFor(() => expect(container.textContent).toContain("free"));
+    expect(container.textContent).toContain("$0.00");
+  });
+
+  it("ignores records with no race id when ranking", async () => {
+    setup({
+      records: [
+        record({ race_id: undefined, cost_usd: 99 }),
+        record({ race_id: "named", cost_usd: 1 }),
+      ],
+    });
+    const { container } = await renderLoaded();
+
+    await waitFor(() => expect(container.textContent).toContain("named"));
+    expect(container.textContent).not.toContain("$99.00");
+  });
+
+  it("adds pipeline, search, and GCP spend into one figure", async () => {
+    setup({
+      windowSummary: { total_usd: 10 },
+      records: [record({ serper_calls: 2000, cost_usd: 0 })],
+      gcp: { configured: true, total_net_usd: 5, by_service: [] },
+    });
+    const { container } = await renderLoaded();
+
+    // 10 pipeline + 2 search + 5 GCP = 17
+    await waitFor(() => expect(container.textContent).toContain("$17.00"));
+  });
+
+  it("omits GCP spend from the total when billing export is off", async () => {
+    setup({
+      windowSummary: { total_usd: 10 },
+      records: [record({ serper_calls: 2000, cost_usd: 0 })],
+      gcp: { configured: false, reason: "not enabled" },
+    });
+    const { container } = await renderLoaded();
+
+    await waitFor(() => expect(container.textContent).toContain("$12.00"));
+  });
+});

--- a/web/src/lib/components/admin/DashboardTab.refresh.test.ts
+++ b/web/src/lib/components/admin/DashboardTab.refresh.test.ts
@@ -1,0 +1,275 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PipelineApiService } from "$lib/services/pipelineApiService";
+
+/**
+ * Complements `DashboardTab.test.ts` (which covers the stat cards) with the
+ * refresh machinery: range switching, in-flight de-duplication, partial-failure
+ * handling, per-race traffic aggregation, and the visibility/interval lifecycle.
+ *
+ * NOTE ON MOCK SHAPE: the sibling file uses `vi.doMock` + dynamic import, which
+ * only works because it contains a single test. Repeating it here fails two
+ * ways — without `vi.resetModules()` the component keeps the first test's spies
+ * and every later assertion sees an uncalled mock; *with* resetModules Svelte 5
+ * throws `effect_orphan`, because the re-imported component gets a different
+ * copy of the Svelte runtime than the render context.
+ *
+ * So the service object is created once and hoisted, and only its methods are
+ * reset per test. The component's import binding stays valid throughout.
+ */
+const { analyticsService } = vi.hoisted(() => ({
+  analyticsService: {
+    getOverview: vi.fn(),
+    getTraffic: vi.fn(),
+    getRaces: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/services/analyticsService", () => ({ analyticsService }));
+
+import DashboardTab from "./DashboardTab.svelte";
+
+function overviewPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    total_requests: 10,
+    unique_visitors: 5,
+    avg_latency_ms: 25,
+    error_rate: 0,
+    error_count: 0,
+    timeseries: [],
+    hours: 24,
+    ...overrides,
+  };
+}
+
+function trafficPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    configured: true,
+    provider: "cloudflare",
+    hours: 24,
+    pageviews: 100,
+    visits: 50,
+    pages_per_visit: 2,
+    timeseries: [],
+    top_pages: [],
+    top_referrers: [],
+    countries: [],
+    devices: [],
+    fetched_at: "2026-06-13T00:00:00Z",
+    error: null,
+    ...overrides,
+  };
+}
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+}
+
+beforeEach(() => {
+  setHidden(false);
+  analyticsService.getOverview.mockReset().mockResolvedValue(overviewPayload());
+  analyticsService.getTraffic.mockReset().mockResolvedValue(trafficPayload());
+  analyticsService.getRaces.mockReset().mockResolvedValue({ races: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+async function renderDashboard(
+  apiService: Partial<PipelineApiService> | undefined = {
+    listRaces: vi.fn().mockResolvedValue([]),
+  } as unknown as PipelineApiService,
+) {
+  const result = render(DashboardTab, {
+    props: { apiService: apiService as PipelineApiService },
+  });
+  await waitFor(() => expect(analyticsService.getOverview).toHaveBeenCalled());
+  return result;
+}
+
+function rangeButton(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+}
+
+describe("DashboardTab time ranges", () => {
+  it("loads the 24 hour window on mount", async () => {
+    await renderDashboard();
+
+    expect(analyticsService.getOverview).toHaveBeenCalledWith(24);
+    expect(analyticsService.getTraffic).toHaveBeenCalledWith(24);
+  });
+
+  it.each([
+    ["1h", 1],
+    ["6h", 6],
+    ["7d", 168],
+    ["30d", 720],
+  ])("reloads with %s selected", async (label, hours) => {
+    const { container } = await renderDashboard();
+    analyticsService.getOverview.mockClear();
+
+    await fireEvent.click(rangeButton(container, label)!);
+
+    await waitFor(() =>
+      expect(analyticsService.getOverview).toHaveBeenCalledWith(hours),
+    );
+  });
+
+  it("highlights the active range", async () => {
+    const { container } = await renderDashboard();
+
+    await fireEvent.click(rangeButton(container, "6h")!);
+
+    await waitFor(() =>
+      expect(rangeButton(container, "6h")?.className).toContain("bg-surface"),
+    );
+  });
+});
+
+describe("DashboardTab request de-duplication", () => {
+  // Two refreshes racing (the 5-minute interval and a manual click, say) must
+  // not double-fetch — loadData hands back the in-flight promise rather than
+  // starting a second pass.
+  it("collapses concurrent refreshes into one request pass", async () => {
+    const { component } = await renderDashboard();
+
+    // Stall only *after* mount has settled, so the pending call under test is
+    // the one the two refreshes share rather than the mount's own.
+    let release: (v: unknown) => void = () => {};
+    analyticsService.getOverview.mockClear();
+    analyticsService.getOverview.mockImplementation(
+      () => new Promise((resolve) => (release = resolve)),
+    );
+
+    const first = component.refresh();
+    const second = component.refresh();
+    release(overviewPayload());
+    await Promise.all([first, second]);
+
+    expect(analyticsService.getOverview).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DashboardTab partial failures", () => {
+  it("reports a failed overview request", async () => {
+    analyticsService.getOverview.mockRejectedValue(new Error("down"));
+    const { container } = await renderDashboard();
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("1 dashboard request failed"),
+    );
+  });
+
+  // A dead Cloudflare integration is a normal state, not a dashboard error —
+  // it synthesises an "unconfigured" payload carrying the reason.
+  it("treats a failed traffic request as unconfigured rather than an error", async () => {
+    analyticsService.getTraffic.mockRejectedValue(new Error("no cf token"));
+    const { container } = await renderDashboard();
+
+    await waitFor(() => expect(container.textContent).toContain("no cf token"));
+    expect(container.textContent).not.toContain("dashboard request failed");
+  });
+
+  it("survives an apiService that cannot list races", async () => {
+    const listRaces = vi.fn().mockRejectedValue(new Error("api down"));
+    const { container } = await renderDashboard({
+      listRaces,
+    } as unknown as PipelineApiService);
+
+    await waitFor(() => expect(listRaces).toHaveBeenCalled());
+    // The failure is swallowed as non-critical; the dashboard still renders.
+    expect(container.textContent).not.toContain("api down");
+  });
+
+  it("works with no apiService at all", async () => {
+    const { container } = await renderDashboard(undefined);
+
+    await waitFor(() => expect(analyticsService.getTraffic).toHaveBeenCalled());
+    expect(container.querySelector("button")).not.toBeNull();
+  });
+});
+
+/**
+ * NOT TESTED HERE: `aggregateRaceTraffic`, which groups top_pages into per-race
+ * view counts. Its only consumer is the `<Doughnut>` dataset, so the aggregated
+ * ids and totals never reach the DOM as text — and once the dataset is
+ * non-empty, chart.js tries to acquire a canvas context and throws in jsdom
+ * ("Cannot read properties of null (reading 'ownerDocument')").
+ *
+ * The logic is worth covering and currently cannot be, because it is a private
+ * function feeding a canvas. Extracting it to `$lib/utils` would make it
+ * directly unit-testable; that is a source change rather than a test one, so it
+ * is flagged rather than done here. What is asserted below is the surrounding
+ * lifecycle, which is observable.
+ */
+
+describe("DashboardTab background refresh", () => {
+  it("skips the periodic refresh while the tab is hidden", async () => {
+    vi.useFakeTimers();
+    await renderDashboard();
+    analyticsService.getOverview.mockClear();
+    setHidden(true);
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    expect(analyticsService.getOverview).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on the interval while visible", async () => {
+    vi.useFakeTimers();
+    await renderDashboard();
+    analyticsService.getOverview.mockClear();
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    expect(analyticsService.getOverview).toHaveBeenCalled();
+  });
+
+  it("refreshes as soon as the tab becomes visible again", async () => {
+    await renderDashboard();
+    analyticsService.getOverview.mockClear();
+
+    setHidden(false);
+    await fireEvent(document, new Event("visibilitychange"));
+
+    await waitFor(() =>
+      expect(analyticsService.getOverview).toHaveBeenCalled(),
+    );
+  });
+
+  it("does not refresh on a visibility event that hid the tab", async () => {
+    await renderDashboard();
+    analyticsService.getOverview.mockClear();
+
+    setHidden(true);
+    await fireEvent(document, new Event("visibilitychange"));
+
+    expect(analyticsService.getOverview).not.toHaveBeenCalled();
+  });
+
+  // Leaving an interval or listener behind would keep polling the analytics API
+  // after the admin navigates away from this tab.
+  it("tears down its timer and listener on destroy", async () => {
+    vi.useFakeTimers();
+    const removeListener = vi.spyOn(document, "removeEventListener");
+    const { unmount } = await renderDashboard();
+    analyticsService.getOverview.mockClear();
+
+    unmount();
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(analyticsService.getOverview).not.toHaveBeenCalled();
+    expect(removeListener).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+});

--- a/web/src/lib/components/admin/ForecastsTab.test.ts
+++ b/web/src/lib/components/admin/ForecastsTab.test.ts
@@ -1,0 +1,288 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ForecastsTab from "./ForecastsTab.svelte";
+import type { PipelineApiService } from "$lib/services/pipelineApiService";
+
+/**
+ * ForecastsTab receives its service as a prop, so no module mocking is needed —
+ * a plain stub object is enough. Every destructive action is behind a
+ * `confirm()`, so that global is stubbed per-test and its return value is part
+ * of the behaviour under test.
+ */
+function makeService(overrides: Record<string, unknown> = {}) {
+  return {
+    getPublishedChamberForecasts: vi.fn().mockResolvedValue(forecasts("pub")),
+    getChamberForecastDraft: vi.fn().mockResolvedValue(forecasts("draft")),
+    generateChamberForecastDraft: vi
+      .fn()
+      .mockResolvedValue({ forecast: forecasts("generated") }),
+    publishChamberForecastDraft: vi.fn().mockResolvedValue({ message: "ok" }),
+    ...overrides,
+  } as unknown as PipelineApiService;
+}
+
+// The panels render `chambers[chamber].narrative`, not the top-level
+// house/senate/governors strings — those are the v1 shape. Tag the chamber
+// narrative so assertions can tell published from draft from generated.
+function forecasts(tag: string) {
+  const chamber = (name: string) => ({
+    narrative: `${tag} ${name} narrative`,
+    control_party: "Democratic",
+    control_probability: 0.6,
+    projected_seats: { Democratic: 0, Republican: 0 },
+    expected_seats: { Democratic: 0, Republican: 0 },
+    bottom_line: `${tag} ${name} bottom line`,
+    why_party_favored: "",
+    tossup_count: 0,
+    competitive_race_count: 0,
+  });
+  return {
+    schema_version: "chamber_forecasts.v2",
+    updated_at: "2026-01-15T00:00:00Z",
+    house: `${tag} house summary`,
+    senate: `${tag} senate summary`,
+    governors: `${tag} governors summary`,
+    chambers: {
+      house: chamber("house"),
+      senate: chamber("senate"),
+      governors: chamber("governors"),
+    },
+  };
+}
+
+function renderTab(apiService = makeService()) {
+  const result = render(ForecastsTab, { apiService });
+  return { ...result, apiService };
+}
+
+async function renderLoaded(apiService = makeService()) {
+  const result = renderTab(apiService);
+  await waitFor(() =>
+    expect(apiService.getChamberForecastDraft).toHaveBeenCalled(),
+  );
+  return result;
+}
+
+function button(container: HTMLElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.toLowerCase().includes(label.toLowerCase()),
+  );
+}
+
+function allowConfirm(value: boolean) {
+  vi.stubGlobal(
+    "confirm",
+    vi.fn(() => value),
+  );
+}
+
+beforeEach(() => {
+  allowConfirm(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("ForecastsTab loading", () => {
+  it("loads published and draft forecasts on mount", async () => {
+    const { apiService, container } = await renderLoaded();
+
+    expect(apiService.getPublishedChamberForecasts).toHaveBeenCalledTimes(1);
+    expect(apiService.getChamberForecastDraft).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(container.textContent).toContain("pub house narrative"),
+    );
+    expect(container.textContent).toContain("draft house narrative");
+  });
+
+  // allSettled: a missing draft is the normal state before anyone generates one.
+  it("still shows the published forecast when no draft exists", async () => {
+    const service = makeService({
+      getChamberForecastDraft: vi.fn().mockRejectedValue(new Error("404")),
+    });
+    const { container } = await renderLoaded(service);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("pub house narrative"),
+    );
+    expect(container.textContent).not.toContain("draft house narrative");
+  });
+
+  it("still shows a draft when nothing is published yet", async () => {
+    const service = makeService({
+      getPublishedChamberForecasts: vi.fn().mockRejectedValue(new Error("404")),
+    });
+    const { container } = await renderLoaded(service);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("draft house narrative"),
+    );
+    expect(container.textContent).not.toContain("pub house narrative");
+  });
+
+  it("survives both sources failing", async () => {
+    const service = makeService({
+      getPublishedChamberForecasts: vi.fn().mockRejectedValue(new Error("x")),
+      getChamberForecastDraft: vi.fn().mockRejectedValue(new Error("y")),
+    });
+    const { container } = await renderLoaded(service);
+
+    await waitFor(() => expect(container.textContent).not.toContain("Loading"));
+    expect(container.textContent).not.toContain("narrative");
+  });
+
+  it("reloads on demand", async () => {
+    const { apiService, container } = await renderLoaded();
+
+    const refresh = container.querySelector(
+      '[aria-label="Refresh forecasts"]',
+    ) as HTMLElement;
+    await fireEvent.click(refresh);
+
+    await waitFor(() =>
+      expect(apiService.getChamberForecastDraft).toHaveBeenCalledTimes(2),
+    );
+  });
+});
+
+describe("ForecastsTab draft generation", () => {
+  it("asks before spending on a generation", async () => {
+    allowConfirm(false);
+    const { apiService, container } = await renderLoaded();
+
+    await fireEvent.click(button(container, "Generate")!);
+
+    expect(apiService.generateChamberForecastDraft).not.toHaveBeenCalled();
+  });
+
+  // The model box is intentionally blank so the server's default applies —
+  // keeping a model id in the browser is what let this control drift stale.
+  it("sends an empty model so the server default wins", async () => {
+    const { apiService, container } = await renderLoaded();
+
+    await fireEvent.click(button(container, "Generate")!);
+
+    await waitFor(() =>
+      expect(apiService.generateChamberForecastDraft).toHaveBeenCalledWith(""),
+    );
+  });
+
+  it("forwards an explicitly chosen model", async () => {
+    const { apiService, container } = await renderLoaded();
+    const input = container.querySelector("#model-select") as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: "some/model" } });
+    await fireEvent.click(button(container, "Generate")!);
+
+    await waitFor(() =>
+      expect(apiService.generateChamberForecastDraft).toHaveBeenCalledWith(
+        "some/model",
+      ),
+    );
+  });
+
+  it("swaps in the newly generated draft and says so", async () => {
+    const { container } = await renderLoaded();
+
+    await fireEvent.click(button(container, "Generate")!);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("generated house narrative"),
+    );
+    expect(container.textContent).toContain(
+      "Generated a new chamber forecast draft.",
+    );
+  });
+
+  it("surfaces a generation failure without wiping the existing draft", async () => {
+    const service = makeService({
+      generateChamberForecastDraft: vi
+        .fn()
+        .mockRejectedValue(new Error("model unavailable")),
+    });
+    const { container } = await renderLoaded(service);
+
+    await fireEvent.click(button(container, "Generate")!);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain(
+        "Generate failed: model unavailable",
+      ),
+    );
+    expect(container.textContent).toContain("draft house narrative");
+  });
+
+  it("describes a non-Error rejection rather than dropping it", async () => {
+    const service = makeService({
+      generateChamberForecastDraft: vi.fn().mockRejectedValue("plain string"),
+    });
+    const { container } = await renderLoaded(service);
+
+    await fireEvent.click(button(container, "Generate")!);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("Generate failed: plain string"),
+    );
+  });
+});
+
+describe("ForecastsTab publishing", () => {
+  it("asks before publishing", async () => {
+    allowConfirm(false);
+    const { apiService, container } = await renderLoaded();
+
+    await fireEvent.click(button(container, "Publish")!);
+
+    expect(apiService.publishChamberForecastDraft).not.toHaveBeenCalled();
+  });
+
+  it("publishes and then refetches so the published pane is current", async () => {
+    const { apiService, container } = await renderLoaded();
+
+    await fireEvent.click(button(container, "Publish")!);
+
+    await waitFor(() =>
+      expect(apiService.publishChamberForecastDraft).toHaveBeenCalledTimes(1),
+    );
+    // A reload follows the publish, so the loaders run a second time.
+    await waitFor(() =>
+      expect(apiService.getPublishedChamberForecasts).toHaveBeenCalledTimes(2),
+    );
+    expect(container.textContent).toContain(
+      "Chamber forecast draft published.",
+    );
+  });
+
+  it("surfaces a publish failure", async () => {
+    const service = makeService({
+      publishChamberForecastDraft: vi
+        .fn()
+        .mockRejectedValue(new Error("no draft to publish")),
+    });
+    const { container } = await renderLoaded(service);
+
+    await fireEvent.click(button(container, "Publish")!);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain(
+        "Publish failed: no draft to publish",
+      ),
+    );
+  });
+
+  it("does not reload when the publish itself failed", async () => {
+    const service = makeService({
+      publishChamberForecastDraft: vi.fn().mockRejectedValue(new Error("nope")),
+    });
+    const { apiService, container } = await renderLoaded(service);
+
+    await fireEvent.click(button(container, "Publish")!);
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("Publish failed"),
+    );
+    expect(apiService.getPublishedChamberForecasts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/components/admin/RacesTab.filters.test.ts
+++ b/web/src/lib/components/admin/RacesTab.filters.test.ts
@@ -1,0 +1,288 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RaceRecord } from "$lib/types";
+
+/**
+ * Covers the table's filtering surface — the global search box, the status
+ * dropdown, and the quality-grade badge — which `RacesTab.status-flow.test.ts`
+ * does not touch.
+ *
+ * The service mock is hoisted and created once. The sibling file achieves the
+ * same thing with `mockFetchWithAuth ??= vi.fn()` inside `beforeEach`; both work
+ * because the component binds the mock at import time and the *object identity*
+ * has to survive across tests. Reassigning a fresh `vi.fn()` each time silently
+ * detaches the spy the component actually calls.
+ */
+const { fetchWithAuth } = vi.hoisted(() => ({ fetchWithAuth: vi.fn() }));
+vi.mock("$lib/stores/apiStore", () => ({ fetchWithAuth }));
+
+import RacesTab from "./RacesTab.svelte";
+
+function makeRace(overrides: Partial<RaceRecord> = {}): RaceRecord {
+  return {
+    race_id: "ga-senate-2026",
+    title: "Georgia Senate 2026",
+    office: "Senate",
+    jurisdiction: "Georgia",
+    election_date: "2026-11-03",
+    status: "empty",
+    published_at: undefined,
+    draft_updated_at: undefined,
+    candidate_count: 2,
+    freshness: "recent",
+    total_runs: 0,
+    requests_24h: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+let rows: RaceRecord[] = [];
+
+async function renderTab() {
+  const result = render(RacesTab);
+  await result.component.refresh();
+  await waitFor(() => expect(fetchWithAuth).toHaveBeenCalled());
+  return result;
+}
+
+function searchBox(container: HTMLElement) {
+  return container.querySelector(
+    'input[placeholder="Search visible races..."]',
+  ) as HTMLInputElement;
+}
+
+function statusSelect(container: HTMLElement) {
+  return container.querySelector(
+    '[aria-label="Filter by status"]',
+  ) as HTMLSelectElement;
+}
+
+beforeEach(() => {
+  rows = [];
+  fetchWithAuth.mockReset();
+  fetchWithAuth.mockImplementation(async () => jsonResponse({ races: rows }));
+  vi.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("RacesTab global search", () => {
+  beforeEach(() => {
+    rows = [
+      // Distinct titles matter: makeRace defaults every row to the same title,
+      // so leaving it would make "georgia" match both and the filter look broken.
+      makeRace({
+        race_id: "ga-senate-2026",
+        title: "Georgia Senate 2026",
+        jurisdiction: "Georgia",
+      }),
+      makeRace({
+        race_id: "ca-house-12",
+        title: "California House 12",
+        jurisdiction: "California",
+      }),
+    ];
+  });
+
+  it("shows every race before filtering", async () => {
+    const { container } = await renderTab();
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("ga-senate-2026"),
+    );
+    expect(container.textContent).toContain("ca-house-12");
+  });
+
+  it("narrows the table to matching races", async () => {
+    const { container } = await renderTab();
+    await waitFor(() => expect(container.textContent).toContain("ca-house-12"));
+
+    await fireEvent.input(searchBox(container), {
+      target: { value: "georgia" },
+    });
+
+    await waitFor(() =>
+      expect(container.textContent).not.toContain("ca-house-12"),
+    );
+    expect(container.textContent).toContain("ga-senate-2026");
+  });
+
+  // `normalize` lower-cases and trims, so search is forgiving of both.
+  it.each([
+    ["upper case", "GEORGIA"],
+    ["surrounding whitespace", "  georgia  "],
+  ])("matches despite %s", async (_label, needle) => {
+    const { container } = await renderTab();
+    await waitFor(() => expect(container.textContent).toContain("ca-house-12"));
+
+    await fireEvent.input(searchBox(container), { target: { value: needle } });
+
+    await waitFor(() =>
+      expect(container.textContent).not.toContain("ca-house-12"),
+    );
+  });
+
+  it("restores every race when the search is cleared", async () => {
+    const { container } = await renderTab();
+
+    await fireEvent.input(searchBox(container), {
+      target: { value: "georgia" },
+    });
+    await waitFor(() =>
+      expect(container.textContent).not.toContain("ca-house-12"),
+    );
+
+    await fireEvent.input(searchBox(container), { target: { value: "" } });
+
+    await waitFor(() => expect(container.textContent).toContain("ca-house-12"));
+  });
+
+  it("shows nothing when the search matches no race", async () => {
+    const { container } = await renderTab();
+
+    await fireEvent.input(searchBox(container), {
+      target: { value: "zzzz-no-match" },
+    });
+
+    await waitFor(() =>
+      expect(container.textContent).not.toContain("ga-senate-2026"),
+    );
+  });
+});
+
+describe("RacesTab status filter", () => {
+  beforeEach(() => {
+    rows = [
+      makeRace({ race_id: "published-race", status: "published" }),
+      makeRace({ race_id: "draft-race", status: "draft" }),
+    ];
+  });
+
+  it("filters down to a single status", async () => {
+    const { container } = await renderTab();
+    await waitFor(() => expect(container.textContent).toContain("draft-race"));
+
+    await fireEvent.change(statusSelect(container), {
+      target: { value: "published" },
+    });
+
+    await waitFor(() =>
+      expect(container.textContent).not.toContain("draft-race"),
+    );
+    expect(container.textContent).toContain("published-race");
+  });
+
+  // "all" clears the column filter rather than filtering on the literal
+  // string "all", which would match nothing.
+  it("restores every race when set back to all", async () => {
+    const { container } = await renderTab();
+
+    await fireEvent.change(statusSelect(container), {
+      target: { value: "published" },
+    });
+    await waitFor(() =>
+      expect(container.textContent).not.toContain("draft-race"),
+    );
+
+    await fireEvent.change(statusSelect(container), {
+      target: { value: "all" },
+    });
+
+    await waitFor(() => expect(container.textContent).toContain("draft-race"));
+  });
+
+  it("combines the status filter with the search box", async () => {
+    rows = [
+      makeRace({
+        race_id: "ga-published",
+        title: "Georgia Senate 2026",
+        status: "published",
+        jurisdiction: "Georgia",
+      }),
+      makeRace({
+        race_id: "ca-published",
+        title: "California House 12",
+        status: "published",
+        jurisdiction: "California",
+      }),
+      makeRace({
+        race_id: "ga-draft",
+        title: "Georgia House 4",
+        status: "draft",
+        jurisdiction: "Georgia",
+      }),
+    ];
+    const { container } = await renderTab();
+
+    await fireEvent.change(statusSelect(container), {
+      target: { value: "published" },
+    });
+    await fireEvent.input(searchBox(container), {
+      target: { value: "georgia" },
+    });
+
+    await waitFor(() =>
+      expect(container.textContent).toContain("ga-published"),
+    );
+    expect(container.textContent).not.toContain("ca-published");
+    expect(container.textContent).not.toContain("ga-draft");
+  });
+});
+
+describe("RacesTab quality grade badge", () => {
+  it.each([
+    ["A", "green"],
+    ["B", "yellow"],
+    ["C", "orange"],
+    ["D", "red"],
+    ["F", "red"],
+  ])("colours grade %s with the %s ramp", async (grade, hue) => {
+    rows = [
+      makeRace({
+        race_id: "graded",
+        quality_grade: grade as RaceRecord["quality_grade"],
+      }),
+    ];
+    const { container } = await renderTab();
+
+    const badge = await waitFor(() => {
+      const el = Array.from(container.querySelectorAll("span")).find(
+        (s) =>
+          s.textContent?.trim() === grade &&
+          s.className.includes("rounded-full"),
+      );
+      expect(el).toBeTruthy();
+      return el!;
+    });
+
+    expect(badge.className).toContain(hue);
+  });
+
+  it("renders no badge for an ungraded race", async () => {
+    rows = [makeRace({ race_id: "ungraded", quality_grade: undefined })];
+    const { container } = await renderTab();
+
+    await waitFor(() => expect(container.textContent).toContain("ungraded"));
+    const badge = Array.from(container.querySelectorAll("span")).find(
+      (s) =>
+        s.className.includes("rounded-full") &&
+        ["A", "B", "C", "D", "F"].includes(s.textContent?.trim() ?? ""),
+    );
+    expect(badge).toBeUndefined();
+  });
+});

--- a/web/src/lib/components/compare/CandidateComparison.logic.test.ts
+++ b/web/src/lib/components/compare/CandidateComparison.logic.test.ts
@@ -1,0 +1,326 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Candidate, IssueStance, Race, RaceForecast } from "$lib/types";
+import CandidateComparison from "./CandidateComparison.svelte";
+
+/**
+ * Complements `CandidateComparison.test.ts` (stance previews, sticky labels,
+ * review banner) with the derived logic: the candidate picker, compact-mode
+ * issue selection, avatar fallback, and forecast probability matching.
+ */
+function candidate(
+  name: string,
+  overrides: Partial<Candidate> = {},
+): Candidate {
+  return {
+    name,
+    party: "Independent",
+    incumbent: false,
+    summary: `${name} summary`,
+    summary_sources: [],
+    issues: {},
+    career_history: [],
+    education: [],
+    links: [],
+    social_media: {},
+    roster_sources: [],
+    voting_sources: [],
+    donor_sources: [],
+    withdrawn: false,
+    ...overrides,
+  } as Candidate;
+}
+
+function race(overrides: Partial<Race> = {}): Race {
+  return {
+    schema_version: "0.3",
+    id: "test-race-2026",
+    title: "Test Race",
+    office: "U.S. Senate",
+    election_date: "2026-11-03",
+    contest_stage: "unknown",
+    updated_utc: "2026-07-01T00:00:00Z",
+    generator: [],
+    polling: [],
+    reviews: [],
+    candidates: [],
+    ...overrides,
+  } as Race;
+}
+
+function sourced(stance: string): IssueStance {
+  return {
+    stance,
+    confidence: "high",
+    sources: [
+      {
+        url: "https://example.test/a",
+        type: "website",
+        title: "Source",
+        last_accessed: "2026-01-01T00:00:00Z",
+        is_fresh: true,
+      },
+    ],
+  };
+}
+
+function checkboxes(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+  );
+}
+
+afterEach(cleanup);
+
+describe("CandidateComparison candidate picker", () => {
+  it("is absent unless a toggle handler is supplied", () => {
+    const jane = candidate("Jane Doe");
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane] }),
+      candidates: [jane],
+    });
+
+    expect(checkboxes(container)).toHaveLength(0);
+  });
+
+  it("offers a checkbox per candidate when a handler is supplied", () => {
+    const jane = candidate("Jane Doe");
+    const john = candidate("John Roe");
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane, john] }),
+      candidates: [jane],
+      onToggle: vi.fn(),
+    });
+
+    expect(checkboxes(container)).toHaveLength(2);
+  });
+
+  it("checks only the candidates currently being compared", () => {
+    const jane = candidate("Jane Doe");
+    const john = candidate("John Roe");
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane, john] }),
+      candidates: [jane],
+      onToggle: vi.fn(),
+    });
+
+    const [first, second] = checkboxes(container);
+    expect(first.checked).toBe(true);
+    expect(second.checked).toBe(false);
+  });
+
+  // A withdrawn candidate stays in race.candidates so their data is preserved,
+  // but offering them as a comparison target would be misleading.
+  it("omits withdrawn candidates from the picker", () => {
+    const jane = candidate("Jane Doe");
+    const gone = candidate("Gone Away", { withdrawn: true });
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane, gone] }),
+      candidates: [jane],
+      onToggle: vi.fn(),
+    });
+
+    expect(checkboxes(container)).toHaveLength(1);
+    expect(container.textContent).not.toContain("Gone Away");
+  });
+
+  it("reports the candidate name when a box is toggled", async () => {
+    const onToggle = vi.fn();
+    const jane = candidate("Jane Doe");
+    const john = candidate("John Roe");
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane, john] }),
+      candidates: [jane],
+      onToggle,
+    });
+
+    await fireEvent.change(checkboxes(container)[1]);
+
+    expect(onToggle).toHaveBeenCalledWith("John Roe");
+  });
+});
+
+describe("CandidateComparison compact mode", () => {
+  const withIssues = candidate("Jane Doe", {
+    issues: {
+      Healthcare: sourced("Healthcare stance"),
+      Economy: sourced("Economy stance"),
+      Immigration: sourced("Immigration stance"),
+      Education: sourced("Education stance"),
+      "Tech & AI": sourced("Tech stance"),
+      // Present but unsourced — compact mode should skip it.
+      "Foreign Policy": {
+        stance: "Unsourced stance",
+        confidence: "low",
+        sources: [],
+      },
+    } as Candidate["issues"],
+  });
+
+  it("shows every canonical issue in full mode", () => {
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [withIssues] }),
+      candidates: [withIssues],
+    });
+
+    // Full mode includes issues with no data at all, e.g. Local Issues.
+    expect(container.textContent).toContain("Local Issues");
+  });
+
+  it("limits compact mode to four issues", () => {
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [withIssues] }),
+      candidates: [withIssues],
+      compact: true,
+    });
+
+    expect(container.textContent).not.toContain("Local Issues");
+  });
+
+  // Compact mode is for previews, so it only surfaces issues backed by a
+  // source — an unsourced stance would look like researched data.
+  it("skips issues whose stance has no sources", () => {
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [withIssues] }),
+      candidates: [withIssues],
+      compact: true,
+    });
+
+    expect(container.textContent).not.toContain("Unsourced stance");
+  });
+});
+
+describe("CandidateComparison avatars", () => {
+  it("shows the headshot when one is available", () => {
+    const jane = candidate("Jane Doe", {
+      image_url: "https://example.test/jane.jpg",
+    });
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane] }),
+      candidates: [jane],
+    });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.test/jane.jpg",
+    );
+  });
+
+  it("falls back to two initials when there is no headshot", () => {
+    const jane = candidate("Jane Doe");
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane] }),
+      candidates: [jane],
+    });
+
+    expect(container.textContent).toContain("JD");
+  });
+
+  it("uses at most two initials for a long name", () => {
+    const person = candidate("Ana Maria Gomez Ruiz");
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [person] }),
+      candidates: [person],
+    });
+
+    expect(container.textContent).toContain("AM");
+    expect(container.textContent).not.toContain("AMGR");
+  });
+
+  // The desktop table and the embedded MobileCandidateComparison each render
+  // their own <img> with independent failure state, so a dead headshot has to
+  // be reported to both before the fallback is complete.
+  it("swaps to initials when the headshot fails to load", async () => {
+    const jane = candidate("Jane Doe", {
+      image_url: "https://example.test/broken.jpg",
+    });
+    const { container } = render(CandidateComparison, {
+      race: race({ candidates: [jane] }),
+      candidates: [jane],
+    });
+
+    const images = Array.from(container.querySelectorAll("img"));
+    expect(images.length).toBeGreaterThan(0);
+    for (const image of images) await fireEvent.error(image);
+
+    expect(container.querySelectorAll("img")).toHaveLength(0);
+    expect(container.textContent).toContain("JD");
+  });
+});
+
+describe("CandidateComparison forecast probability", () => {
+  const jane = candidate("Jane Doe", { party: "Democratic" });
+
+  function renderWithForecast(overrides: Partial<RaceForecast> | undefined) {
+    const forecast: RaceForecast | undefined = overrides
+      ? {
+          party_probabilities: {},
+          rating: "tossup",
+          confidence: "medium",
+          rationale: "Test rationale",
+          key_reasons: [],
+          based_on_poll_count: 0,
+          generated_at: "2026-01-01T00:00:00Z",
+          model: "test",
+          source_urls: [],
+          market_signals: [],
+          ...overrides,
+        }
+      : undefined;
+    return render(CandidateComparison, {
+      race: race({ candidates: [jane], forecast }),
+      candidates: [jane],
+    });
+  }
+
+  it("uses the headline win probability for the predicted winner", () => {
+    const { container } = renderWithForecast({
+      predicted_winner_name: "Jane Doe",
+      win_probability: 0.72,
+      party_probabilities: {},
+      rating: "lean_d",
+      generated_at: "2026-01-01T00:00:00Z",
+      model: "test",
+    });
+
+    expect(container.textContent).toContain("72%");
+  });
+
+  // Anyone who is not the predicted winner falls back to their party's
+  // probability, matched loosely because the two vocabularies disagree
+  // ("Democratic" vs "Democrat" vs "D").
+  it.each([
+    ["a full party name", { Democratic: 0.44 }],
+    ["a shorter party key", { Democrat: 0.44 }],
+    ["a single-letter key", { D: 0.44 }],
+  ])("matches %s to the candidate's party", (_label, partyProbabilities) => {
+    const { container } = renderWithForecast({
+      predicted_winner_name: "Someone Else",
+      win_probability: 0.9,
+      party_probabilities: partyProbabilities,
+      rating: "lean_d",
+      generated_at: "2026-01-01T00:00:00Z",
+      model: "test",
+    });
+
+    expect(container.textContent).toContain("44%");
+  });
+
+  it("shows no probability when the race has no forecast", () => {
+    const { container } = renderWithForecast(undefined);
+
+    expect(container.textContent).not.toContain("estimated win probability");
+  });
+
+  it("shows no probability when no party key matches", () => {
+    const { container } = renderWithForecast({
+      predicted_winner_name: "Someone Else",
+      win_probability: 0.9,
+      party_probabilities: { Republican: 0.9 },
+      rating: "lean_r",
+      generated_at: "2026-01-01T00:00:00Z",
+      model: "test",
+    });
+
+    expect(container.textContent).not.toContain("estimated win probability");
+  });
+});

--- a/web/src/lib/components/home/FeaturedElections.test.ts
+++ b/web/src/lib/components/home/FeaturedElections.test.ts
@@ -1,0 +1,172 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import FeaturedElections from "./FeaturedElections.svelte";
+import type { RaceSummary } from "$lib/types";
+
+function race(overrides: Partial<RaceSummary> = {}): RaceSummary {
+  return {
+    id: "mo-senate-2024",
+    title: "2024 Missouri U.S. Senate Election",
+    office: "U.S. Senate",
+    state: "Missouri",
+    jurisdiction: "Missouri",
+    election_date: "2024-11-05",
+    updated_utc: "2024-06-01T12:00:00Z",
+    candidates: [{ name: "Jane Doe", party: "Democratic", incumbent: false }],
+    ...overrides,
+  } as RaceSummary;
+}
+
+function manyRaces(n: number) {
+  return Array.from({ length: n }, (_, i) =>
+    race({ id: `race-${i}`, title: `Race ${i}` }),
+  );
+}
+
+function links(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('a[href^="/races/"]'));
+}
+
+afterEach(cleanup);
+
+describe("FeaturedElections empty state", () => {
+  // The whole section is hidden rather than rendering an empty shell — the
+  // homepage should not show a "Featured races" heading with nothing under it.
+  it("renders nothing at all without races", () => {
+    const { container } = render(FeaturedElections, { races: [] });
+
+    expect(container.querySelector("section")).toBeNull();
+    expect(container.textContent?.trim()).toBe("");
+  });
+
+  it("renders the section as soon as there is one race", () => {
+    const { container } = render(FeaturedElections, { races: [race()] });
+
+    expect(container.querySelector("section")).not.toBeNull();
+    expect(container.textContent).toContain("Featured races");
+  });
+});
+
+describe("FeaturedElections lead race", () => {
+  it("promotes the first race into the lead slot", () => {
+    const { container } = render(FeaturedElections, {
+      races: [race({ id: "lead", title: "Lead Race" })],
+    });
+
+    const lead = links(container)[0];
+    expect(lead.getAttribute("href")).toBe("/races/lead/");
+    expect(lead.textContent).toContain("Lead Race");
+    expect(lead.textContent).toContain("Featured");
+  });
+
+  it.each([
+    ["title", { title: "A Title" }, "A Title"],
+    ["office when the title is absent", { title: undefined }, "U.S. Senate"],
+    [
+      "a generic label when both are absent",
+      { title: undefined, office: undefined },
+      "Election research",
+    ],
+  ])("labels the lead race by %s", (_label, overrides, expected) => {
+    const { container } = render(FeaturedElections, {
+      races: [race(overrides as Partial<RaceSummary>)],
+    });
+
+    expect(links(container)[0].textContent).toContain(expected);
+  });
+
+  it("falls back to United States when the lead race has no jurisdiction", () => {
+    const { container } = render(FeaturedElections, {
+      races: [race({ jurisdiction: undefined })],
+    });
+
+    expect(links(container)[0].textContent).toContain("United States");
+  });
+
+  it("shows at most four candidate chips on the lead race", () => {
+    const { container } = render(FeaturedElections, {
+      races: [
+        race({
+          candidates: Array.from({ length: 7 }, (_, i) => ({
+            name: `Candidate ${i}`,
+            party: "Independent",
+            incumbent: false,
+          })),
+        }),
+      ],
+    });
+
+    const lead = links(container)[0];
+    const shown = [0, 1, 2, 3].filter((i) =>
+      lead.textContent?.includes(`Candidate ${i}`),
+    );
+    expect(shown).toHaveLength(4);
+    expect(lead.textContent).not.toContain("Candidate 4");
+  });
+});
+
+describe("FeaturedElections secondary list", () => {
+  it("lists the next four races after the lead", () => {
+    const { container } = render(FeaturedElections, { races: manyRaces(10) });
+
+    // 1 lead + 4 secondary = 5 race links (index links use a different href).
+    // Assert on hrefs: unlike the lead slot, the secondary list renders a
+    // *derived* title via raceDisplayTitle rather than race.title.
+    const hrefs = links(container).map((a) => a.getAttribute("href"));
+    expect(hrefs).toEqual([
+      "/races/race-0/",
+      "/races/race-1/",
+      "/races/race-2/",
+      "/races/race-3/",
+      "/races/race-4/",
+    ]);
+    expect(hrefs).not.toContain("/races/race-5/");
+  });
+
+  it("renders only the lead when a single race is supplied", () => {
+    const { container } = render(FeaturedElections, { races: [race()] });
+
+    expect(links(container)).toHaveLength(1);
+  });
+
+  it("reports how many candidates each secondary race has", () => {
+    const { container } = render(FeaturedElections, {
+      races: [
+        race({ id: "lead" }),
+        race({
+          id: "second",
+          candidates: [
+            { name: "A", party: "D", incumbent: false },
+            { name: "B", party: "R", incumbent: false },
+          ],
+        }),
+      ],
+    });
+
+    expect(container.textContent).toContain("2 candidates researched");
+  });
+
+  it("falls back to National for a secondary race with no jurisdiction", () => {
+    const { container } = render(FeaturedElections, {
+      races: [race({ id: "lead" }), race({ id: "b", jurisdiction: undefined })],
+    });
+
+    expect(container.textContent).toContain("National");
+  });
+});
+
+describe("FeaturedElections index links", () => {
+  // Two links to the index exist by design — one for wide screens in the
+  // header, one for narrow screens at the foot of the section.
+  it("offers a route to the full index at both breakpoints", () => {
+    const { container } = render(FeaturedElections, { races: [race()] });
+
+    const indexLinks = Array.from(
+      container.querySelectorAll('a[href="/elections/"]'),
+    );
+    expect(indexLinks).toHaveLength(2);
+    expect(indexLinks.every((a) => a.textContent?.includes("full index"))).toBe(
+      true,
+    );
+  });
+});

--- a/web/src/lib/components/home/InteractiveRaceCompare.test.ts
+++ b/web/src/lib/components/home/InteractiveRaceCompare.test.ts
@@ -1,0 +1,229 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import InteractiveRaceCompare from "./InteractiveRaceCompare.svelte";
+import type { Candidate, Race } from "$lib/types";
+
+function candidate(name: string, withdrawn = false): Candidate {
+  return {
+    name,
+    party: "Independent",
+    incumbent: false,
+    summary: `${name} summary`,
+    issues: {},
+    career_history: [],
+    education: [],
+    links: [],
+    social_media: {},
+    summary_sources: [],
+    roster_sources: [],
+    voting_sources: [],
+    donor_sources: [],
+    withdrawn,
+  } as unknown as Candidate;
+}
+
+function race(id: string, candidates: Candidate[] = []): Race {
+  return {
+    id,
+    title: `${id} title`,
+    office: "U.S. Senate",
+    jurisdiction: "Missouri",
+    state: "Missouri",
+    election_date: "2024-11-05",
+    updated_utc: "2024-06-01T12:00:00Z",
+    generator: [],
+    candidates: candidates.length
+      ? candidates
+      : [candidate("Jane Doe"), candidate("John Roe")],
+    polling: [],
+  } as unknown as Race;
+}
+
+function pills(container: HTMLElement) {
+  return Array.from(container.querySelectorAll("button[aria-pressed]"));
+}
+
+/**
+ * Pills are labelled "01 <jurisdiction> · <office>", not by race id, so the
+ * selected race must be identified by *position*. Asserting on pill text is a
+ * trap: with a shared office every label contains most letters, so an id-based
+ * assertion passes whatever is selected.
+ */
+function selectedIndex(container: HTMLElement): number {
+  return pills(container).findIndex(
+    (b) => b.getAttribute("aria-pressed") === "true",
+  );
+}
+
+function arrow(container: HTMLElement, direction: "Previous" | "Next") {
+  return container.querySelector(
+    `[aria-label="${direction} featured race"]`,
+  ) as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  // The pill strip auto-scrolls the active pill into view; jsdom elements have
+  // no scrollTo, and the component guards on that, but stubbing it lets the
+  // centring path actually run.
+  Element.prototype.scrollTo =
+    vi.fn() as unknown as typeof Element.prototype.scrollTo;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("InteractiveRaceCompare visibility", () => {
+  it("renders nothing without races", () => {
+    const { container } = render(InteractiveRaceCompare, { races: [] });
+
+    expect(container.textContent?.trim()).toBe("");
+  });
+
+  // The whole point is a side-by-side comparison; one candidate cannot be
+  // compared against anything, so the widget hides rather than half-rendering.
+  it("hides when the selected race has fewer than two candidates", () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: [race("solo", [candidate("Only One")])],
+    });
+
+    expect(container.textContent?.trim()).toBe("");
+  });
+
+  it("renders once a race has two comparable candidates", () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: [race("a")],
+    });
+
+    expect(container.textContent).toContain("Featured comparison");
+  });
+
+  it("excludes withdrawn candidates from the comparison", () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: [
+        race("a", [
+          candidate("Jane Doe"),
+          candidate("John Roe"),
+          candidate("Gone Away", true),
+        ]),
+      ],
+    });
+
+    expect(container.textContent).toContain("Jane Doe");
+    expect(container.textContent).not.toContain("Gone Away");
+  });
+
+  it("hides when withdrawals leave fewer than two candidates", () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: [
+        race("a", [candidate("Jane Doe"), candidate("Withdrawn One", true)]),
+      ],
+    });
+
+    expect(container.textContent?.trim()).toBe("");
+  });
+});
+
+describe("InteractiveRaceCompare race selection", () => {
+  const threeRaces = [race("a"), race("b"), race("c")];
+
+  it("starts on the first race", () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+
+    expect(selectedIndex(container)).toBe(0);
+  });
+
+  it("offers one pill per race", () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+
+    expect(pills(container)).toHaveLength(3);
+  });
+
+  it("switches race when a pill is clicked", async () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+
+    await fireEvent.click(pills(container)[2]);
+
+    await waitFor(() => expect(selectedIndex(container)).toBe(2));
+  });
+
+  it("advances with the next arrow", async () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+
+    await fireEvent.click(arrow(container, "Next"));
+
+    await waitFor(() => expect(selectedIndex(container)).toBe(1));
+  });
+
+  it("wraps forward past the last race", async () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+
+    await fireEvent.click(arrow(container, "Next"));
+    await fireEvent.click(arrow(container, "Next"));
+    await fireEvent.click(arrow(container, "Next"));
+
+    await waitFor(() => expect(selectedIndex(container)).toBe(0));
+  });
+
+  it("wraps backward from the first race to the last", async () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+
+    await fireEvent.click(arrow(container, "Previous"));
+
+    await waitFor(() => expect(selectedIndex(container)).toBe(2));
+  });
+
+  it("marks exactly one pill as pressed at a time", async () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+
+    await fireEvent.click(pills(container)[1]);
+
+    await waitFor(() => {
+      const pressed = pills(container).filter(
+        (b) => b.getAttribute("aria-pressed") === "true",
+      );
+      expect(pressed).toHaveLength(1);
+    });
+  });
+
+  it("scrolls the active pill into view on selection", async () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: threeRaces,
+    });
+    const scrollTo = Element.prototype.scrollTo as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    scrollTo.mockClear();
+
+    await fireEvent.click(pills(container)[2]);
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalled());
+    expect(scrollTo.mock.calls[0][0]).toMatchObject({ behavior: "smooth" });
+  });
+
+  it("still works with a single race", async () => {
+    const { container } = render(InteractiveRaceCompare, {
+      races: [race("only")],
+    });
+
+    // Wrapping with one race lands back on itself rather than going undefined.
+    await fireEvent.click(arrow(container, "Next"));
+
+    await waitFor(() => expect(selectedIndex(container)).toBe(0));
+  });
+});

--- a/web/src/lib/prerenderData.entries.test.ts
+++ b/web/src/lib/prerenderData.entries.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `prerenderData` holds module-level caches (`summariesCache`, `raceCache`), so
+ * every test resets the module registry and re-imports rather than sharing
+ * state. `publicDataBase` is mocked through a mutable holder so a single test
+ * can choose between "static GCS hosting" and "same-origin" URL shapes.
+ *
+ * The `import.meta.env.SSR` branches (node:fs reads during prerender) are not
+ * exercised here — vitest runs with SSR false, and forcing it would test the
+ * build-time path rather than the browser path these functions take in prod.
+ */
+const { dataBase } = vi.hoisted(() => ({
+  dataBase: { value: undefined as string | undefined },
+}));
+
+vi.mock("$lib/config/api", () => ({
+  publicDataBase: () => dataBase.value,
+  racesApiBase: () => "https://api.test",
+}));
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./prerenderData");
+}
+
+function okJson(body: unknown) {
+  return { ok: true, json: () => Promise.resolve(body) } as Response;
+}
+
+function notFound() {
+  return {
+    ok: false,
+    status: 404,
+    json: () => Promise.resolve({}),
+  } as Response;
+}
+
+const summaries = [
+  { id: "mo-senate-2024", candidates: [{ name: "Jane Q. Doe" }] },
+  { id: "ks-house-01", candidates: [{ name: "Bob Roe" }] },
+];
+
+beforeEach(() => {
+  dataBase.value = undefined;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("fetchPublishedRaceSummaries", () => {
+  it("reads same-origin summaries when no static base is configured", async () => {
+    const { fetchPublishedRaceSummaries } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson(summaries));
+
+    await expect(fetchPublishedRaceSummaries(fetchFn)).resolves.toEqual(
+      summaries,
+    );
+    expect(fetchFn).toHaveBeenCalledWith("/summaries.json");
+  });
+
+  it("reads from the static data host when one is configured", async () => {
+    dataBase.value = "https://data.test";
+    const { fetchPublishedRaceSummaries } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson(summaries));
+
+    await fetchPublishedRaceSummaries(fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("https://data.test/summaries.json");
+  });
+
+  it("fetches once and serves later callers from cache", async () => {
+    const { fetchPublishedRaceSummaries } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson(summaries));
+
+    await fetchPublishedRaceSummaries(fetchFn);
+    await fetchPublishedRaceSummaries(fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the status code on a failed response", async () => {
+    const { fetchPublishedRaceSummaries } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(notFound());
+
+    await expect(fetchPublishedRaceSummaries(fetchFn)).rejects.toThrow(
+      "Failed to fetch race summaries: 404",
+    );
+  });
+});
+
+describe("fetchPublishedRace", () => {
+  it("requests the race file by id", async () => {
+    const { fetchPublishedRace } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson({ id: "mo-senate-2024" }));
+
+    await fetchPublishedRace("mo-senate-2024", fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/mo-senate-2024.json");
+  });
+
+  it("percent-encodes an id so it cannot escape its path", async () => {
+    const { fetchPublishedRace } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson({}));
+
+    await fetchPublishedRace("mo/senate 2024", fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/mo%2Fsenate%202024.json");
+  });
+
+  it("caches per id rather than globally", async () => {
+    const { fetchPublishedRace } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson({}));
+
+    await fetchPublishedRace("a", fetchFn);
+    await fetchPublishedRace("a", fetchFn);
+    await fetchPublishedRace("b", fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the status code and id on failure", async () => {
+    const { fetchPublishedRace } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(notFound());
+
+    await expect(fetchPublishedRace("gone", fetchFn)).rejects.toThrow(
+      "Failed to fetch race gone: 404",
+    );
+  });
+});
+
+describe("prerender entry generation", () => {
+  // Prerendering every race is opt-in; the default build must not enumerate
+  // them, or a fast build turns into a full crawl.
+  it("returns no entries unless dynamic prerendering is switched on", async () => {
+    vi.stubEnv("MODE", "test");
+    vi.stubEnv("VITE_PRERENDER_RACES", "false");
+    const { raceEntries, candidateEntries } = await loadModule();
+
+    await expect(raceEntries()).resolves.toEqual([]);
+    await expect(candidateEntries()).resolves.toEqual([]);
+  });
+
+  it.each([
+    ["crawl mode", "MODE", "crawl"],
+    ["the explicit flag", "VITE_PRERENDER_RACES", "true"],
+  ])("enumerates races when enabled by %s", async (_label, key, value) => {
+    vi.stubEnv(key, value);
+    const { raceEntries } = await loadModule();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(okJson(summaries)));
+
+    await expect(raceEntries()).resolves.toEqual([
+      { slug: "mo-senate-2024" },
+      { slug: "ks-house-01" },
+    ]);
+  });
+
+  it("slugifies candidate names into per-candidate entries", async () => {
+    vi.stubEnv("MODE", "crawl");
+    const { candidateEntries } = await loadModule();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(okJson(summaries)));
+
+    await expect(candidateEntries()).resolves.toEqual([
+      { slug: "mo-senate-2024", candidate: "jane-q-doe" },
+      { slug: "ks-house-01", candidate: "bob-roe" },
+    ]);
+  });
+
+  it("tolerates a race with no candidates array", async () => {
+    vi.stubEnv("MODE", "crawl");
+    const { candidateEntries } = await loadModule();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(okJson([{ id: "empty" }])),
+    );
+
+    await expect(candidateEntries()).resolves.toEqual([]);
+  });
+
+  // A build must not be blocked by an unreachable data host — it degrades to
+  // prerendering the fixed routes only.
+  it.each([
+    ["raceEntries", "raceEntries"],
+    ["candidateEntries", "candidateEntries"],
+  ])("%s degrades to empty when summaries cannot be loaded", async (_l, fn) => {
+    vi.stubEnv("MODE", "crawl");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mod = await loadModule();
+    const loadEntries =
+      fn === "raceEntries" ? mod.raceEntries : mod.candidateEntries;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(notFound()));
+
+    await expect(loadEntries()).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("loadPrerenderChamberForecasts", () => {
+  it("reads same-origin forecasts by default", async () => {
+    const { loadPrerenderChamberForecasts } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson({ house: "" }));
+
+    await loadPrerenderChamberForecasts(fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/chamber_forecasts.json");
+  });
+
+  it("reads from the static data host when configured", async () => {
+    dataBase.value = "https://data.test";
+    const { loadPrerenderChamberForecasts } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson({ house: "" }));
+
+    await loadPrerenderChamberForecasts(fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://data.test/chamber_forecasts.json",
+    );
+  });
+
+  it("reports the status code on failure", async () => {
+    const { loadPrerenderChamberForecasts } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(notFound());
+
+    await expect(loadPrerenderChamberForecasts(fetchFn)).rejects.toThrow(
+      "Failed to fetch chamber forecasts: 404",
+    );
+  });
+
+  it("is not cached, so a later call re-reads", async () => {
+    const { loadPrerenderChamberForecasts } = await loadModule();
+    const fetchFn = vi.fn().mockResolvedValue(okJson({ house: "" }));
+
+    await loadPrerenderChamberForecasts(fetchFn);
+    await loadPrerenderChamberForecasts(fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/lib/utils/forecastPresentation.format.test.ts
+++ b/web/src/lib/utils/forecastPresentation.format.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  colorForRating,
+  marketAsOf,
+  marketSignalTarget,
+  marketSpread,
+  oneDecimal,
+  partyClass,
+  probability,
+  probabilityOneDecimal,
+  ratingClass,
+  ratingCompetitiveness,
+} from "./forecastPresentation";
+import type { ForecastRating } from "$lib/types";
+
+/**
+ * The pure presentation helpers. `forecastPresentation.test.ts` covers the
+ * composite builders (seat charts, state map data); this file covers the small
+ * formatters and classifiers those builders lean on, where the interesting
+ * behaviour is entirely in the boundaries.
+ */
+
+describe("partyClass", () => {
+  it.each([
+    ["Democratic", "blue"],
+    ["Republican", "red"],
+  ])("colours %s with the %s ramp", (party, hue) => {
+    expect(partyClass(party)).toContain(hue);
+  });
+
+  it.each(["Independent", "Libertarian", "", "democratic"])(
+    "falls back to muted text for %j",
+    (party) => {
+      expect(partyClass(party)).toBe("text-content-muted");
+    },
+  );
+
+  it("gives every recognised party a dark-mode variant", () => {
+    expect(partyClass("Democratic")).toContain("dark:");
+    expect(partyClass("Republican")).toContain("dark:");
+  });
+});
+
+describe("ratingClass", () => {
+  it.each(["safe_d", "likely_d", "lean_d", "tilt_d"])(
+    "treats %s as a Democratic rating",
+    (rating) => {
+      expect(ratingClass(rating as ForecastRating)).toContain("blue");
+    },
+  );
+
+  it.each(["safe_r", "likely_r", "lean_r", "tilt_r"])(
+    "treats %s as a Republican rating",
+    (rating) => {
+      expect(ratingClass(rating as ForecastRating)).toContain("red");
+    },
+  );
+
+  it.each(["tossup", "other"])("treats %s as neutral", (rating) => {
+    expect(ratingClass(rating as ForecastRating)).toContain("slate");
+  });
+});
+
+describe("colorForRating", () => {
+  it("maps a rating onto its CSS custom property", () => {
+    expect(colorForRating("safe_d" as ForecastRating)).toBe(
+      "var(--color-safe-d)",
+    );
+  });
+
+  it("leaves a single-word rating unhyphenated", () => {
+    expect(colorForRating("tossup" as ForecastRating)).toBe(
+      "var(--color-tossup)",
+    );
+  });
+
+  // Only the first underscore is replaced, which is fine for the current
+  // vocabulary but worth pinning in case a three-part rating is ever added.
+  it("replaces only the first underscore", () => {
+    expect(colorForRating("a_b_c" as ForecastRating)).toBe(
+      "var(--color-a-b_c)",
+    );
+  });
+});
+
+describe("ratingCompetitiveness", () => {
+  // Lower is more competitive; the ordering drives "closest race" selection.
+  it("orders ratings from tossup outward", () => {
+    const order = [
+      "tossup",
+      "tilt_d",
+      "lean_r",
+      "likely_d",
+      "safe_r",
+    ] as ForecastRating[];
+    const scores = order.map(ratingCompetitiveness);
+
+    expect(scores).toEqual([0, 1, 2, 3, 4]);
+    expect([...scores].sort((a, b) => a - b)).toEqual(scores);
+  });
+
+  it("scores an unknown rating as least competitive", () => {
+    expect(ratingCompetitiveness("other" as ForecastRating)).toBe(5);
+  });
+
+  it("scores both parties of a band identically", () => {
+    expect(ratingCompetitiveness("lean_d" as ForecastRating)).toBe(
+      ratingCompetitiveness("lean_r" as ForecastRating),
+    );
+  });
+});
+
+describe("probability", () => {
+  it.each([
+    [undefined, "n/a"],
+    [null, "n/a"],
+  ])("renders %s as n/a", (value, expected) => {
+    expect(probability(value as number | null | undefined)).toBe(expected);
+  });
+
+  // Certainty is never claimed: 1 and 0 are clamped to >99% / <1%, because a
+  // forecast that says "100%" reads as a promise rather than an estimate.
+  it.each([
+    [1, ">99%"],
+    [1.2, ">99%"],
+    [0, "<1%"],
+    [-0.5, "<1%"],
+  ])("clamps %s to %s", (value, expected) => {
+    expect(probability(value)).toBe(expected);
+  });
+
+  it.each([
+    [0.5, "50%"],
+    [0.674, "67%"],
+    [0.675, "68%"],
+    [0.009, "1%"],
+  ])("rounds %s to %s", (value, expected) => {
+    expect(probability(value)).toBe(expected);
+  });
+});
+
+describe("probabilityOneDecimal", () => {
+  it.each([
+    [undefined, "n/a"],
+    [null, "n/a"],
+  ])("renders %s as n/a", (value, expected) => {
+    expect(probabilityOneDecimal(value as number | null | undefined)).toBe(
+      expected,
+    );
+  });
+
+  // Unlike `probability`, this one does not clamp — it is used for market
+  // quotes, where an exact 100.0% bid is a real thing to display.
+  it.each([
+    [0.5, "50.0%"],
+    [0.6745, "67.5%"],
+    [1, "100.0%"],
+    [0, "0.0%"],
+  ])("formats %s as %s", (value, expected) => {
+    expect(probabilityOneDecimal(value)).toBe(expected);
+  });
+});
+
+describe("marketSignalTarget", () => {
+  it("annotates the party when it differs from the matched name", () => {
+    expect(
+      marketSignalTarget({
+        matched_to: "Jane Doe",
+        matched_party: "Democratic",
+      }),
+    ).toBe("Jane Doe (Democratic)");
+  });
+
+  it("omits a redundant party annotation", () => {
+    expect(
+      marketSignalTarget({
+        matched_to: "Democratic",
+        matched_party: "Democratic",
+      }),
+    ).toBe("Democratic");
+  });
+
+  it.each([undefined, ""])("omits an absent party (%j)", (party) => {
+    expect(
+      marketSignalTarget({ matched_to: "Jane Doe", matched_party: party }),
+    ).toBe("Jane Doe");
+  });
+});
+
+describe("marketSpread", () => {
+  it("renders a bid/ask pair", () => {
+    expect(marketSpread({ yes_bid: 0.42, yes_ask: 0.45 })).toBe(
+      "42.0% bid / 45.0% ask",
+    );
+  });
+
+  it.each([
+    ["a missing bid", { yes_ask: 0.45 }],
+    ["a missing ask", { yes_bid: 0.42 }],
+    ["a null bid", { yes_bid: null, yes_ask: 0.45 }],
+    ["neither side", {}],
+  ])("returns null for %s", (_label, signal) => {
+    expect(marketSpread(signal)).toBeNull();
+  });
+
+  // 0 is a legitimate quote, so the guard is a type check rather than
+  // truthiness — a falsy check would hide a market priced at zero.
+  it("renders a zero bid rather than treating it as missing", () => {
+    expect(marketSpread({ yes_bid: 0, yes_ask: 0.05 })).toBe(
+      "0.0% bid / 5.0% ask",
+    );
+  });
+});
+
+describe("marketAsOf", () => {
+  it("formats a valid timestamp", () => {
+    expect(marketAsOf("2026-01-15T00:00:00Z")).toMatch(/Jan/);
+    expect(marketAsOf("2026-01-15T00:00:00Z")).toMatch(/2026/);
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["undefined", undefined],
+    ["null", null],
+    ["an unparseable value", "not-a-date"],
+  ])("returns an empty string for %s", (_label, value) => {
+    expect(marketAsOf(value as string | null | undefined)).toBe("");
+  });
+});
+
+describe("oneDecimal", () => {
+  it.each([
+    [undefined, "n/a"],
+    [null, "n/a"],
+  ])("renders %s as n/a", (value, expected) => {
+    expect(oneDecimal(value as number | null | undefined)).toBe(expected);
+  });
+
+  it.each([
+    [1, "1.0"],
+    [1.25, "1.3"],
+    [1.24, "1.2"],
+    [0, "0.0"],
+    [-2.5, "-2.5"],
+  ])("formats %s as %s", (value, expected) => {
+    expect(oneDecimal(value)).toBe(expected);
+  });
+});

--- a/web/src/lib/utils/format.test.ts
+++ b/web/src/lib/utils/format.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { LEGACY_MODEL_ALIASES, MODEL_LABELS } from "$lib/config/modelCatalog";
+import { candidateSlug, formatModelName } from "./format";
+
+// modelCatalog.ts is generated from shared/model_catalog.py, so its contents
+// change whenever the roster does. Derive fixtures from the catalog rather than
+// hardcoding IDs — otherwise a routine model swap turns into a red test.
+const [canonicalId, canonicalLabel] = Object.entries(MODEL_LABELS)[0];
+const bareAlias = Object.entries(LEGACY_MODEL_ALIASES).find(
+  ([, target]) => MODEL_LABELS[target] !== undefined,
+)!;
+
+describe("formatModelName", () => {
+  it("returns falsy input unchanged", () => {
+    expect(formatModelName("")).toBe("");
+  });
+
+  it("labels a current catalog model", () => {
+    expect(formatModelName(canonicalId)).toBe(canonicalLabel);
+  });
+
+  it("resolves a bare alias through the catalog", () => {
+    const [alias, target] = bareAlias;
+    expect(formatModelName(alias)).toBe(MODEL_LABELS[target]);
+  });
+
+  it("labels pre-catalog models that only appear in old run records", () => {
+    expect(formatModelName("gpt-4o")).toBe("GPT-4o");
+    expect(formatModelName("claude-sonnet-4-20250514")).toBe("Claude Sonnet 4");
+    expect(formatModelName("grok-3")).toBe("Grok 3");
+  });
+
+  it("maps historical pipeline generator tags to the model they actually used", () => {
+    expect(formatModelName("pipeline-agent")).toBe("GPT-4o Mini");
+    expect(formatModelName("pipeline-v2-agent")).toBe("GPT-4o Mini");
+  });
+
+  // The documented rule: a run renders as the model it ran on, never as
+  // whatever replaced it. A direct label must win over alias redirection.
+  it("prefers a direct label over alias redirection", () => {
+    const aliasedArchived = Object.keys(LEGACY_MODEL_ALIASES).find(
+      (key) => key === "gpt-4o",
+    );
+    // Only meaningful if the catalog ever aliases an archived name; when it
+    // does not, the direct-hit path is still the one exercised above.
+    if (aliasedArchived) {
+      expect(formatModelName("gpt-4o")).toBe("GPT-4o");
+    }
+    expect(formatModelName(canonicalId)).toBe(canonicalLabel);
+  });
+
+  it("falls back to the raw id for anything unrecognised", () => {
+    expect(formatModelName("some/unknown-model-9")).toBe(
+      "some/unknown-model-9",
+    );
+  });
+
+  it("does not resolve an alias whose target has no label", () => {
+    // Guards the `aliased && MODEL_LABELS[aliased]` conjunction: a dangling
+    // alias must fall through to the raw id, not return undefined.
+    const dangling = Object.entries(LEGACY_MODEL_ALIASES).find(
+      ([, target]) => MODEL_LABELS[target] === undefined,
+    );
+    if (dangling) {
+      expect(formatModelName(dangling[0])).toBe(dangling[0]);
+    }
+  });
+});
+
+describe("candidateSlug", () => {
+  it.each([
+    ["Jane Doe", "jane-doe"],
+    ["Jane Q. Doe", "jane-q-doe"],
+    ["O'Brien", "o-brien"],
+    ["Mary-Jane Watson", "mary-jane-watson"],
+    ["  Leading and trailing  ", "leading-and-trailing"],
+    ["UPPERCASE NAME", "uppercase-name"],
+    ["Name123", "name123"],
+  ])("slugifies %j to %j", (input, expected) => {
+    expect(candidateSlug(input)).toBe(expected);
+  });
+
+  it("collapses runs of separators into a single dash", () => {
+    expect(candidateSlug("A  ---  B")).toBe("a-b");
+  });
+
+  it("strips leading and trailing dashes", () => {
+    expect(candidateSlug("!!!Jane!!!")).toBe("jane");
+  });
+
+  it("returns an empty string when nothing survives", () => {
+    expect(candidateSlug("")).toBe("");
+    expect(candidateSlug("!!!")).toBe("");
+  });
+
+  // Non-ASCII letters become separators rather than being transliterated, so an
+  // accented name fragments: "José Ñuñez" -> "jos-u-ez", not "jose-nunez".
+  // Pinned deliberately — switching to transliteration would change every
+  // existing candidate URL, so it must be a conscious migration, not a drive-by.
+  it("turns non-ASCII characters into separators instead of transliterating", () => {
+    expect(candidateSlug("José Ñuñez")).toBe("jos-u-ez");
+    expect(candidateSlug("Müller")).toBe("m-ller");
+  });
+
+  it("produces a stable slug for the same name", () => {
+    expect(candidateSlug("Jane Doe")).toBe(candidateSlug("Jane  Doe"));
+  });
+});

--- a/web/src/lib/utils/logger.test.ts
+++ b/web/src/lib/utils/logger.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `isDev` is captured once at module load, so each case has to reset the module
+ * registry and re-import after stubbing the env. The production branch is the
+ * one worth pinning: the logger deliberately swallows output there, and a
+ * regression that starts logging to a user's console is silent in dev.
+ */
+async function loadLogger(dev: boolean) {
+  vi.resetModules();
+  vi.stubEnv("DEV", dev);
+  const { logger } = await import("./logger");
+  return logger;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("logger in development", () => {
+  it.each([
+    ["error", "error"],
+    ["warn", "warn"],
+    ["info", "info"],
+  ] as const)("forwards %s to the console", async (method, consoleMethod) => {
+    const spy = vi.spyOn(console, consoleMethod).mockImplementation(() => {});
+    const logger = await loadLogger(true);
+
+    logger[method]("a message", { detail: 1 }, "extra");
+
+    expect(spy).toHaveBeenCalledWith("a message", { detail: 1 }, "extra");
+  });
+
+  it("forwards a message with no extra arguments", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logger = await loadLogger(true);
+
+    logger.error("bare");
+
+    expect(spy).toHaveBeenCalledWith("bare");
+  });
+});
+
+describe("logger in production", () => {
+  it.each([
+    ["error", "error"],
+    ["warn", "warn"],
+    ["info", "info"],
+  ] as const)("suppresses %s entirely", async (method, consoleMethod) => {
+    const spy = vi.spyOn(console, consoleMethod).mockImplementation(() => {});
+    const logger = await loadLogger(false);
+
+    logger[method]("should not appear", "nor this");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("still returns undefined rather than throwing", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const logger = await loadLogger(false);
+
+    expect(logger.error("quiet")).toBeUndefined();
+  });
+});

--- a/web/src/lib/utils/pipelineUtils.test.ts
+++ b/web/src/lib/utils/pipelineUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { getLogClass, getStatusClass } from "./pipelineUtils";
+
+/**
+ * These map domain states to Tailwind classes. The value of testing them is not
+ * the exact class strings — it is that every known state maps to a *distinct*
+ * style and that unknown input degrades to the neutral surface rather than
+ * returning undefined and rendering an unstyled badge.
+ */
+
+const RUN_STATUSES = [
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+  "continued",
+] as const;
+
+const LOG_LEVELS = ["error", "warning", "info", "debug"] as const;
+
+describe("getStatusClass", () => {
+  it.each(RUN_STATUSES)("returns a non-empty class for %s", (status) => {
+    expect(getStatusClass(status)).toBeTruthy();
+  });
+
+  it("gives each run status a visually distinct style", () => {
+    const classes = RUN_STATUSES.map(getStatusClass);
+    expect(new Set(classes).size).toBe(RUN_STATUSES.length);
+  });
+
+  it.each([
+    ["running", "blue"],
+    ["completed", "green"],
+    ["failed", "red"],
+    ["cancelled", "yellow"],
+    ["continued", "purple"],
+  ])("colours %s with the %s ramp", (status, hue) => {
+    expect(getStatusClass(status)).toContain(hue);
+  });
+
+  it("supplies both light and dark variants for every status", () => {
+    for (const status of RUN_STATUSES) {
+      expect(getStatusClass(status)).toContain("dark:");
+    }
+  });
+
+  it.each(["pending", "unknown", "", "COMPLETED"])(
+    "falls back to the neutral surface for %j",
+    (status) => {
+      expect(getStatusClass(status)).toBe(
+        "bg-surface-alt text-content border-stroke",
+      );
+    },
+  );
+});
+
+describe("getLogClass", () => {
+  it.each(LOG_LEVELS)("returns a non-empty class for %s", (level) => {
+    expect(getLogClass(level)).toBeTruthy();
+  });
+
+  it.each([
+    ["error", "red"],
+    ["warning", "yellow"],
+    ["info", "blue"],
+  ])("colours %s with the %s ramp", (level, hue) => {
+    expect(getLogClass(level)).toContain(hue);
+  });
+
+  it("gives every level a left border so the log gutter reads as a rail", () => {
+    for (const level of LOG_LEVELS) {
+      expect(getLogClass(level)).toContain("border-l-");
+    }
+  });
+
+  // debug and the default branch intentionally share styling — debug output is
+  // not an exceptional state. Pinned so a future divergence is deliberate.
+  it("styles debug the same as an unrecognised level", () => {
+    expect(getLogClass("debug")).toBe(getLogClass("something-else"));
+  });
+
+  it.each(["", "ERROR", "trace"])(
+    "falls back to the muted surface for %j",
+    (level) => {
+      expect(getLogClass(level)).toBe(
+        "bg-surface-alt text-content-muted border-l-stroke",
+      );
+    },
+  );
+});

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -24,11 +24,18 @@ export default defineConfig({
         "src/lib/sampleData.ts",
         "src/lib/config/modelCatalog.ts",
       ],
+      // Ratchet floors: set a couple of points under measured coverage so a real
+      // regression fails the build while ordinary variance does not. They were
+      // 35/25/35/40, which measured coverage had outgrown by ~20 points — a
+      // floor that far below actual stops being a guard and just reports a
+      // number. Raise these whenever coverage climbs; never lower them to make
+      // a red build green.
+      // Measured at the time of writing: 81.32 / 67.97 / 81.24 / 82.35.
       thresholds: {
-        statements: 35,
-        branches: 25,
-        functions: 35,
-        lines: 40,
+        statements: 80,
+        branches: 66,
+        functions: 79,
+        lines: 81,
       },
       reporter: ["text", "json-summary"],
     },


### PR DESCRIPTION
## What changed

- add strict, state-driven roster completeness recovery after verification removes inactive candidates
- preserve roster recovery and original-roster state across continuations and targeted runs
- make queued local runs persist durable GCS artifacts and retain caller intent across handoffs
- add broad frontend unit coverage and raise coverage ratchets to current measured levels

## Root cause

Roster sync could correctly remove completed-primary losers but had no evidence-gated recovery path when its final tool call was missed. Queued local runs also bypassed the direct runner's artifact path and defaulted generic artifacts to ephemeral container storage.

## Validation

- `python -m pytest tests -q`: 1,397 passed, 9 skipped
- focused roster/artifact suites: 206 passed
- `npm run check`: 0 errors, 0 warnings
- `npm run lint`: passed
- `npm run test:coverage`: 75 files / 825 tests passed; 81.32% statements, 67.97% branches, 81.24% functions, 82.35% lines
- pre-commit and pre-push hooks passed