### PR TITLE
Add independent roster completeness review fallback

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -269,6 +269,13 @@ successful lookup does record its exact parsed page as fetched provenance, so
 the normal source-class, exact-contest, current-cycle, and independent roster
 adjudication gates can evaluate a Ballotpedia completeness citation without a
 second fetch of the same bot-protected page.
+Completeness is judged per source first. If every ordinary judgment rejects,
+the pipeline sends the combined, bounded evidence packet to one stronger
+independent reviewer. Approval still passes through the same deterministic
+source-class, retrieved-content, exact-contest, and current-cycle gates; a
+negative, unavailable, or unparseable second review remains fail-closed. This
+fallback applies only to whole-roster completeness, never candidate membership
+or removal.
 The lookup has a short, best-effort timeout: when ample invocation time remains,
 a timeout is logged and model-backed roster research continues. It triggers a
 durable handoff only when the invocation is genuinely near its checkpoint

--- a/pipeline_client/agent/roster_adjudicator.py
+++ b/pipeline_client/agent/roster_adjudicator.py
@@ -47,6 +47,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Mapping
 
 from shared.model_catalog import ADJUDICATOR_MODEL as _ADJUDICATOR_MODEL
+from shared.model_catalog import ROSTER_COMPLETENESS_REVIEW_MODEL
 
 logger = logging.getLogger("pipeline")
 
@@ -127,9 +128,11 @@ _CLAIM_QUESTIONS: Dict[str, str] = {
         "The same person is routinely written differently across sources: 'Andrew Harris' and "
         "'Andy Harris', 'James P. McGovern' and 'Jim McGovern', 'Incumbent Harris', initials, "
         "maiden or married names, or a surname alone once introduced. Treat those as the same "
-        "person. A sentence naming only the Democratic and Republican nominees, or saying they are "
+        "person. A sentence merely naming the Democratic and Republican nominees, or saying they are "
         "the nominees for their respective parties, is NOT a whole-field listing and cannot establish "
-        "that no third-party nominee exists. Answer false if the source contradicts the roster or covers "
+        "that no third-party nominee exists. By contrast, a reference page's election section that "
+        "explicitly says 'A and B are running in the general election' and presents them as its candidate "
+        "field is a full-field listing, even when there are only two candidates. Answer false if the source contradicts the roster or covers "
         "a different contest — not merely because it contains additional low-profile candidates or a "
         "name is spelled or shortened differently. "
         "Answer false if it is a page about a single candidate, an evidently partial or truncated "
@@ -277,6 +280,7 @@ async def adjudicate(
     contest: str,
     source: Mapping[str, Any],
     run_budget: Any = None,
+    model: str = ADJUDICATOR_MODEL,
 ) -> Verdict:
     """Judge one bounded question about one piece of evidence.
 
@@ -288,7 +292,7 @@ async def adjudicate(
         return _unavailable(f"unknown claim {claim!r}")
 
     evidence = str(source.get("evidence") or source.get("text") or "")
-    key = _cache_key(claim, subject, contest, evidence + str(source.get("url") or ""))
+    key = _cache_key(claim, subject, contest, evidence + str(source.get("url") or "") + model)
     cached = _VERDICT_CACHE.get(key)
     if cached is not None:
         return cached
@@ -305,7 +309,7 @@ async def adjudicate(
                         "content": _build_user_prompt(claim=claim, subject=subject, contest=contest, source=source),
                     },
                 ],
-                model=ADJUDICATOR_MODEL,
+                model=model,
                 max_tokens=ADJUDICATOR_MAX_TOKENS,
                 temperature=ADJUDICATOR_TEMPERATURE,
                 run_budget=run_budget,
@@ -325,6 +329,7 @@ async def adjudicate(
         logger.warning("Roster adjudicator returned unparseable content for claim=%s", claim)
         return _unavailable("adjudicator returned an unparseable verdict")
 
+    verdict = Verdict(supports=verdict.supports, reason=verdict.reason, model=model)
     _VERDICT_CACHE[key] = verdict
     return verdict
 
@@ -434,4 +439,34 @@ async def adjudicate_sources(
             for source in targets
         )
     )
-    return {str(source["url"]).strip(): verdict.to_record() for source, verdict in zip(targets, verdicts)}
+    result = {str(source["url"]).strip(): verdict.to_record() for source, verdict in zip(targets, verdicts)}
+    if claim != Claim.COMPLETENESS or any(verdict.supports for verdict in verdicts):
+        return result
+
+    # A field can be established by several sources together even when no one
+    # excerpt is sufficient. On that narrow failure, ask a stronger independent
+    # reviewer about the combined packet. The synchronous handler still applies
+    # source-class, retrieval, exact-contest, and current-cycle gates afterward.
+    evidence_parts = []
+    for index, source in enumerate(targets, start=1):
+        evidence_parts.append(
+            f"SOURCE {index}\nTITLE: {source.get('title', '')}\nURL: {source.get('url', '')}\n"
+            f"EVIDENCE: {source.get('evidence') or source.get('text') or ''}"
+        )
+    bundle = await adjudicate(
+        claim=Claim.COMPLETENESS,
+        subject=subject,
+        contest=contest,
+        source={
+            "title": "Combined exact-contest roster evidence",
+            "url": "bundle://roster-completeness",
+            "evidence": "\n\n".join(evidence_parts),
+        },
+        run_budget=run_budget,
+        model=ROSTER_COMPLETENESS_REVIEW_MODEL,
+    )
+    if bundle.supports:
+        record = bundle.to_record()
+        record["review_scope"] = "combined_sources"
+        return {str(source["url"]).strip(): dict(record) for source in targets}
+    return result

--- a/shared/model_catalog.py
+++ b/shared/model_catalog.py
@@ -226,6 +226,10 @@ PREMIUM_REVIEW_GROK = "x-ai/grok-4.5"
 #: the live API. ``scripts/check_model_catalog.py`` enforces the separation.
 ADJUDICATOR_MODEL = SMALL_MODEL
 
+#: Strong, independent second look used only when every ordinary completeness
+#: judgment rejects a structurally valid roster-evidence bundle.
+ROSTER_COMPLETENESS_REVIEW_MODEL = FRONTIER_MODEL
+
 #: Chamber-forecast narratives: a handful of long-context calls over every
 #: published race summary, run by hand from the admin UI rather than per race.
 #: Volume is negligible, so this takes the strong Gemini rather than the cheap

--- a/tests/test_roster_adjudicator.py
+++ b/tests/test_roster_adjudicator.py
@@ -287,6 +287,69 @@ def test_adjudicate_sources_skips_urlless_sources(monkeypatch):
     assert verdicts == {}
 
 
+def test_completeness_rejection_gets_one_combined_stronger_review(monkeypatch):
+    models = []
+
+    async def _judge(messages, **kwargs):
+        models.append(kwargs["model"])
+        if kwargs["model"] == adj.ROSTER_COMPLETENESS_REVIEW_MODEL:
+            assert "SOURCE 1" in messages[1]["content"]
+            return _reply('{"supports": true, "reason": "the combined packet establishes the field"}')
+        return _reply('{"supports": false, "reason": "one excerpt is insufficient"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _judge)
+    verdicts = _run(
+        adj.adjudicate_sources(
+            claim=adj.Claim.COMPLETENESS,
+            subject="Jane Roe, John Doe",
+            contest="ne-house-02-2026",
+            sources=[_source()],
+        )
+    )
+    record = verdicts[_source()["url"]]
+    assert models == [adj.ADJUDICATOR_MODEL, adj.ROSTER_COMPLETENESS_REVIEW_MODEL]
+    assert record["supports"] is True
+    assert record["model"] == adj.ROSTER_COMPLETENESS_REVIEW_MODEL
+    assert record["review_scope"] == "combined_sources"
+
+
+def test_completeness_fallback_stays_closed_when_stronger_review_rejects(monkeypatch):
+    async def _reject(messages, **kwargs):
+        return _reply('{"supports": false, "reason": "still incomplete"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _reject)
+    verdicts = _run(
+        adj.adjudicate_sources(
+            claim=adj.Claim.COMPLETENESS,
+            subject="Jane Roe, John Doe",
+            contest="ne-house-02-2026",
+            sources=[_source()],
+        )
+    )
+    assert verdicts[_source()["url"]]["supports"] is False
+    assert verdicts[_source()["url"]]["model"] == adj.ADJUDICATOR_MODEL
+
+
+def test_membership_rejection_does_not_use_completeness_fallback(monkeypatch):
+    models = []
+
+    async def _reject(messages, **kwargs):
+        models.append(kwargs["model"])
+        return _reply('{"supports": false, "reason": "wrong contest"}')
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _reject)
+    verdicts = _run(
+        adj.adjudicate_sources(
+            claim=adj.Claim.MEMBERSHIP,
+            subject="Jane Roe",
+            contest="ne-house-02-2026",
+            sources=[_source()],
+        )
+    )
+    assert verdicts[_source()["url"]]["supports"] is False
+    assert models == [adj.ADJUDICATOR_MODEL]
+
+
 def test_verdict_record_is_persistable():
     """The record is written onto the source, so it must be plain JSON-safe data."""
     import json


### PR DESCRIPTION
## Summary
- keep standard per-source roster completeness adjudication
- fall back to a stronger independent combined-evidence review only when all standard judgments reject
- preserve fail-closed deterministic source, retrieval, contest, and cycle gates
- clarify two-candidate general-election field semantics and document the path

## Validation
- python -m pytest tests/test_roster_adjudicator.py tests/test_roster_adjudicator_gates.py tests/test_editing_tools.py -q (149 passed)
- python -m pytest tests/test_model_registry.py tests/test_agent_loop.py -q (55 passed)