### PR TITLE
Remove invalid empty social links during cleanup

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -211,6 +211,9 @@ reuse an exact URL's already-persisted tier-1/2 content evidence; it reuses the
 stored source object, never the model's new claims about an unfetched page. A
 trusted persisted source is considered automatically during finalization, so a
 low-cost refresh does not depend on the synthesis model repeating its URL.
+The final deterministic cleanup also drops null or blank candidate social-link
+values before schema validation, preventing legacy optional fields from turning
+an otherwise valid review into a schema error.
 For a special primary, completeness matching uses the primary date stated in
 `primary_status`, not the later general-election date stored on the profile. A
 blocked/error tool result and its bounded reason are recorded in debug logs and

--- a/shared/race_cleanup.py
+++ b/shared/race_cleanup.py
@@ -76,6 +76,7 @@ def cleanup_race_data(race_data: Dict[str, Any]) -> Dict[str, int]:
     text_changes = 0
     source_duplicates_removed = 0
     forecast_sources_added = 0
+    invalid_social_links_removed = 0
 
     for field in ("title", "description", "polling_note"):
         before = race_data.get(field)
@@ -113,6 +114,13 @@ def cleanup_race_data(race_data: Dict[str, Any]) -> Dict[str, int]:
             before_count = len(links)
             candidate["links"] = _dedupe_sources(links)
             source_duplicates_removed += before_count - len(candidate["links"])
+        social_media = candidate.get("social_media")
+        if isinstance(social_media, dict):
+            cleaned_social_media = {
+                str(platform): url.strip() for platform, url in social_media.items() if isinstance(url, str) and url.strip()
+            }
+            invalid_social_links_removed += len(social_media) - len(cleaned_social_media)
+            candidate["social_media"] = cleaned_social_media
         issues = candidate.get("issues")
         if isinstance(issues, dict):
             for issue in issues.values():
@@ -183,6 +191,7 @@ def cleanup_race_data(race_data: Dict[str, Any]) -> Dict[str, int]:
         "text_changes": text_changes,
         "source_duplicates_removed": source_duplicates_removed,
         "forecast_sources_added": forecast_sources_added,
+        "invalid_social_links_removed": invalid_social_links_removed,
     }
 
 

--- a/tests/test_race_cleanup.py
+++ b/tests/test_race_cleanup.py
@@ -1,6 +1,26 @@
 from shared.race_cleanup import cleanup_race_data, forecast_evidence_gaps, validate_forecast_evidence
 
 
+def test_cleanup_removes_null_and_blank_social_media_values():
+    race = {
+        "candidates": [
+            {
+                "name": "Candidate",
+                "social_media": {
+                    "linkedin": None,
+                    "facebook": "  ",
+                    "website": " https://example.com/candidate ",
+                },
+            }
+        ]
+    }
+
+    report = cleanup_race_data(race)
+
+    assert race["candidates"][0]["social_media"] == {"website": "https://example.com/candidate"}
+    assert report["invalid_social_links_removed"] == 2
+
+
 def test_cleanup_fixes_known_text_artifact_deduplicates_sources_and_seeds_forecast_evidence():
     race = {
         "description": "Candidate advanced after advanced from the primary.  Updated.",


### PR DESCRIPTION
## Summary
- remove null and blank candidate social-link values during deterministic cleanup
- report the mutation count and document the behavior
- cover the schema-regression case

## Validation
- python -m pytest tests/test_race_cleanup.py tests/test_run_agent.py -q (87 passed)