### PR TITLE
Match special roster evidence to active contest date

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -215,8 +215,10 @@ Deterministic cleanup runs immediately before review and again after any review
 iteration. It drops null or blank candidate social-link values before schema
 validation, preventing legacy optional fields from turning
 an otherwise valid review into a schema error.
-For a special primary, completeness matching uses the primary date stated in
-`primary_status`, not the later general-election date stored on the profile. A
+For a pre-primary special contest, completeness matching uses the primary date
+stated in `primary_status`, not a later general-election date stored on the
+profile. After the primary, a special-general roster instead matches the active
+general-election date in `race_identity.election_date`. A
 blocked/error tool result and its bounded reason are recorded in debug logs and
 surfaced to the model as a failure. After two consecutive blocked edits, roster sync
 keeps the accumulated research but escalates subsequent synthesis to the

--- a/pipeline_client/agent/handlers.py
+++ b/pipeline_client/agent/handlers.py
@@ -625,15 +625,18 @@ def _roster_completeness_source_rejection_reason(
     if "special" in primary_status.casefold():
         if "special" not in text:
             return "race identity is a special election, but the source does not identify the special contest"
-        # The profile election_date is normally the November general election,
-        # while a roster source may certify an earlier special primary. Prefer
-        # the explicit date embedded in primary_status for this gate.
+        # Match the date for the stage whose roster is being finalized. Before
+        # the primary, primary_status supplies the special-primary date even if
+        # the profile stores November. After it, the active field is the general
+        # election and evidence must identify race_identity.election_date.
         parsed_date = None
-        iso_match = re.search(r"\b((?:19|20)\d{2}-\d{2}-\d{2})\b", primary_status)
+        contest_stage = str(identity.get("contest_stage") or "").casefold()
+        date_text = primary_status if contest_stage == "pre_primary" else str(identity.get("election_date") or "")
+        iso_match = re.search(r"\b((?:19|20)\d{2}-\d{2}-\d{2})\b", date_text)
         named_match = re.search(
             r"\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+"
             r"(\d{1,2})(?:st|nd|rd|th)?[,]?\s+((?:19|20)\d{2})\b",
-            primary_status,
+            date_text,
             re.IGNORECASE,
         )
         try:

--- a/tests/test_editing_tools.py
+++ b/tests/test_editing_tools.py
@@ -1050,6 +1050,54 @@ def test_special_primary_uses_primary_status_date_not_general_election_date():
     assert result == "Roster finalized with 1 evidence-backed active candidate(s)."
 
 
+def test_post_primary_special_general_uses_general_election_date():
+    from pipeline_client.agent.agent import _make_editing_handlers
+
+    source = {
+        "url": "https://ballotpedia.org/Alabama's_2nd_Congressional_District",
+        "type": "ballotpedia",
+        "title": "Alabama's 2nd Congressional District",
+        "evidence": (
+            "Incumbent Shomari Figures (D) and Rhett Marques (R) are running in the special general election "
+            "for U.S. House Alabama District 2 on November 3, 2026."
+        ),
+        "race_id": "al-house-02-2026",
+        "published_at": "2026-08-12",
+        "evidence_tier": 2,
+        "retrieval_status": "content",
+    }
+    race_json = {
+        "id": "al-house-02-2026",
+        "pipeline_state": {
+            "race_identity": {
+                "office": "U.S. House Alabama District 2",
+                "contest_stage": "post_primary_general",
+                "primary_status": "Special Primary Election held August 11, 2026",
+                "election_date": "2026-11-03",
+            }
+        },
+        "candidates": [
+            {"name": "Shomari Figures", "party": "Democratic", "roster_sources": [source]},
+            {"name": "Rhett Marques", "party": "Republican", "roster_sources": [source]},
+        ],
+    }
+    handlers = _make_editing_handlers(race_json, lambda *_: None)
+
+    result = handlers["finalize_roster"](
+        {
+            "summary": "Exact special-general field",
+            "candidates": [
+                {"name": "Shomari Figures", "party": "Democratic"},
+                {"name": "Rhett Marques", "party": "Republican"},
+            ],
+            "source_candidate_names": ["Shomari Figures", "Rhett Marques"],
+            "completeness_sources": [source],
+        }
+    )
+
+    assert result == "Roster finalized with 2 evidence-backed active candidate(s)."
+
+
 def test_finalize_roster_atomically_applies_complete_proposed_roster():
     from pipeline_client.agent.agent import _make_editing_handlers
 


### PR DESCRIPTION
## Summary
- use the primary date for pre-primary special rosters
- use the general-election date once the special contest is post-primary
- add the exact Alabama two-candidate regression case

## Validation
- python -m pytest tests/test_editing_tools.py -q (103 passed)