### PR TITLE
Retry malformed roster review verdict once

### DIFF
--- a/docs/pipeline-operations.md
+++ b/docs/pipeline-operations.md
@@ -282,6 +282,8 @@ source-class, retrieved-content, exact-contest, and current-cycle gates; a
 negative, unavailable, or unparseable second review remains fail-closed. This
 fallback applies only to whole-roster completeness, never candidate membership
 or removal.
+If the stronger reviewer emits no parseable JSON, it gets one bounded
+JSON-only retry; a second malformed or unavailable response remains fail-closed.
 The lookup has a short, best-effort timeout: when ample invocation time remains,
 a timeout is logged and model-backed roster research continues. It triggers a
 durable handoff only when the invocation is genuinely near its checkpoint

--- a/pipeline_client/agent/roster_adjudicator.py
+++ b/pipeline_client/agent/roster_adjudicator.py
@@ -328,6 +328,31 @@ async def adjudicate(
         return _unavailable(f"{type(exc).__name__}", model=model)
 
     verdict = _parse_verdict(content)
+    if verdict is None and model == ROSTER_COMPLETENESS_REVIEW_MODEL:
+        # Reasoning models can occasionally spend the first response without
+        # emitting the tiny JSON payload. Retry once with an even tighter
+        # instruction; a second malformed response still fails closed.
+        try:
+            response = await asyncio.wait_for(
+                _call_openrouter(
+                    [
+                        {"role": "system", "content": _SYSTEM},
+                        {
+                            "role": "user",
+                            "content": _build_user_prompt(claim=claim, subject=subject, contest=contest, source=source)
+                            + "\n\nReturn exactly one JSON object. Do not include analysis or markdown.",
+                        },
+                    ],
+                    model=model,
+                    max_tokens=max_tokens,
+                    temperature=ADJUDICATOR_TEMPERATURE,
+                    run_budget=run_budget,
+                ),
+                timeout=ADJUDICATOR_TIMEOUT_SECONDS,
+            )
+            verdict = _parse_verdict(response.choices[0].message.content or "")
+        except Exception as exc:
+            logger.warning("Roster completeness reviewer retry failed: %s", exc)
     if verdict is None:
         logger.warning("Roster adjudicator returned unparseable content for claim=%s", claim)
         return _unavailable("adjudicator returned an unparseable verdict", model=model)

--- a/tests/test_roster_adjudicator.py
+++ b/tests/test_roster_adjudicator.py
@@ -330,6 +330,32 @@ def test_completeness_fallback_stays_closed_when_stronger_review_rejects(monkeyp
     assert verdicts[_source()["url"]]["model"] == adj.ADJUDICATOR_MODEL
 
 
+def test_completeness_reviewer_retries_one_unparseable_response(monkeypatch):
+    responses = iter(
+        [
+            _reply('{"supports": false, "reason": "single source insufficient"}'),
+            _reply(""),
+            _reply('{"supports": true, "reason": "combined packet establishes the field"}'),
+        ]
+    )
+
+    async def _respond(messages, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr("pipeline_client.agent.llm._call_openrouter", _respond)
+    verdicts = _run(
+        adj.adjudicate_sources(
+            claim=adj.Claim.COMPLETENESS,
+            subject="Jane Roe, John Doe",
+            contest="ne-house-02-2026",
+            sources=[_source()],
+        )
+    )
+
+    assert verdicts[_source()["url"]]["supports"] is True
+    assert verdicts[_source()["url"]]["review_scope"] == "combined_sources"
+
+
 def test_membership_rejection_does_not_use_completeness_fallback(monkeypatch):
     models = []
 


### PR DESCRIPTION
## Summary
- retry one malformed Claude Opus completeness-review response with a strict JSON-only instruction
- retain fail-closed behavior after the bounded retry
- keep the retry exclusive to whole-roster fallback review

## Validation
- python -m pytest tests/test_roster_adjudicator.py tests/test_editing_tools.py -q (146 passed)