### PR TITLE
Prefer the current Ballotpedia general roster

### DIFF
--- a/pipeline_client/agent/ballotpedia.py
+++ b/pipeline_client/agent/ballotpedia.py
@@ -639,11 +639,26 @@ def _parse_candidate_list_from_html(html: str) -> List[Dict[str, Any]]:
 
     # Ballotpedia pages include many unrelated/historical tables. Only parse the
     # current election's votebox sections headed "... election" or "... convention".
-    for section_m in re.finditer(
-        r"<h4>(?P<label>[^<]*(?:election|convention)[^<]*)</h4>(?P<body>.*?)(?=<h4>|<h3>|<h2>|$)",
-        current_html,
-        re.DOTALL | re.IGNORECASE,
-    ):
+    sections = list(
+        re.finditer(
+            r"<h4>(?P<label>[^<]*(?:election|convention)[^<]*)</h4>(?P<body>.*?)(?=<h4>|<h3>|<h2>|$)",
+            current_html,
+            re.DOTALL | re.IGNORECASE,
+        )
+    )
+    # Once Ballotpedia publishes an exact general-election table, that is the
+    # current field. Mixing it with completed primary tables reintroduced every
+    # losing primary candidate (AL-02 produced seven names instead of the two
+    # nominees). Prefer the general section wholesale; an empty/general markup
+    # mismatch safely returns no names and triggers model-backed verification.
+    general_sections = [section for section in sections if "general" in unescape(section.group("label")).casefold()]
+    if general_sections:
+        # Election pages are newest-first. Parsing every "General election"
+        # block also mixes prior-cycle fields that appear before Ballotpedia's
+        # inconsistent history anchor. The first exact general block is current;
+        # if it is empty, fail closed instead of falling through to an older one.
+        sections = general_sections[:1]
+    for section_m in sections:
         label = unescape(section_m.group("label"))
         body = section_m.group("body")
 

--- a/tests/test_ballotpedia.py
+++ b/tests/test_ballotpedia.py
@@ -288,6 +288,41 @@ def test_candidate_parser_keeps_only_winners_from_completed_primary_sections():
     assert _parse_candidate_list_from_html(html) == [{"name": "Winner Candidate", "party": "Democratic", "incumbent": False}]
 
 
+def test_candidate_parser_prefers_general_field_over_primary_tables():
+    """A published general table must not be combined with losing primary candidates."""
+    html = """
+    <h4>Special general election</h4>
+    <div class="votebox">
+      <tr class="results_row"><td class="votebox-results-cell--text">
+        <a href="https://ballotpedia.org/Shomari_Figures">Shomari Figures</a> (D)
+      </td></tr>
+      <tr class="results_row"><td class="votebox-results-cell--text">
+        <a href="https://ballotpedia.org/Rhett_Marques">Rhett Marques</a> (R)
+      </td></tr>
+    </div>
+    <h4>Special Republican primary election</h4>
+    <div class="votebox">
+      <tr class="results_row winner"><td class="votebox-results-cell--text">
+        <a href="https://ballotpedia.org/Rhett_Marques">Rhett Marques</a> (R)
+      </td></tr>
+      <tr class="results_row"><td class="votebox-results-cell--text">
+        <a href="https://ballotpedia.org/Hampton_Harris">Hampton Harris</a> (R)
+      </td></tr>
+    </div>
+    <h4>General election</h4>
+    <div class="votebox">
+      <tr class="results_row"><td class="votebox-results-cell--text">
+        <a href="https://ballotpedia.org/Caroleene_Dobson">Caroleene Dobson</a> (R)
+      </td></tr>
+    </div>
+    """
+
+    assert _parse_candidate_list_from_html(html) == [
+        {"name": "Shomari Figures", "party": "Democratic", "incumbent": False},
+        {"name": "Rhett Marques", "party": "Republican", "incumbent": False},
+    ]
+
+
 class _FakeBallotpediaClient:
     def __init__(self, *args, **kwargs):
         self.calls = []


### PR DESCRIPTION
## What changed

- prefer the first current general-election votebox when Ballotpedia also includes primary and prior-cycle tables
- fail closed when that current general section is empty instead of falling through to older elections
- add an AL-02 regression fixture covering the two nominees plus primary and older general rows

## Root cause

The parser combined every matching general-election section before Ballotpedia's inconsistent history anchor. On AL-02 that returned the current two nominees plus five older candidates, preventing deterministic confirmation of the correct roster.

## Validation

- tests/test_ballotpedia.py: 49 passed
- live lookup for al-house-02-2026 now returns Shomari Figures and Rhett Marques only
- black, isort, pre-commit secret and file-integrity hooks passed