### PR TITLE
Preserve election lookup provenance

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -264,7 +264,11 @@ qualification; FEC corroboration for federal candidates; then a current
 exact-race Ballotpedia page and reputable news/campaign sources. The
 `ballotpedia_election_lookup` extraction is advisory only because a page can
 contain stale-cycle, primary, or unrelated navigation tables. Its names must
-never drive an add/removal alone or override a current official source.
+never drive an add/removal alone or override a current official source. A
+successful lookup does record its exact parsed page as fetched provenance, so
+the normal source-class, exact-contest, current-cycle, and independent roster
+adjudication gates can evaluate a Ballotpedia completeness citation without a
+second fetch of the same bot-protected page.
 The lookup has a short, best-effort timeout: when ample invocation time remains,
 a timeout is logged and model-backed roster research continues. It triggers a
 durable handoff only when the invocation is genuinely near its checkpoint

--- a/pipeline_client/agent/llm.py
+++ b/pipeline_client/agent/llm.py
@@ -785,6 +785,15 @@ async def _agent_loop(
                     )
                     n_found = len(election_data.get("candidates", []))
                     log("debug", f"    🗳️  found={election_data.get('found')} candidates={n_found}")
+                    # The election lookup fetched and parsed this exact page;
+                    # preserve that provenance just like fetch_page. This does
+                    # not make its names authoritative by itself: roster edits
+                    # still pass source-class, exact-contest, current-cycle, and
+                    # independent completeness adjudication in the handler.
+                    election_url = str(election_data.get("page_url") or "").strip()
+                    if election_data.get("found") is True and n_found > 0 and election_url.startswith(("http://", "https://")):
+                        fetched_urls.add(election_url)
+                        researched_urls.add(election_url)
                     messages.append(
                         {
                             "role": "tool",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -815,6 +815,59 @@ async def test_agent_loop_injects_actual_search_and_fetch_urls_into_editing_call
 
 
 @pytest.mark.asyncio
+async def test_agent_loop_records_successful_election_lookup_as_fetched_provenance():
+    source_url = "https://ballotpedia.org/Alabama%27s_2nd_Congressional_District_election,_2026"
+    looked_up = _mock_openai_response(
+        tool_calls=[
+            {
+                "id": "lookup",
+                "function": {
+                    "name": "ballotpedia_election_lookup",
+                    "arguments": json.dumps({"race_id": "al-house-02-2026"}),
+                },
+            }
+        ]
+    )
+    edited = _mock_openai_response(
+        tool_calls=[{"id": "edit", "function": {"name": "set_sources", "arguments": json.dumps({"name": "Alice"})}}]
+    )
+    stopped = _mock_openai_response(content="Done")
+    handler = MagicMock(return_value="OK")
+    edit_tool = {
+        "type": "function",
+        "function": {"name": "set_sources", "description": "Set", "parameters": {"type": "object"}},
+    }
+
+    with (
+        patch("pipeline_client.agent.llm._call_openrouter", new_callable=AsyncMock) as call,
+        patch(
+            "pipeline_client.agent.llm._ballotpedia_election_lookup",
+            new_callable=AsyncMock,
+            return_value={
+                "found": True,
+                "page_url": source_url,
+                "candidates": [{"name": "Shomari Figures"}, {"name": "Rhett Marques"}],
+            },
+        ),
+    ):
+        call.side_effect = [looked_up, edited, stopped]
+        await _agent_loop(
+            "system",
+            "user",
+            model=DEFAULT_RESEARCH_MODEL,
+            phase_name="roster-lookup-provenance",
+            max_iterations=4,
+            tools_mode=True,
+            extra_tools=[edit_tool],
+            extra_tool_handlers={"set_sources": handler},
+        )
+
+    trace = handler.call_args.args[0]["_research_trace"]
+    assert trace["researched_urls"] == [source_url]
+    assert trace["fetched_urls"] == [source_url]
+
+
+@pytest.mark.asyncio
 async def test_agent_loop_escalates_after_repeated_blocked_edits():
     blocked_calls = _mock_openai_response(
         tool_calls=[


### PR DESCRIPTION
## What changed

- record a successful exact election-page lookup URL as researched and fetched provenance
- retain all existing structural and independent roster adjudication gates
- add an agent-loop regression test for provenance injection
- document why this avoids a redundant bot-protected fetch without trusting extracted names directly

## Root cause

The specialized Ballotpedia lookup fetched and parsed AL-02 correctly, but its URL was not added to the research trace. The model then retried through generic fetch_page, which could fail on bot protection, leaving valid retrieved evidence unusable by the strict finalizer.

## Validation

- roster-focused suite: 185 passed
- black, isort, pre-commit secret and file-integrity hooks passed