### PR TITLE
Preserve checkpoint state and failed-run cost metrics

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -265,6 +265,11 @@ exact-race Ballotpedia page and reputable news/campaign sources. The
 `ballotpedia_election_lookup` extraction is advisory only because a page can
 contain stale-cycle, primary, or unrelated navigation tables. Its names must
 never drive an add/removal alone or override a current official source.
+The lookup has a short, best-effort timeout: when ample invocation time remains,
+a timeout is logged and model-backed roster research continues. It triggers a
+durable handoff only when the invocation is genuinely near its checkpoint
+deadline. Update runs mutate the handler's checkpoint object directly so a
+handoff cannot persist stale completed-unit markers from the baseline.
 
 Removals have three paths, chosen by what the evidence actually supports:
 

--- a/pipeline_client/agent/phases/_common.py
+++ b/pipeline_client/agent/phases/_common.py
@@ -56,6 +56,30 @@ async def _await_with_run_budget(
         raise RunBudgetExceeded(f"{operation} exceeded the remaining run budget") from exc
 
 
+async def _await_advisory_with_run_budget(
+    awaitable: Any,
+    *,
+    run_budget: RunBudget | None,
+    requested_timeout: float,
+    operation: str,
+    log: Any,
+    continuation: str,
+) -> Any | None:
+    """Run best-effort enrichment without treating its own timeout as deadline exhaustion."""
+    try:
+        return await _await_with_run_budget(
+            awaitable,
+            run_budget=run_budget,
+            requested_timeout=requested_timeout,
+            operation=operation,
+        )
+    except RunBudgetExceeded:
+        if run_budget is None or run_budget.usable_seconds() < 30.0:
+            raise
+        log("warning", f"  {operation} timed out; {continuation}")
+        return None
+
+
 def _candidate_name(candidate: Any) -> str:
     return roster.candidate_name(candidate)
 

--- a/pipeline_client/agent/phases/fresh_run.py
+++ b/pipeline_client/agent/phases/fresh_run.py
@@ -11,7 +11,7 @@ from ..prompts import DISCOVERY_SYSTEM, DISCOVERY_USER, cycle_kwargs
 from ..run_budget import RunBudget
 from ..selection import _scale_iterations, _select_target_candidates
 from ..utils import make_logger
-from ._common import _await_with_run_budget, _candidate_name
+from ._common import _await_advisory_with_run_budget, _candidate_name
 from .context import PhaseContext
 from .discovery import _sanitize_roster
 from .shared_runner import _run_shared_phases
@@ -70,11 +70,13 @@ async def _run_fresh(
     )
     _sanitize_roster(race_json, log)
     apply_canonical_race_title(race_json, race_id)
-    await _await_with_run_budget(
+    await _await_advisory_with_run_budget(
         _sync_ballotpedia_roster(race_json, race_id, log),
         run_budget=run_budget,
         requested_timeout=20.0,
-        operation="Ballotpedia roster sync",
+        operation="Ballotpedia advisory roster lookup",
+        log=log,
+        continuation="continuing with discovered roster",
     )
     _sanitize_roster(race_json, log)
 

--- a/pipeline_client/agent/phases/update_run.py
+++ b/pipeline_client/agent/phases/update_run.py
@@ -1,6 +1,5 @@
 """Update run (existing race): roster sync -> meta update -> shared phases."""
 
-import copy
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -33,7 +32,7 @@ from ..tools import (
 from ..utils import make_logger
 from ._common import (
     RunFailureReason,
-    _await_with_run_budget,
+    _await_advisory_with_run_budget,
     _candidate_name,
     _mark_pipeline_unit_complete,
     _pipeline_completed_units,
@@ -92,14 +91,20 @@ async def _run_update(
     if track is None:
         track = lambda a, s, **kw: None
 
-    race_json: Dict[str, Any] = copy.deepcopy(existing)
+    # Keep the handler's checkpoint holder on this same object. A deepcopy here
+    # meant a timeout before the first progress callback checkpointed the
+    # untouched baseline; its old completed-unit markers then made the
+    # continuation skip discovery and report a false zero-cost success.
+    race_json: Dict[str, Any] = existing
     _backfill_source_timestamps(race_json)
     _sanitize_roster(race_json, log)
-    await _await_with_run_budget(
+    await _await_advisory_with_run_budget(
         _sync_ballotpedia_roster(race_json, race_id, log),
         run_budget=run_budget,
         requested_timeout=20.0,
-        operation="Ballotpedia roster sync",
+        operation="Ballotpedia advisory roster lookup",
+        log=log,
+        continuation="continuing with roster research",
     )
     _sanitize_roster(race_json, log)
 
@@ -215,11 +220,13 @@ async def _run_update(
                 race_json["pipeline_state"].pop("roster_finalization_pending", None)
             else:
                 race_json["pipeline_state"]["roster_finalization_pending"] = True
-            await _await_with_run_budget(
+            await _await_advisory_with_run_budget(
                 _sync_ballotpedia_roster(race_json, race_id, log),
                 run_budget=run_budget,
                 requested_timeout=20.0,
-                operation="Ballotpedia roster sync",
+                operation="Ballotpedia advisory roster lookup",
+                log=log,
+                continuation="continuing with roster verification",
             )
             _sanitize_roster(race_json, log)
             if not roster_sync_succeeded:

--- a/pipeline_client/backend/handlers/agent.py
+++ b/pipeline_client/backend/handlers/agent.py
@@ -732,11 +732,21 @@ class AgentHandler:
         race_json_holder[0] = race_json
 
         # Save as draft (not published) — admin must explicitly publish
-        draft_path = await self._save_draft(
-            race_id,
-            race_json,
-            verified_baseline_candidate_names=verified_baseline_candidate_names,
-        )
+        try:
+            draft_path = await self._save_draft(
+                race_id,
+                race_json,
+                verified_baseline_candidate_names=verified_baseline_candidate_names,
+            )
+        except Exception as exc:
+            # ``run_agent`` has already finalized and detached its cost context at
+            # this point. Preserve those provider-backed metrics on the exception
+            # so the queue processor can attribute spend even when the draft save
+            # guard (or storage) rejects the completed result.
+            agent_metrics = race_json.get("agent_metrics")
+            if isinstance(agent_metrics, dict):
+                exc.pipeline_agent_metrics = dict(agent_metrics)
+            raise
 
         # Update race record metadata from the new draft data
         if not queue_item_id:

--- a/pipeline_client/backend/queue_processor.py
+++ b/pipeline_client/backend/queue_processor.py
@@ -465,6 +465,7 @@ async def process_claimed_item(
             from pipeline_client.agent.cost import _cost_ctx, estimate_cost
             from pipeline_client.backend.pipeline_metrics import get_pipeline_metrics_store
 
+            provided_metrics = getattr(exc, "pipeline_agent_metrics", None)
             acc = _cost_ctx.get() or {}
             breakdown = acc.get("model_breakdown", {})
             estimated_usd = sum(
@@ -474,25 +475,30 @@ async def process_claimed_item(
             search_cost_usd = int(acc.get("serper_calls", 0) or 0) * 0.001
             llm_cost_usd = float(acc.get("provider_cost_usd", 0.0) or 0.0)
             has_exact_cost = int(acc.get("priced_calls", 0) or 0) > 0 and int(acc.get("unpriced_calls", 0) or 0) == 0
-            failed_metrics = {
-                "model": options.get("research_model", ""),
-                "model_profile": options.get("model_profile"),
-                "prompt_tokens": int(acc.get("prompt_tokens", 0) or 0),
-                "completion_tokens": int(acc.get("completion_tokens", 0) or 0),
-                "total_tokens": int(acc.get("prompt_tokens", 0) or 0) + int(acc.get("completion_tokens", 0) or 0),
-                "llm_cost_usd": llm_cost_usd if has_exact_cost else None,
-                "search_cost_usd": search_cost_usd,
-                "cost_usd": llm_cost_usd + search_cost_usd if has_exact_cost else None,
-                "cost_source": "provider" if has_exact_cost else "estimated",
-                "estimated_usd": estimated_usd + search_cost_usd,
-                "model_breakdown": breakdown,
-                "phase_breakdown": acc.get("phase_breakdown", {}),
-                "page_fetches": int(acc.get("page_fetches", 0) or 0),
-                "fetched_chars": int(acc.get("fetched_chars", 0) or 0),
-                "page_budget_blocked": int(acc.get("page_budget_blocked", 0) or 0),
-                "duration_s": round(_time.perf_counter() - started_at, 1),
-                "serper_calls": int(acc.get("serper_calls", 0) or 0),
-            }
+            failed_metrics = (
+                dict(provided_metrics)
+                if isinstance(provided_metrics, dict)
+                else {
+                    "model": options.get("research_model", ""),
+                    "model_profile": options.get("model_profile"),
+                    "prompt_tokens": int(acc.get("prompt_tokens", 0) or 0),
+                    "completion_tokens": int(acc.get("completion_tokens", 0) or 0),
+                    "total_tokens": int(acc.get("prompt_tokens", 0) or 0) + int(acc.get("completion_tokens", 0) or 0),
+                    "llm_cost_usd": llm_cost_usd if has_exact_cost else None,
+                    "search_cost_usd": search_cost_usd,
+                    "cost_usd": llm_cost_usd + search_cost_usd if has_exact_cost else None,
+                    "cost_source": "provider" if has_exact_cost else "estimated",
+                    "estimated_usd": estimated_usd + search_cost_usd,
+                    "model_breakdown": breakdown,
+                    "phase_breakdown": acc.get("phase_breakdown", {}),
+                    "page_fetches": int(acc.get("page_fetches", 0) or 0),
+                    "fetched_chars": int(acc.get("fetched_chars", 0) or 0),
+                    "page_budget_blocked": int(acc.get("page_budget_blocked", 0) or 0),
+                    "duration_s": round(_time.perf_counter() - started_at, 1),
+                    "serper_calls": int(acc.get("serper_calls", 0) or 0),
+                }
+            )
+            failed_metrics.setdefault("serper_calls", int(failed_metrics.get("search_calls", 0) or 0))
             await get_pipeline_metrics_store().record_run(
                 run_id,
                 race_id,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -64,6 +64,26 @@ async def test_v2_handler_raises_on_missing_race_id():
 
 
 @pytest.mark.asyncio
+async def test_v2_handler_preserves_agent_metrics_when_draft_save_fails():
+    """A post-agent save guard must not erase the provider spend it incurred."""
+    handler = AgentHandler()
+    fake_result = {
+        "id": "test-race",
+        "candidates": [{"name": "Candidate"}],
+        "agent_metrics": {"cost_usd": 0.123, "cost_source": "provider", "serper_calls": 2},
+    }
+
+    with (
+        patch("pipeline_client.agent.agent.run_agent", new_callable=AsyncMock, return_value=fake_result),
+        patch.object(handler, "_save_draft", new_callable=AsyncMock, side_effect=ValueError("save rejected")),
+    ):
+        with pytest.raises(ValueError, match="save rejected") as caught:
+            await handler.handle({"race_id": "test-race"}, {"enabled_steps": ["discovery"]})
+
+    assert caught.value.pipeline_agent_metrics == fake_result["agent_metrics"]
+
+
+@pytest.mark.asyncio
 async def test_v2_handler_runs_agent_and_publishes():
     """AgentHandler calls run_agent and saves draft."""
     handler = AgentHandler()

--- a/tests/test_queue_worker.py
+++ b/tests/test_queue_worker.py
@@ -166,6 +166,38 @@ async def test_process_marks_failed_on_agent_error():
 
 
 @pytest.mark.asyncio
+async def test_process_records_attached_provider_cost_when_post_agent_save_fails():
+    from pipeline_client.backend import queue_processor as qp
+
+    item = {"race_id": "ca-house-01-2026", "run_id": "run-save-failed", "options": {"cheap_mode": True}}
+    db, _item_ref, _run_ref, _race_ref = _fs_mock(item)
+    metrics_store = MagicMock()
+    metrics_store.record_run = AsyncMock()
+    error = ValueError("draft save rejected")
+    error.pipeline_agent_metrics = {
+        "prompt_tokens": 1200,
+        "completion_tokens": 300,
+        "total_tokens": 1500,
+        "cost_usd": 0.014,
+        "cost_source": "provider",
+        "serper_calls": 2,
+        "search_calls": 2,
+    }
+
+    with (
+        patch.object(qp, "_run_agent", new_callable=AsyncMock, side_effect=error),
+        patch("pipeline_client.backend.pipeline_metrics.get_pipeline_metrics_store", return_value=metrics_store),
+    ):
+        await qp.process_claimed_item(db, MagicMock(), "bucket", "item-save-failed", item, "owner-save-failed")
+
+    metrics_store.record_run.assert_awaited_once()
+    args = metrics_store.record_run.await_args.args
+    assert args[:2] == ("run-save-failed", "ca-house-01-2026")
+    assert args[2] == error.pipeline_agent_metrics
+    assert args[3] == "failed"
+
+
+@pytest.mark.asyncio
 async def test_process_persists_run_health_from_successful_agent_result():
     """A run can finish without raising while still carrying a degraded/failed
     run_health verdict (e.g. review didn't pass) — that verdict must survive

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -7,6 +7,7 @@ import copy
 import json
 import os
 import re
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -20,6 +21,7 @@ from pipeline_client.agent.phases import (
     _sanitize_roster,
 )
 from pipeline_client.agent.prompts import CANONICAL_ISSUES
+from pipeline_client.agent.run_budget import RunBudget, RunBudgetExceeded
 from pipeline_client.backend.handlers.agent import HandoffTriggered
 from shared.models import RaceJSON
 from shared.pipeline_config import PIPELINE_STEP_IDS
@@ -702,6 +704,75 @@ async def test_failed_roster_sync_writes_recovery_state_before_checkpoint():
 
     assert checkpoint["roster_finalization_pending"] is True
     assert checkpoint["roster_sync_original_names"] == ["Shomari Figures", "Rhett Marques"]
+
+
+@pytest.mark.asyncio
+async def test_advisory_roster_timeout_does_not_checkpoint_stale_completed_units():
+    existing = {
+        "id": "ak-governor-2026",
+        "election_date": "2026-11-03",
+        "candidates": [{"name": "Candidate One", "party": "Independent", "roster_sources": []}],
+        "pipeline_state": {
+            "complete": True,
+            "remaining_candidates": [],
+            "remaining_steps": [],
+            "completed_units": ["discovery.roster_sync", "discovery.roster_verify", "discovery.metadata"],
+        },
+        "updated_utc": "2026-08-12T00:00:00Z",
+    }
+
+    async def advisory_timeout(*_args, **_kwargs):
+        raise RunBudgetExceeded("Ballotpedia roster sync exceeded the remaining run budget")
+
+    async def inspect_cleared_checkpoint(*_args, **kwargs):
+        if kwargs.get("phase_name") == "roster-sync":
+            units = set((existing.get("pipeline_state") or {}).get("completed_units") or [])
+            assert not units.intersection({"discovery.roster_sync", "discovery.roster_verify", "discovery.metadata"})
+            return {"_tool_trace": {"required_final_tool_succeeded": True}}
+        return {}
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock) as mock_loop,
+        patch("pipeline_client.agent.phases._sync_ballotpedia_roster", side_effect=advisory_timeout),
+    ):
+        mock_loop.side_effect = inspect_cleared_checkpoint
+        result = await run_agent(
+            "ak-governor-2026",
+            cheap_mode=True,
+            existing_data=existing,
+            enabled_steps=["discovery"],
+            run_budget=RunBudget(deadline_at=time.time() + 3600),
+        )
+
+    assert any(call.kwargs.get("phase_name") == "roster-sync" for call in mock_loop.call_args_list)
+    assert result["run_health"]["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_fresh_run_continues_after_advisory_roster_timeout():
+    discovered = {
+        "id": "ak-governor-2026",
+        "election_date": "2026-11-03",
+        "candidates": [{"name": "Candidate One", "party": "Independent", "roster_sources": []}],
+    }
+
+    async def advisory_timeout(*_args, **_kwargs):
+        raise RunBudgetExceeded("Ballotpedia roster sync exceeded the remaining run budget")
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock, return_value=discovered),
+        patch("pipeline_client.agent.phases._sync_ballotpedia_roster", side_effect=advisory_timeout),
+    ):
+        result = await run_agent(
+            "ak-governor-2026",
+            cheap_mode=True,
+            existing_data={},
+            enabled_steps=["discovery"],
+            run_budget=RunBudget(deadline_at=time.time() + 3600),
+        )
+
+    assert [candidate["name"] for candidate in result["candidates"]] == ["Candidate One"]
+    assert result["run_health"]["status"] == "healthy"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- keep update-run checkpoints attached to the live race object
- treat the short Ballotpedia lookup as advisory while real invocation budget remains
- preserve provider-backed metrics when post-agent draft saving fails
- cover update and fresh timeout paths plus failed-save accounting
- document checkpoint and advisory-timeout behavior

## Root cause

A deep-copied update object left the handler checkpoint holder pointing at stale baseline state. Separately, a short lookup timeout was converted into the same signal as true invocation-budget exhaustion. A failure after agent completion also lost the detached cost context.

## Validation

- pipeline tests: 1306 passed, 9 skipped; coverage 76.86%
- races API: 167 passed; coverage 65.68%
- focused regression suite: 110 passed
- black, isort, type sync, model catalog sync, mypy
- web check, lint, build, unit coverage; Playwright rerun 72 passed
- design-system typecheck/build
- Terraform fmt/validate
- pre-commit hooks including hardcoded-secret detection

The umbrella local Gitleaks directory scan remains noisy on this workspace (329 findings); the scoped pre-commit secret scan passed, and GitHub CI is the authoritative gate.