### PR TITLE
Run deterministic cleanup before review

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -211,8 +211,9 @@ reuse an exact URL's already-persisted tier-1/2 content evidence; it reuses the
 stored source object, never the model's new claims about an unfetched page. A
 trusted persisted source is considered automatically during finalization, so a
 low-cost refresh does not depend on the synthesis model repeating its URL.
-The final deterministic cleanup also drops null or blank candidate social-link
-values before schema validation, preventing legacy optional fields from turning
+Deterministic cleanup runs immediately before review and again after any review
+iteration. It drops null or blank candidate social-link values before schema
+validation, preventing legacy optional fields from turning
 an otherwise valid review into a schema error.
 For a special primary, completeness matching uses the primary date stated in
 `primary_status`, not the later general-election date stored on the profile. A

--- a/pipeline_client/agent/agent.py
+++ b/pipeline_client/agent/agent.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from shared.pipeline_config import DEFAULT_UPDATE_PIPELINE_STEPS, PIPELINE_STEP_IDS, REVIEW_PROVIDERS, PipelineRuntimeConfig
+from shared.race_cleanup import cleanup_race_data, validate_forecast_evidence
 from shared.run_health import clear_step_failures
 
 from .ballotpedia import default_ballotpedia_race_url
@@ -897,6 +898,11 @@ async def run_agent(
         )
 
     if should_review:
+        # Review the canonical object that will be saved. Legacy drafts can
+        # carry schema-invalid optional values (for example a null social URL),
+        # and judging before deterministic cleanup creates a stale error that
+        # cleanup fixes only after the grade has already failed.
+        pre_review_cleanup = cleanup_race_data(race_json)
         prior_review_metrics = (race_json.get("agent_metrics") or {}).get("review", {})
         review_metrics: Dict[str, Any] = copy.deepcopy(prior_review_metrics) if resume_review_iteration else {}
         review_cache: Dict[str, Any] = {}
@@ -1038,9 +1044,12 @@ async def run_agent(
     # Apply safe mechanical cleanup after all model-authored changes. This pass
     # also carries explicit polling/market/finance evidence URLs into forecasts
     # before enforcing the forecast evidence gate.
-    from shared.race_cleanup import cleanup_race_data, validate_forecast_evidence
-
     cleanup_report = cleanup_race_data(race_json)
+    if should_review:
+        cleanup_report = {
+            key: int(pre_review_cleanup.get(key, 0)) + int(cleanup_report.get(key, 0))
+            for key in set(pre_review_cleanup) | set(cleanup_report)
+        }
     pipeline_state = race_json.setdefault("pipeline_state", pipeline_state)
     pipeline_state["deterministic_cleanup"] = cleanup_report
     if any(cleanup_report.values()):

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1046,6 +1046,30 @@ async def test_run_agent_respects_review_provider_selection():
 
 
 @pytest.mark.asyncio
+async def test_run_agent_cleans_legacy_optional_values_before_review():
+    discovery_result = {
+        "id": "cleanup-before-review-2026",
+        "candidates": [{"name": "Alice", "issues": {}, "social_media": {"linkedin": None}}],
+    }
+    reviews = [{"model": "claude", "verdict": "approved", "score": 95, "flags": []}]
+
+    with (
+        patch("pipeline_client.agent.phases._agent_loop", new_callable=AsyncMock, return_value=discovery_result),
+        patch("pipeline_client.agent.agent._load_existing", return_value=None),
+        patch("pipeline_client.agent.agent.run_reviews", new_callable=AsyncMock, return_value=reviews) as mock_reviews,
+    ):
+        result = await run_agent(
+            "cleanup-before-review-2026",
+            existing_data={},
+            enabled_steps=["discovery", "review"],
+            review_providers=["claude"],
+        )
+
+    assert mock_reviews.call_args.args[1]["candidates"][0]["social_media"] == {}
+    assert result["pipeline_state"]["deterministic_cleanup"]["invalid_social_links_removed"] == 1
+
+
+@pytest.mark.asyncio
 async def test_run_agent_default_iteration_rereviews_full_profile_once():
     discovery_result = {
         "id": "review-cycle-2026",


### PR DESCRIPTION
## Summary
- canonicalize RaceJSON immediately before review and again after review iteration
- aggregate cleanup audit counts across both passes
- prevent stale schema flags for values removed before save

## Validation
- python -m pytest tests/test_run_agent.py tests/test_race_cleanup.py -q (88 passed)